### PR TITLE
Add missing `root` property to vitest

### DIFF
--- a/packages/knip/fixtures/plugins/vitest4/node_modules/vitest/config.js
+++ b/packages/knip/fixtures/plugins/vitest4/node_modules/vitest/config.js
@@ -1,0 +1,5 @@
+function defineConfig(config) {
+  return config;
+}
+
+export { defineConfig };

--- a/packages/knip/fixtures/plugins/vitest4/node_modules/vitest/package.json
+++ b/packages/knip/fixtures/plugins/vitest4/node_modules/vitest/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "vitest",
+  "version": "*"
+}

--- a/packages/knip/fixtures/plugins/vitest4/package.json
+++ b/packages/knip/fixtures/plugins/vitest4/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/vitest4",
+  "devDependencies": {
+    "vitest": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/vitest4/src/index.ts
+++ b/packages/knip/fixtures/plugins/vitest4/src/index.ts
@@ -1,1 +1,0 @@
-export const adder = (a: number, b: number) => a + b;

--- a/packages/knip/fixtures/plugins/vitest4/src/index.ts
+++ b/packages/knip/fixtures/plugins/vitest4/src/index.ts
@@ -1,0 +1,1 @@
+export const adder = (a: number, b: number) => a + b;

--- a/packages/knip/fixtures/plugins/vitest4/src/unused.test.ts
+++ b/packages/knip/fixtures/plugins/vitest4/src/unused.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('Unit A', () => {
+  expect(true).toBe(!false);
+});

--- a/packages/knip/fixtures/plugins/vitest4/tests/adder.test.ts
+++ b/packages/knip/fixtures/plugins/vitest4/tests/adder.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('Unit A', () => {
+  expect(true).toBe(!false);
+});

--- a/packages/knip/fixtures/plugins/vitest4/tests/setup.ts
+++ b/packages/knip/fixtures/plugins/vitest4/tests/setup.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/knip/fixtures/plugins/vitest4/vitest.config.ts
+++ b/packages/knip/fixtures/plugins/vitest4/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    root: 'tests',
+    include: ['*.test.ts'],
+    setupFiles: ['./setup.ts'],
+  },
+});

--- a/packages/knip/src/plugins/vitest/types.ts
+++ b/packages/knip/src/plugins/vitest/types.ts
@@ -5,6 +5,7 @@ interface VitestConfig {
       enabled?: boolean;
       provider: string;
     };
+    root?: string;
     environment?: string;
     globalSetup?: string | string[];
     reporters?: (string | unknown)[];

--- a/packages/knip/test/plugins/vitest4.test.ts
+++ b/packages/knip/test/plugins/vitest4.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/plugins/vitest4');
+
+test('Find dependencies with Vitest plugin (4)', async () => {
+  const { counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    files: 0,
+    processed: 4,
+    total: 4,
+  });
+});

--- a/packages/knip/test/plugins/vitest4.test.ts
+++ b/packages/knip/test/plugins/vitest4.test.ts
@@ -1,21 +1,23 @@
 import { test } from 'bun:test';
 import assert from 'node:assert/strict';
 import { main } from '../../src/index.js';
-import { resolve } from '../../src/util/path.js';
+import { join, resolve } from '../../src/util/path.js';
 import baseArguments from '../helpers/baseArguments.js';
 import baseCounters from '../helpers/baseCounters.js';
 
 const cwd = resolve('fixtures/plugins/vitest4');
 
 test('Find dependencies with Vitest plugin (4)', async () => {
-  const { counters } = await main({
+  const { issues, counters } = await main({
     ...baseArguments,
     cwd,
   });
 
+  assert(issues.files.has(join(cwd, 'src/unused.test.ts')));
+
   assert.deepEqual(counters, {
     ...baseCounters,
-    files: 0,
+    files: 1,
     processed: 4,
     total: 4,
   });


### PR DESCRIPTION
This adds support for the [Vitest `root` config](https://vitest.dev/config/#root). Without it, valid `vitest.config.ts` and `vitest.workspace.ts` files were being improperly parsed.

Existing fixtures and tests are still passing. Added a new test to prove `root` does indeed change the relative path in which files are include (incl. global and setup files).