### PR TITLE
Fix Cannot read properties of undefined (reading 'name')

### DIFF
--- a/packages/knip/src/typescript/visitors/dynamic-imports/importCall.ts
+++ b/packages/knip/src/typescript/visitors/dynamic-imports/importCall.ts
@@ -44,7 +44,7 @@ export default visit(
                         return { identifier, specifier, pos };
                       });
                     }
-                  } else if (ts.isObjectBindingPattern(arg.name)) {
+                  } else if (arg && ts.isObjectBindingPattern(arg.name)) {
                     // Pattern: import('specifier').then({ identifier } => identifier);
                     return arg.name.elements.map(element => {
                       const identifier = (element.propertyName ?? element.name).getText();


### PR DESCRIPTION
# Description

We see the following exception when running the latest versions of `knip`

```
file:///Users/christian/project/node_modules/knip/dist/typescript/visitors/dynamic-imports/importCall.js:33
                                else if (ts.isObjectBindingPattern(arg.name)) {
                                                                       ^

TypeError: Cannot read properties of undefined (reading 'name')
    at file:///Users/christian/project/node_modules/knip/dist/typescript/visitors/dynamic-imports/importCall.js:33:72
    at file:///Users/christian/project/node_modules/knip/dist/typescript/visitors/index.js:4:35
```

Version: Any version >[5.22.1](https://github.com/webpro-nl/knip/releases/tag/5.22.1)
Root cause: https://github.com/webpro-nl/knip/commit/1343826aa56bc70da74e9d79648329439ce010d8#diff-4f5da9f532afb6319ca695a791c6d09766d095bdb5e2466bd1aa989e58823ebbR47

# Note

Even with `--debug` I wasn't able to figure out which file caused the issue
