### PR TITLE
Better explain `ignoreBinaries` configuration option

### DIFF
--- a/packages/docs/src/content/docs/reference/configuration.md
+++ b/packages/docs/src/content/docs/reference/configuration.md
@@ -165,8 +165,8 @@ in `entry` and `project` glob patterns.
 
 ### `ignoreBinaries`
 
-Array of binaries to exclude from the report. Regular expressions allowed.
-Example:
+Exclude binaries that are used but not provided by any dependency from the
+report. Value is an array of binary names or regular expressions. Example:
 
 ```json title="knip.json"
 {


### PR DESCRIPTION
As mentioned in #668, the documentation for the `ignoreBinaries` confused me and lead me to use it for an unintended side effect. I hope the change makes it clear what the configuration option is for.


<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->