### PR TITLE
fix: add runtime field of jest config

### DIFF
--- a/packages/knip/fixtures/plugins/jest/jest.config.js
+++ b/packages/knip/fixtures/plugins/jest/jest.config.js
@@ -26,4 +26,5 @@ module.exports = {
   ],
   testResultsProcessor: 'jest-phabricator',
   snapshotResolver: '<rootDir>/snapshotResolver.js',
+  runtime: '@side/jest-runtime',
 };

--- a/packages/knip/src/plugins/jest/index.ts
+++ b/packages/knip/src/plugins/jest/index.ts
@@ -76,6 +76,7 @@ const resolveDependencies = async (config: JestInitialOptions, options: PluginOp
   const snapshotResolver = config.snapshotResolver ? [config.snapshotResolver] : [];
   const testSequencer = config.testSequencer ? [config.testSequencer] : [];
   const globalSetup = config.globalSetup ? [config.globalSetup] : [];
+  const runtime = config.runtime ? [config.runtime] : [];
 
   return [
     ...presets,
@@ -93,6 +94,7 @@ const resolveDependencies = async (config: JestInitialOptions, options: PluginOp
     ...snapshotResolver,
     ...testSequencer,
     ...globalSetup,
+    ...runtime,
   ];
 };
 

--- a/packages/knip/test/plugins/jest.test.ts
+++ b/packages/knip/test/plugins/jest.test.ts
@@ -29,7 +29,7 @@ test('Find dependencies with the Jest plugin', async () => {
   assert.deepEqual(counters, {
     ...baseCounters,
     devDependencies: 1,
-    unlisted: 10,
+    unlisted: 11,
     unresolved: 1,
     processed: 6,
     total: 6,


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->

fix #603 
