### PR TITLE
fix: 🐛 Fix regular expression escape error

### DIFF
--- a/packages/knip/src/typescript/getImportsAndExports.ts
+++ b/packages/knip/src/typescript/getImportsAndExports.ts
@@ -31,6 +31,7 @@ import getExportVisitors from './visitors/exports/index.js';
 import { getImportsFromPragmas } from './visitors/helpers.js';
 import getImportVisitors from './visitors/imports/index.js';
 import getScriptVisitors from './visitors/scripts/index.js';
+import { escapeRegExp } from '#p/util/regex.ts';
 
 const getVisitors = (sourceFile: ts.SourceFile) => ({
   export: getExportVisitors(sourceFile),
@@ -400,7 +401,7 @@ const getImportsAndExports = (
   const setRefs = (item: SerializableExport | SerializableExportMember) => {
     if (!item.symbol) return;
     const symbols = new Set<ts.Symbol>();
-    for (const match of sourceFile.text.matchAll(new RegExp(item.identifier.replace(/\$/g, '\\$'), 'g'))) {
+    for (const match of sourceFile.text.matchAll(new RegExp(escapeRegExp(item.identifier), 'g'))) {
       const isDeclaration = match.index === item.pos || match.index === item.pos + 1; // off-by-one from `stripQuotes`
       if (!isDeclaration) {
         // @ts-expect-error ts.getTokenAtPosition is internal fn

--- a/packages/knip/src/util/regex.ts
+++ b/packages/knip/src/util/regex.ts
@@ -3,3 +3,16 @@ export const toRegexOrString = (value: string | RegExp) =>
 
 export const findMatch = (haystack: undefined | (string | RegExp)[], needle: string) =>
   haystack?.find(n => (typeof n === 'string' ? n === needle : n.test(needle)));
+
+const reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+const reHasRegExpChar = RegExp(reRegExpChar.source);
+
+/** 
+ * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+",
+ * "?", "(", ")", "[", "]", "{", "}", and "|" in `string`.
+ * copy from lodash, see: https://github.com/lodash/lodash/blob/main/src/escapeRegExp.ts */
+export const escapeRegExp = (str: string) => {
+  return str && reHasRegExpChar.test(str)
+    ? str.replace(reRegExpChar, '\\$&')
+    : str || '';
+}


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
fix: #595 
