### PR TITLE
Fix lockfile-lint config filename

### DIFF
--- a/packages/knip/src/plugins/lockfile-lint/index.ts
+++ b/packages/knip/src/plugins/lockfile-lint/index.ts
@@ -10,7 +10,7 @@ const enablers: EnablerPatterns = ['lockfile-lint'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['.lockfile-lintrc', '.lockfile-lint.{js,toml}', '.lockfile-lint.config.js', 'package.json'];
+const config = ['.lockfile-lintrc', '.lockfile-lint.{js,toml}', 'lockfile-lint.config.js', 'package.json'];
 
 export default {
   title,


### PR DESCRIPTION
The dot before `lockfile-lint.config.js` is not a supported config.
Not in cosmiconfig v8 & v9.

The list of supported configs is actually larger: 
https://github.com/lirantal/lockfile-lint/blob/main/packages/lockfile-lint/README.md#file-based-configuration
https://github.com/cosmiconfig/cosmiconfig?tab=readme-ov-file#cosmiconfig

But that is out of scope for this bugfix.