### PR TITLE
fix(Auto-fix): ignore is not applied

### DIFF
--- a/packages/knip/fixtures/fix-workspaces/exports.ts
+++ b/packages/knip/fixtures/fix-workspaces/exports.ts
@@ -1,0 +1,7 @@
+export const c = 1;
+export const d = 2;
+
+export type T = number;
+
+/** @knipignore */
+export type U = number;

--- a/packages/knip/fixtures/fix-workspaces/ignored.ts
+++ b/packages/knip/fixtures/fix-workspaces/ignored.ts
@@ -1,0 +1,4 @@
+export const a = 1;
+export const b = 2;
+
+export type T = number;

--- a/packages/knip/fixtures/fix-workspaces/index.js
+++ b/packages/knip/fixtures/fix-workspaces/index.js
@@ -1,0 +1,5 @@
+import { a } from './ignored';
+import { c } from './exports';
+
+a;
+c;

--- a/packages/knip/fixtures/fix-workspaces/knip.ts
+++ b/packages/knip/fixtures/fix-workspaces/knip.ts
@@ -1,0 +1,13 @@
+export default {
+  ignoreWorkspaces: ['packages/ignored'],
+  workspaces: {
+    '.': {
+      ignore: ['ignored.ts'],
+      ignoreDependencies: ['ignored'],
+    },
+    'packages/lib': {
+      ignore: ['ignored.ts'],
+      ignoreDependencies: ['ignored'],
+    },
+  },
+};

--- a/packages/knip/fixtures/fix-workspaces/package.json
+++ b/packages/knip/fixtures/fix-workspaces/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixtures/fix-workspaces",
+  "dependencies": {
+    "unused": "*",
+    "ignored": "*"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/knip/fixtures/fix-workspaces/packages/ignored/exports.ts
+++ b/packages/knip/fixtures/fix-workspaces/packages/ignored/exports.ts
@@ -1,0 +1,4 @@
+export const a = 1;
+export const b = 2;
+
+export type T = number;

--- a/packages/knip/fixtures/fix-workspaces/packages/ignored/index.js
+++ b/packages/knip/fixtures/fix-workspaces/packages/ignored/index.js
@@ -1,0 +1,3 @@
+import { a } from './exports';
+
+a;

--- a/packages/knip/fixtures/fix-workspaces/packages/ignored/package.json
+++ b/packages/knip/fixtures/fix-workspaces/packages/ignored/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@org/ignored",
+  "dependencies": {
+    "unused": "*"
+  }
+}

--- a/packages/knip/fixtures/fix-workspaces/packages/lib/exports.ts
+++ b/packages/knip/fixtures/fix-workspaces/packages/lib/exports.ts
@@ -1,0 +1,7 @@
+export const c = 1;
+export const d = 2;
+
+export type T = number;
+
+/** @knipignore */
+export type U = number;

--- a/packages/knip/fixtures/fix-workspaces/packages/lib/ignored.ts
+++ b/packages/knip/fixtures/fix-workspaces/packages/lib/ignored.ts
@@ -1,0 +1,4 @@
+export const a = 1;
+export const b = 2;
+
+export type T = number;

--- a/packages/knip/fixtures/fix-workspaces/packages/lib/index.js
+++ b/packages/knip/fixtures/fix-workspaces/packages/lib/index.js
@@ -1,0 +1,5 @@
+import { a } from './ignored';
+import { c } from './exports';
+
+a;
+c;

--- a/packages/knip/fixtures/fix-workspaces/packages/lib/package.json
+++ b/packages/knip/fixtures/fix-workspaces/packages/lib/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@org/lib",
+  "dependencies": {
+    "unused": "*",
+    "ignored": "*"
+  }
+}

--- a/packages/knip/fixtures/fix/ignored.ts
+++ b/packages/knip/fixtures/fix/ignored.ts
@@ -1,0 +1,4 @@
+export const a = 1;
+export const b = 2;
+
+export type T = number;

--- a/packages/knip/fixtures/fix/index.js
+++ b/packages/knip/fixtures/fix/index.js
@@ -2,10 +2,12 @@ import _ from 'lodash';
 import { z } from './mod';
 import { USED } from './access';
 import { identifier } from './exports';
+import { a } from './ignored';
 import * as NS from './reexports';
 
 _;
 z;
 USED;
 identifier;
+a;
 NS.One;

