### PR TITLE
fix: Use `parseFragment` instead of `text` node which breaks formatting

### DIFF
--- a/packages/docs/scripts/generate-plugin-docs.ts
+++ b/packages/docs/scripts/generate-plugin-docs.ts
@@ -81,7 +81,7 @@ for await (const dir of directories) {
       u('heading', { depth: 2 }, [u('text', 'Enabled')]),
       ...en,
       u('heading', { depth: 2 }, [u('text', 'Default configuration')]),
-      u('text', 'This configuration is added automatically if the plugin is enabled:'),
+      ...parseFragment('This configuration is added automatically if the plugin is enabled:'),
       u('code', {
         lang: 'json title="knip.json"', // TODO How to set attributes/properties/props properly?
         value: JSON.stringify({ [pluginName]: defaults }, null, 2),


### PR DESCRIPTION
Before (currently live https://knip.dev/reference/plugins/cucumber): 
![image](https://github.com/webpro-nl/knip/assets/3907965/e5c182be-2d79-4a0b-9a98-0b0d79dc253d)

After: 
![image](https://github.com/webpro-nl/knip/assets/3907965/64e791b7-0026-403d-b8de-206607006b20)


Sidenote: The edit link that gets generated on these pages is misleading
