### PR TITLE
Support Jest's globalTeardown

### DIFF
--- a/packages/knip/src/plugins/jest/index.ts
+++ b/packages/knip/src/plugins/jest/index.ts
@@ -76,6 +76,7 @@ const resolveDependencies = async (config: JestInitialOptions, options: PluginOp
   const snapshotResolver = config.snapshotResolver ? [config.snapshotResolver] : [];
   const testSequencer = config.testSequencer ? [config.testSequencer] : [];
   const globalSetup = config.globalSetup ? [config.globalSetup] : [];
+  const globalTeardown = config.globalTeardown ? [config.globalTeardown] : [];
 
   return [
     ...presets,
@@ -93,6 +94,7 @@ const resolveDependencies = async (config: JestInitialOptions, options: PluginOp
     ...snapshotResolver,
     ...testSequencer,
     ...globalSetup,
+    ...globalTeardown,
   ];
 };
 


### PR DESCRIPTION
Add support for Jest's `globalTeardown` property https://jestjs.io/docs/configuration#globalteardown-string
Similar to the existing `globalSetup` property

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