--- a/packages/knip/fixtures/fix/knip.ts
+++ b/packages/knip/fixtures/fix/knip.ts
@@ -1,0 +1,4 @@
+export default {
+  ignore: ['ignored.ts'],
+  ignoreDependencies: ['ignored'],
+};

--- a/packages/knip/fixtures/fix/mod.ts
+++ b/packages/knip/fixtures/fix/mod.ts
@@ -12,3 +12,6 @@ export const { a, b } = { a: 1, b: 1 };
 export const [c, d] = [1, 2];
 
 export default class MyClass {}
+
+/** @knipignore */
+export type U = number;

--- a/packages/knip/fixtures/fix/package.json
+++ b/packages/knip/fixtures/fix/package.json
@@ -2,7 +2,8 @@
   "name": "@fixtures/fix",
   "dependencies": {
     "lodash": "*",
-    "unused": "*"
+    "unused": "*",
+    "ignored": "*"
   },
   "devDependencies": {
     "unreferenced": "*"

--- a/packages/knip/src/IssueCollector.ts
+++ b/packages/knip/src/IssueCollector.ts
@@ -77,6 +77,7 @@ export class IssueCollector {
       this.issues[issue.type][key][issue.symbol] = issue;
       this.counters[issue.type]++;
     }
+    return issue;
   }
 
   addConfigurationHint(issue: ConfigurationHint) {

--- a/packages/knip/src/index.ts
+++ b/packages/knip/src/index.ts
@@ -509,7 +509,7 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
               if (!isSkipLibs && principal?.hasReferences(filePath, exportedItem)) continue;
 
               const type = getType(hasStrictlyNsReferences, isType);
-              collector.addIssue({
+              const issue = collector.addIssue({
                 type,
                 filePath,
                 symbol: identifier,
@@ -519,8 +519,10 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
                 line: exportedItem.line,
                 col: exportedItem.col,
               });
-              if (isType) fixer.addUnusedTypeNode(filePath, exportedItem.fixes);
-              else fixer.addUnusedExportNode(filePath, exportedItem.fixes);
+              if (issue) {
+                if (isType) fixer.addUnusedTypeNode(filePath, exportedItem.fixes);
+                else fixer.addUnusedExportNode(filePath, exportedItem.fixes);
+              }
             }
           }
         }

--- a/packages/knip/src/index.ts
+++ b/packages/knip/src/index.ts
@@ -509,7 +509,7 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
               if (!isSkipLibs && principal?.hasReferences(filePath, exportedItem)) continue;
 
               const type = getType(hasStrictlyNsReferences, isType);
