### PR TITLE
feat(cypress): add support for cypress-multi-reporter

### DIFF
--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/cypress.config.ts
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/cypress.config.ts
@@ -1,0 +1,15 @@
+import { nxE2EPreset } from '@nrwl/cypress/plugins/cypress-preset';
+import { defineConfig } from 'cypress';
+
+const cypressJsonConfig = {};
+
+export default defineConfig({
+  reporter: "cypress-multi-reporters",
+  reporterOptions: {
+    configFile: 'reporter-config.json',
+  },
+  e2e: {
+    ...nxE2EPreset(__dirname, {}),
+    ...cypressJsonConfig,
+  },
+});

--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/cypress/support/commands.ts
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/cypress/support/commands.ts
@@ -1,0 +1,7 @@
+import { faker } from '@faker-js/faker';
+
+function login() {
+  return faker;
+}
+
+Cypress.Commands.add('login', login);

--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/cypress/support/e2e.ts
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/cypress/support/e2e.ts
@@ -1,0 +1,2 @@
+import '@testing-library/cypress/add-commands';
+import './commands';

--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/node_modules/@nrwl/cypress/plugins/cypress-preset.js
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/node_modules/@nrwl/cypress/plugins/cypress-preset.js
@@ -1,0 +1,1 @@
+export const nxE2EPreset = (p, c) => ({});

--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/node_modules/cypress/index.js
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/node_modules/cypress/index.js
@@ -1,0 +1,1 @@
+export const defineConfig = c => c;

--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/node_modules/cypress/package.json
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/node_modules/cypress/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "cypress"
+}

--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/package.json
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixtures/cypress",
+  "devDependencies": {
+    "cypress": "*",
+    "cypress-multi-reporters": "*",
+    "mocha-junit-reporter": "*",
+    "mochawesome": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/reporter-config.json
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/reporter-config.json
@@ -1,4 +1,4 @@
 {
-    "reporterEnabled": "mochawesome, mocha-junit-reporter, @testing-library/my-fake-reporter"
+    "reporterEnabled": "mochawesome, mocha-junit-reporter ,  @testing-library/my-fake-reporter"
 }
   

--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/reporter-config.json
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/reporter-config.json
@@ -1,4 +1,4 @@
 {
-    "reporterEnabled": "mochawesome, mocha-junit-reporter"
-  }
+    "reporterEnabled": "mochawesome, mocha-junit-reporter, @testing-library/my-fake-reporter"
+}
   

--- a/packages/knip/fixtures/plugins/cypress-multi-reporter/reporter-config.json
+++ b/packages/knip/fixtures/plugins/cypress-multi-reporter/reporter-config.json
@@ -1,0 +1,4 @@
+{
+    "reporterEnabled": "mochawesome, mocha-junit-reporter"
+  }
+  

