### PR TITLE
Add support for graphql-codegen plugin level config (resolves #692)

### DIFF
--- a/packages/knip/src/plugins/graphql-codegen/index.ts
+++ b/packages/knip/src/plugins/graphql-codegen/index.ts
@@ -61,6 +61,10 @@ const resolveConfig: ResolveConfig<GraphqlCodegenTypes | GraphqlConfigTypes | Gr
   const nestedPlugins = configurationOutput
     .flatMap(configOutput => (configOutput.plugins ? configOutput.plugins : []))
     .flatMap(plugin => {
+      if (typeof plugin === 'object') return Object.keys(plugin);
+      return [plugin];
+    })
+    .flatMap(plugin => {
       if (typeof plugin !== 'string') return [];
       if (isInternal(plugin)) return [toEntryPattern(plugin)];
       return [`@graphql-codegen/${plugin}`];

--- a/packages/knip/test/plugins/graphql-codegen-graphql-config.test.ts
+++ b/packages/knip/test/plugins/graphql-codegen-graphql-config.test.ts
@@ -21,11 +21,13 @@ test('Find dependencies with the graphql-codegen plugin (graphql-config)', async
   assert(issues.unlisted['graphql.config.ts']['@graphql-codegen/typescript-urql']);
   assert(issues.unlisted['graphql.config.ts']['@graphql-codegen/typescript-msw']);
 
+  assert(issues.unlisted['.graphqlrc']['@graphql-codegen/add']);
   assert(issues.unlisted['.graphqlrc']['@graphql-codegen/typescript']);
   assert(issues.unlisted['.graphqlrc']['@graphql-codegen/typescript-operations']);
   assert(issues.unlisted['.graphqlrc']['@graphql-codegen/typed-document-node']);
   assert(issues.unlisted['.graphqlrc']['@graphql-codegen/typescript-resolvers']);
 
+  assert(issues.unlisted['graphql.config.toml']['@graphql-codegen/add']);
   assert(issues.unlisted['graphql.config.toml']['@graphql-codegen/typescript']);
   assert(issues.unlisted['graphql.config.toml']['@graphql-codegen/typescript-operations']);
   assert(issues.unlisted['graphql.config.toml']['@graphql-codegen/typed-document-node']);
@@ -35,7 +37,7 @@ test('Find dependencies with the graphql-codegen plugin (graphql-config)', async
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    unlisted: 16,
+    unlisted: 18,
     processed: 1,
     total: 1,
   });

--- a/packages/knip/test/plugins/graphql-codegen.test.ts
+++ b/packages/knip/test/plugins/graphql-codegen.test.ts
@@ -21,6 +21,7 @@ test('Find dependencies with the graphql-codegen plugin (codegen.ts function)', 
   assert(issues.unlisted['codegen.ts']['@graphql-codegen/typescript-urql']);
   assert(issues.unlisted['codegen.ts']['@graphql-codegen/typescript-msw']);
 
+  assert(issues.unlisted['codegen.yaml']['@graphql-codegen/add']);
   assert(issues.unlisted['codegen.yaml']['@graphql-codegen/typescript']);
   assert(issues.unlisted['codegen.yaml']['@graphql-codegen/typescript-operations']);
   assert(issues.unlisted['codegen.yaml']['@graphql-codegen/typed-document-node']);
@@ -30,7 +31,7 @@ test('Find dependencies with the graphql-codegen plugin (codegen.ts function)', 
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    unlisted: 12,
+    unlisted: 13,
     processed: 1,
     total: 1,
   });


### PR DESCRIPTION
This ensures knip finds references to graphql-codegen plugins with plugin-level configuration, and can detect these as used, unused or unlisted dependencies.

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
