### PR TITLE
feat: add command to ignored binaries

### DIFF
--- a/packages/knip/fixtures/plugins/husky-v9/.husky/pre-commit
+++ b/packages/knip/fixtures/plugins/husky-v9/.husky/pre-commit
@@ -1,3 +1,9 @@
 npx lint-staged
 npx --no-install commitlint --edit "$1"
 npm test
+
+if ! command -v yalc check &> /dev/null
+then
+    echo "yalc could not be found"
+    exit
+fi

--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -34,6 +34,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'cat',
   'cd',
   'chmod',
+  'command',
   'corepack',
   'cp',
   'curl',


### PR DESCRIPTION
Hey, firstable thanks for this awesome project!

'command' is part of npm https://www.npmjs.com/package/command, but it's not maintained (last publish 10 years ago). 'command' is also a unix command that, for example, can check if a command is available in the current shell. This creates a false positive whenever 'command' is used.

We use it for example inside of a husky pre-commit hook like this:

```bash
if ! command -v yalc check &> /dev/null
then
    echo "yalc could not be found"
    exit
fi
```

This results in knip flagging this as a unlisted binary:

```
Unlisted binaries (1)
command  .husky/pre-commit
```

I've added a test for this in the husky v9 fixture, but it's actually not really related to husky, because this could be used in any kind of bash script. If there is a better place for this test, let me know.