--- a/packages/knip/src/plugins/cypress/helpers.ts
+++ b/packages/knip/src/plugins/cypress/helpers.ts
@@ -14,7 +14,7 @@ export const resolveDependencies = async (config: CypressConfig, options: Plugin
   const resolve = (specifier: string) => resolveEntry(options, specifier);
 
   // Initialize the array of reporters with the initial reporter if present.
-  const reporters = reporter ? new Set(reporter) : new Set();
+  const reporters = reporter ? new Set([reporter]) : new Set();
   // https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters#configuring-reporters
   if (reporter === 'cypress-multi-reporters' && config.reporterOptions?.configFile) {
     // Try to resolve the config file if present and attach the reporters listed in it.

--- a/packages/knip/src/plugins/cypress/helpers.ts
+++ b/packages/knip/src/plugins/cypress/helpers.ts
@@ -4,7 +4,7 @@ import { load, resolveEntry } from '#p/util/plugin.ts';
 import type { CypressConfig } from './types.js';
 
 interface ReporterConfig {
-    reporterEnabled: string;
+  reporterEnabled: string;
 }
 
 export const resolveDependencies = async (config: CypressConfig, options: PluginOptions) => {

--- a/packages/knip/src/plugins/cypress/helpers.ts
+++ b/packages/knip/src/plugins/cypress/helpers.ts
@@ -14,7 +14,7 @@ export const resolveDependencies = async (config: CypressConfig, options: Plugin
   const resolve = (specifier: string) => resolveEntry(options, specifier);
 
   // Initialize the array of reporters with the initial reporter if present.
-  const reporters = reporter ? new Set([reporter]) : new Set();
+  const reporters: Set<string> = reporter ? new Set(reporter) : new Set();
   // https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters#configuring-reporters
   if (reporter === 'cypress-multi-reporters' && config.reporterOptions?.configFile) {
     // Try to resolve the config file if present and attach the reporters listed in it.

--- a/packages/knip/src/plugins/cypress/helpers.ts
+++ b/packages/knip/src/plugins/cypress/helpers.ts
@@ -1,0 +1,34 @@
+import type { PluginOptions } from "#p/types/plugins.ts";
+import { isInternal, toAbsolute } from "#p/util/path.ts";
+import { load, resolveEntry } from "#p/util/plugin.ts";
+import { dirname } from "path";
+import type { CypressConfig } from "./types.js";
+
+export const resolveDependencies = async (config: CypressConfig, options: PluginOptions) => {
+    const {reporter} = config;
+    const { configFileDir } = options;
+
+    const resolve = (specifier: string) => resolveEntry(options, specifier);
+
+    // Initialize the array of reporters with the initial reporter if present.
+    const reporters = reporter ? [reporter] : [];
+    // https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters#configuring-reporters
+    if(reporter === 'cypress-multi-reporters' && config.reporterOptions?.configFile){
+        // Try to resolve the config file if present and attach the reporters listed in it.
+        const {configFile} = config.reporterOptions;
+        const configFilePath = toAbsolute(configFile, configFileDir);
+        if(isInternal(configFilePath)){
+            const reporterConfig = await load(configFilePath);
+            if(typeof reporterConfig === 'object' && reporterConfig.reporterEnabled){
+                const {reporterEnabled: reporterConcatenatedNames} = reporterConfig;
+                const reporterNames = reporterConcatenatedNames.split(', ');
+                for(const reporterName of reporterNames){
+                    reporters.push(resolve(reporterName));
+                }
+            }
+        }
+    }
+    return [
+        ...reporters
+    ]
+}

--- a/packages/knip/src/plugins/cypress/helpers.ts
+++ b/packages/knip/src/plugins/cypress/helpers.ts
@@ -1,6 +1,6 @@
-import type { PluginOptions } from '#p/types/plugins.ts';
-import { isInternal, toAbsolute } from '#p/util/path.ts';
-import { load, resolveEntry } from '#p/util/plugin.ts';
+import type { PluginOptions } from '#p/types/plugins.js';
+import { isInternal, toAbsolute } from '#p/util/path.js';
+import { load, resolveEntry } from '#p/util/plugin.js';
 import type { CypressConfig } from './types.js';
 
 interface ReporterConfig {

--- a/packages/knip/src/plugins/cypress/helpers.ts
+++ b/packages/knip/src/plugins/cypress/helpers.ts
@@ -14,7 +14,7 @@ export const resolveDependencies = async (config: CypressConfig, options: Plugin
   const resolve = (specifier: string) => resolveEntry(options, specifier);
 
   // Initialize the array of reporters with the initial reporter if present.
-  const reporters: Set<string> = reporter ? new Set(reporter) : new Set();
+  const reporters: Set<string> = reporter ? new Set([reporter]) : new Set();
   // https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters#configuring-reporters
   if (reporter === 'cypress-multi-reporters' && config.reporterOptions?.configFile) {
     // Try to resolve the config file if present and attach the reporters listed in it.

--- a/packages/knip/src/plugins/cypress/helpers.ts
+++ b/packages/knip/src/plugins/cypress/helpers.ts
@@ -14,7 +14,7 @@ export const resolveDependencies = async (config: CypressConfig, options: Plugin
   const resolve = (specifier: string) => resolveEntry(options, specifier);
 
   // Initialize the array of reporters with the initial reporter if present.
-  const reporters = reporter ? [reporter] : [];
+  const reporters = reporter ? new Set(reporter) : new Set();
   // https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters#configuring-reporters
   if (reporter === 'cypress-multi-reporters' && config.reporterOptions?.configFile) {
     // Try to resolve the config file if present and attach the reporters listed in it.
@@ -28,7 +28,7 @@ export const resolveDependencies = async (config: CypressConfig, options: Plugin
         // Not sure why they allow for extra whitespace characters, but let's handle it the same as them.
         const reporterNames = reporterConcatenatedNames.split(',');
         for (const reporterName of reporterNames) {
-          reporters.push(resolve(reporterName.trim()));
+          reporters.add(resolve(reporterName.trim()));
         }
       }
     }

--- a/packages/knip/src/plugins/cypress/helpers.ts
+++ b/packages/knip/src/plugins/cypress/helpers.ts
@@ -1,34 +1,31 @@
-import type { PluginOptions } from "#p/types/plugins.ts";
-import { isInternal, toAbsolute } from "#p/util/path.ts";
-import { load, resolveEntry } from "#p/util/plugin.ts";
-import { dirname } from "path";
-import type { CypressConfig } from "./types.js";
+import type { PluginOptions } from '#p/types/plugins.ts';
+import { isInternal, toAbsolute } from '#p/util/path.ts';
+import { load, resolveEntry } from '#p/util/plugin.ts';
+import type { CypressConfig } from './types.js';
 
 export const resolveDependencies = async (config: CypressConfig, options: PluginOptions) => {
-    const {reporter} = config;
-    const { configFileDir } = options;
+  const { reporter } = config;
+  const { configFileDir } = options;
 
-    const resolve = (specifier: string) => resolveEntry(options, specifier);
+  const resolve = (specifier: string) => resolveEntry(options, specifier);
 
-    // Initialize the array of reporters with the initial reporter if present.
-    const reporters = reporter ? [reporter] : [];
-    // https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters#configuring-reporters
-    if(reporter === 'cypress-multi-reporters' && config.reporterOptions?.configFile){
-        // Try to resolve the config file if present and attach the reporters listed in it.
-        const {configFile} = config.reporterOptions;
-        const configFilePath = toAbsolute(configFile, configFileDir);
-        if(isInternal(configFilePath)){
-            const reporterConfig = await load(configFilePath);
-            if(typeof reporterConfig === 'object' && reporterConfig.reporterEnabled){
-                const {reporterEnabled: reporterConcatenatedNames} = reporterConfig;
-                const reporterNames = reporterConcatenatedNames.split(', ');
-                for(const reporterName of reporterNames){
-                    reporters.push(resolve(reporterName));
-                }
-            }
+  // Initialize the array of reporters with the initial reporter if present.
+  const reporters = reporter ? [reporter] : [];
+  // https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters#configuring-reporters
+  if (reporter === 'cypress-multi-reporters' && config.reporterOptions?.configFile) {
+    // Try to resolve the config file if present and attach the reporters listed in it.
+    const { configFile } = config.reporterOptions;
+    const configFilePath = toAbsolute(configFile, configFileDir);
+    if (isInternal(configFilePath)) {
+      const reporterConfig = await load(configFilePath);
+      if (typeof reporterConfig === 'object' && reporterConfig.reporterEnabled) {
+        const { reporterEnabled: reporterConcatenatedNames } = reporterConfig;
+        const reporterNames = reporterConcatenatedNames.split(', ');
+        for (const reporterName of reporterNames) {
+          reporters.push(resolve(reporterName));
         }
+      }
     }
-    return [
-        ...reporters
-    ]
-}
+  }
+  return [...reporters];
+};

--- a/packages/knip/src/plugins/cypress/index.ts
+++ b/packages/knip/src/plugins/cypress/index.ts
@@ -34,7 +34,7 @@ const resolveEntryPaths: ResolveEntryPaths = async localConfig => {
 };
 
 const resolveConfig: ResolveConfig<CypressConfig> = (config, options) => {
-  return resolveDependencies(config, options)
+  return resolveDependencies(config, options);
 };
 
 export default {
@@ -44,5 +44,5 @@ export default {
   config,
   entry,
   resolveEntryPaths,
-  resolveConfig
+  resolveConfig,
 } satisfies Plugin;

--- a/packages/knip/src/plugins/cypress/index.ts
+++ b/packages/knip/src/plugins/cypress/index.ts
@@ -1,6 +1,8 @@
-import type { IsPluginEnabled, Plugin, ResolveEntryPaths } from '#p/types/plugins.js';
+import type { IsPluginEnabled, Plugin, ResolveConfig, ResolveEntryPaths } from '#p/types/plugins.js';
 import { hasDependency } from '#p/util/plugin.js';
 import { toEntryPattern } from '../../util/protocols.js';
+import { resolveDependencies } from './helpers.js';
+import type { CypressConfig } from './types.js';
 
 // https://docs.cypress.io/guides/references/configuration
 
@@ -31,6 +33,10 @@ const resolveEntryPaths: ResolveEntryPaths = async localConfig => {
   ].map(toEntryPattern);
 };
 
+const resolveConfig: ResolveConfig<CypressConfig> = (config, options) => {
+  return resolveDependencies(config, options)
+};
+
 export default {
   title,
   enablers,
@@ -38,4 +44,5 @@ export default {
   config,
   entry,
   resolveEntryPaths,
+  resolveConfig
 } satisfies Plugin;

--- a/packages/knip/src/plugins/cypress/types.ts
+++ b/packages/knip/src/plugins/cypress/types.ts
@@ -1,1 +1,4 @@
-export interface CypressConfig {reporter: string; reporterOptions?: {configFile?: string}};
+export interface CypressConfig {
+  reporter: string;
+  reporterOptions?: { configFile?: string };
+}

--- a/packages/knip/src/plugins/cypress/types.ts
+++ b/packages/knip/src/plugins/cypress/types.ts
@@ -1,0 +1,1 @@
+export interface CypressConfig {reporter: string; reporterOptions?: {configFile?: string}};

--- a/packages/knip/test/plugins/cypress-multi-reporter.test.ts
+++ b/packages/knip/test/plugins/cypress-multi-reporter.test.ts
@@ -16,11 +16,12 @@ test('Find dependencies with the cypress-multi-reporter plugin', async () => {
   assert(issues.unlisted['cypress.config.ts']['@nrwl/cypress/plugins/cypress-preset']);
   assert(issues.unlisted['cypress/support/commands.ts']['@faker-js/faker']);
   assert(issues.unlisted['cypress/support/e2e.ts']['@testing-library/cypress/add-commands']);
+  assert(issues.unlisted['cypress.config.ts']['@testing-library/my-fake-reporter']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     devDependencies: 0,
-    unlisted: 3,
+    unlisted: 4,
     processed: 3,
     total: 3,
   });

--- a/packages/knip/test/plugins/cypress-multi-reporter.test.ts
+++ b/packages/knip/test/plugins/cypress-multi-reporter.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/plugins/cypress-multi-reporter');
+
+test('Find dependencies with the cypress-multi-reporter plugin', async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert(issues.unlisted['cypress.config.ts']['@nrwl/cypress/plugins/cypress-preset']);
+  assert(issues.unlisted['cypress/support/commands.ts']['@faker-js/faker']);
+  assert(issues.unlisted['cypress/support/e2e.ts']['@testing-library/cypress/add-commands']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    devDependencies: 0,
+    unlisted: 3,
+    processed: 3,
+    total: 3,
+  });
+});


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Closes #701 
