### PR TITLE
Escape all regex special characters in identifiers

### DIFF
--- a/packages/knip/src/typescript/getImportsAndExports.ts
+++ b/packages/knip/src/typescript/getImportsAndExports.ts
@@ -13,6 +13,7 @@ import type {
   UnresolvedImport,
 } from '../types/serializable-map.js';
 import { timerify } from '../util/Performance.js';
+import { escapeRegex } from '../util/regex.js';
 import { isStartsLikePackageName, sanitizeSpecifier } from '../util/modules.js';
 import { extname, isInNodeModules } from '../util/path.js';
 import { shouldIgnore } from '../util/tag.js';
@@ -400,7 +401,7 @@ const getImportsAndExports = (
   const setRefs = (item: SerializableExport | SerializableExportMember) => {
     if (!item.symbol) return;
     const symbols = new Set<ts.Symbol>();
-    for (const match of sourceFile.text.matchAll(new RegExp(item.identifier.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'), 'g'))) {
+    for (const match of sourceFile.text.matchAll(new RegExp(escapeRegex(item.identifier), 'g'))) {
       const isDeclaration = match.index === item.pos || match.index === item.pos + 1; // off-by-one from `stripQuotes`
       if (!isDeclaration) {
         // @ts-expect-error ts.getTokenAtPosition is internal fn

--- a/packages/knip/src/typescript/getImportsAndExports.ts
+++ b/packages/knip/src/typescript/getImportsAndExports.ts
@@ -400,7 +400,7 @@ const getImportsAndExports = (
   const setRefs = (item: SerializableExport | SerializableExportMember) => {
     if (!item.symbol) return;
     const symbols = new Set<ts.Symbol>();
-    for (const match of sourceFile.text.matchAll(new RegExp(item.identifier.replace(/\$/g, '\\$'), 'g'))) {
+    for (const match of sourceFile.text.matchAll(new RegExp(item.identifier.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'), 'g'))) {
       const isDeclaration = match.index === item.pos || match.index === item.pos + 1; // off-by-one from `stripQuotes`
       if (!isDeclaration) {
         // @ts-expect-error ts.getTokenAtPosition is internal fn

--- a/packages/knip/src/util/regex.ts
+++ b/packages/knip/src/util/regex.ts
@@ -3,3 +3,12 @@ export const toRegexOrString = (value: string | RegExp) =>
 
 export const findMatch = (haystack: undefined | (string | RegExp)[], needle: string) =>
   haystack?.find(n => (typeof n === 'string' ? n === needle : n.test(needle)));
+
+/**
+ * Escapes a string to be used in a regular expression.
+ *
+ * Escapes all characters that have a special meaning in regular expressions.
+ */
+export function escapeRegex(str: string): string {
+  return str.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+}


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->

Rather than just escaping `$`, escape all regex special characters in any identifiers to make sure the RegExp that is created is valid. 

Used the list of characters to escape from the regex-escaping proposal 

https://github.com/tc39/proposal-regex-escaping/blob/66d654ea6561ea064045c7ecf2da6870c892c9be/polyfill.js#L4

Closes #595 