-              const issue = collector.addIssue({
+              const isIssueAdded = collector.addIssue({
                 type,
                 filePath,
                 symbol: identifier,
@@ -519,7 +519,7 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
                 line: exportedItem.line,
                 col: exportedItem.col,
               });
-              if (issue) {
+              if (isIssueAdded) {
                 if (isType) fixer.addUnusedTypeNode(filePath, exportedItem.fixes);
                 else fixer.addUnusedExportNode(filePath, exportedItem.fixes);
               }

--- a/packages/knip/test/fix-workspaces.test.ts
+++ b/packages/knip/test/fix-workspaces.test.ts
@@ -1,0 +1,171 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { readFile, writeFile } from 'node:fs/promises';
+import { EOL } from 'node:os';
+import { main } from '../src/index.js';
+import { join, resolve } from '../src/util/path.js';
+import baseArguments from './helpers/baseArguments.js';
+
+const cwd = resolve('fixtures/fix-workspaces');
+
+const readContents = async (fileName: string) => await readFile(join(cwd, fileName), 'utf8');
+
+test('Remove exports and dependencies', async () => {
+  const tests = [
+    [
+      'exports.ts',
+      await readContents('exports.ts'),
+      `export const c = 1;
+const d = 2;
+
+type T = number;
+
+/** @knipignore */
+export type U = number;
+`.replace(/\n/g, EOL),
+    ],
+    [
+      'package.json',
+      await readContents('package.json'),
+      `{
+  "name": "@fixtures/fix-workspaces",
+  "dependencies": {
+    "ignored": "*"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}
+`.replace(/\n/g, EOL),
+    ],
+    [
+      'packages/lib/exports.ts',
+      await readContents('packages/lib/exports.ts'),
+      `export const c = 1;
+const d = 2;
+
+type T = number;
+
+/** @knipignore */
+export type U = number;
+`.replace(/\n/g, EOL),
+    ],
+    [
+      'packages/lib/package.json',
+      await readContents('packages/lib/package.json'),
+      `{
+  "name": "@org/lib",
+  "dependencies": {
+    "ignored": "*"
+  }
+}
+`.replace(/\n/g, EOL),
+    ],
+  ];
+
+  const { issues } = await main({
+    ...baseArguments,
+    cwd,
+    isFix: true,
+    tags: [[], ['knipignore']],
+  });
+
+  assert(issues.exports['exports.ts']['d']);
+  assert(issues.exports['packages/lib/exports.ts']['d']);
+  assert(issues.types['exports.ts']['T']);
+  assert(issues.types['packages/lib/exports.ts']['T']);
+
+  assert(issues.dependencies['package.json']['unused']);
+  assert(issues.dependencies['packages/lib/package.json']['unused']);
+
+  // check ignore
+  assert(issues.exports['ignored.ts'] === undefined);
+  assert(issues.exports['packages/lib/ignored.ts'] === undefined);
+
+  // check ignoreDependencies
+  assert(issues.dependencies['package.json']['ignored'] === undefined);
+  assert(issues.dependencies['packages/lib/package.json']['ignored'] === undefined);
+
+  // check ignoreWorkspaces
+  assert(issues.exports['packages/ignored/package.json'] === undefined);
+  assert(issues.exports['packages/ignored/exports.ts'] === undefined);
+
+  // check ignored by tags
+  assert(issues.types['exports.ts']['U'] === undefined);
+  assert(issues.types['packages/lib/exports.ts']['U'] === undefined);
+
+  for (const [fileName, before, after] of tests) {
+    const filePath = join(cwd, fileName);
+    const originalFile = await readFile(filePath);
+    assert.equal(String(originalFile), after);
+    await writeFile(filePath, before);
+  }
+});
+
+test('Remove exports (--fix-type types)', async () => {
+  const tests = [
+    [
+      'exports.ts',
+      await readContents('exports.ts'),
+      `export const c = 1;
+export const d = 2;
+
+type T = number;
+
+/** @knipignore */
+export type U = number;
+`.replace(/\n/g, EOL),
+    ],
+    [
+      'packages/lib/exports.ts',
+      await readContents('packages/lib/exports.ts'),
+      `export const c = 1;
+export const d = 2;
+
+type T = number;
+
+/** @knipignore */
+export type U = number;
+`.replace(/\n/g, EOL),
+    ],
+  ];
+
+  const { issues } = await main({
+    ...baseArguments,
+    cwd,
+    isFix: true,
+    fixTypes: ['types'],
+    tags: [[], ['knipignore']],
+  });
+
+  assert(issues.exports['exports.ts']['d']);
+  assert(issues.exports['packages/lib/exports.ts']['d']);
+  assert(issues.types['exports.ts']['T']);
+  assert(issues.types['packages/lib/exports.ts']['T']);
+
+  assert(issues.dependencies['package.json']['unused']);
+  assert(issues.dependencies['packages/lib/package.json']['unused']);
+
+  // check ignore
+  assert(issues.exports['ignored.ts'] === undefined);
+  assert(issues.exports['packages/lib/ignored.ts'] === undefined);
+
+  // check ignoreDependencies
+  assert(issues.dependencies['package.json']['ignored'] === undefined);
+  assert(issues.dependencies['packages/lib/package.json']['ignored'] === undefined);
+
+  // check ignoreWorkspaces
+  assert(issues.exports['packages/ignored/package.json'] === undefined);
+  assert(issues.exports['packages/ignored/exports.ts'] === undefined);
+
+  // check ignored by tags
+  assert(issues.types['exports.ts']['U'] === undefined);
+  assert(issues.types['packages/lib/exports.ts']['U'] === undefined);
+
+  for (const [fileName, before, after] of tests) {
+    const filePath = join(cwd, fileName);
+    const originalFile = await readFile(filePath);
+    assert.equal(String(originalFile), after);
+    await writeFile(filePath, before);
+  }
+});


### PR DESCRIPTION
Closes https://github.com/webpro-nl/knip/issues/653

Fixed and added test cases for the following cases

- `ignore`.
- ignoreDependencies`
- use `ignoreWorkspaces` for ignore
- `tags` for ignore

Since `ignoreMembers` is not yet supported by Auto-fix and I thought `ignoreBinaries` was an option unrelated to Auto-fix, I did not include either of them in the test case.