### PR TITLE
Add ‘kill’ and ‘ssh’ as globally available binaries

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -46,6 +46,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'git',
   'grep',
   'gzip',
+  'kill',
   'ln',
   'ls',
   'mkdir',
@@ -58,6 +59,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'rm',
   'set',
   'sh',
+  'ssh',
   'sudo',
   'test', // exception (node built-in module)
   'touch',


### PR DESCRIPTION
Hello! 👋  It seems we list a lot of unix commands as available binaries already so I thought `kill` and `ssh` would be fair game. Let me know if not.

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
