### PR TITLE
Fix: Support Cypress configs with `false` value for `e2e.supportFile` and `component.supportFile`

### DIFF
--- a/packages/knip/src/plugins/cypress/index.ts
+++ b/packages/knip/src/plugins/cypress/index.ts
@@ -24,7 +24,7 @@ const entry = [...TEST_FILE_PATTERNS, ...SUPPORT_FILE_PATTERNS];
 
 const resolveEntryPaths: ResolveEntryPaths = async localConfig => {
   const specPatterns = [localConfig.e2e?.specPattern ?? [], localConfig.component?.specPattern ?? []].flat();
-  const supportFiles = [localConfig.e2e?.supportFile ?? [], localConfig.component?.supportFile ?? []].flat();
+  const supportFiles = [localConfig.e2e?.supportFile || [], localConfig.component?.supportFile || []].flat();
   return [
     ...(specPatterns.length > 0 ? specPatterns : TEST_FILE_PATTERNS),
     ...(supportFiles.length > 0 ? supportFiles : SUPPORT_FILE_PATTERNS),


### PR DESCRIPTION
Cypress config can support the value of `false` for both the `e2e.supportFile` and `component.supportFile` settings
https://docs.cypress.io/guides/references/configuration#e2e
https://docs.cypress.io/guides/references/configuration#component

Because `false` is neither a `string` nor `Array<string>`, when transformed by the map in line 31, `toEntryPattern` tries to perform `specifier.replace(/^(entry:)?/, 'entry:')` which gives the error `TypeError: specifier.replace is not a function`