### PR TITLE
feat(vite): add vite-env file for entrypoints

### DIFF
--- a/packages/knip/src/plugins/vite/index.ts
+++ b/packages/knip/src/plugins/vite/index.ts
@@ -12,6 +12,8 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 
 export const config = ['vite*.config.{js,mjs,ts,cjs,mts,cts}'];
 
+const entry = ['src/vite-env.d.ts'];
+
 const production: string[] = [];
 
 export default {
@@ -19,6 +21,7 @@ export default {
   enablers,
   isEnabled,
   config,
+  entry,
   production,
   resolveEntryPaths,
   resolveConfig,

--- a/packages/knip/src/plugins/vite/index.ts
+++ b/packages/knip/src/plugins/vite/index.ts
@@ -10,9 +10,7 @@ const enablers = ['vite', 'vitest'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-export const config = ['vite*.config.{js,mjs,ts,cjs,mts,cts}'];
-
-const entry = ['src/vite-env.d.ts'];
+export const config = ['vite*.config.{js,mjs,ts,cjs,mts,cts}', 'src/vite-env.d.ts'];
 
 const production: string[] = [];
 
@@ -21,7 +19,6 @@ export default {
   enablers,
   isEnabled,
   config,
-  entry,
   production,
   resolveEntryPaths,
   resolveConfig,

--- a/packages/knip/src/plugins/vite/index.ts
+++ b/packages/knip/src/plugins/vite/index.ts
@@ -1,6 +1,8 @@
-import type { IsPluginEnabled, Plugin } from '#p/types/plugins.js';
+import type { IsPluginEnabled, Plugin, ResolveEntryPaths } from '#p/types/plugins.js';
 import { hasDependency } from '#p/util/plugin.js';
+import { toEntryPattern } from '#p/util/protocols.ts';
 import { resolveConfig, resolveEntryPaths } from '../vitest/index.js';
+import type { ViteConfigOrFn, VitestWorkspaceConfig } from '../vitest/types.js';
 
 // https://vitejs.dev/config/
 
@@ -10,9 +12,18 @@ const enablers = ['vite', 'vitest'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-export const config = ['vite*.config.{js,mjs,ts,cjs,mts,cts}', 'src/vite-env.d.ts'];
+export const config = ['vite*.config.{js,mjs,ts,cjs,mts,cts}'];
 
 const production: string[] = [];
+
+const viteResolveEntryPaths: ResolveEntryPaths<ViteConfigOrFn | VitestWorkspaceConfig> = async (
+  localConfig,
+  options
+) => {
+  const vitestEntryPaths = await resolveEntryPaths(localConfig, options);
+
+  return [...vitestEntryPaths, toEntryPattern('src/vite-env.d.ts')];
+};
 
 export default {
   title,
@@ -20,6 +31,6 @@ export default {
   isEnabled,
   config,
   production,
-  resolveEntryPaths,
+  resolveEntryPaths: viteResolveEntryPaths,
   resolveConfig,
 } satisfies Plugin;

--- a/packages/knip/src/plugins/vite/index.ts
+++ b/packages/knip/src/plugins/vite/index.ts
@@ -1,6 +1,6 @@
 import type { IsPluginEnabled, Plugin, ResolveEntryPaths } from '#p/types/plugins.js';
 import { hasDependency } from '#p/util/plugin.js';
-import { toEntryPattern } from '#p/util/protocols.ts';
+import { toEntryPattern } from '#p/util/protocols.js';
 import { resolveConfig, resolveEntryPaths } from '../vitest/index.js';
 import type { ViteConfigOrFn, VitestWorkspaceConfig } from '../vitest/types.js';
 


### PR DESCRIPTION
Vite provides type definitions file `vite-end.d.ts` - https://vitejs.dev/guide/env-and-mode.html#intellisense-for-typescript.

But now this file gives an error:
<img width="323" alt="Screenshot 2024-07-16 at 13 06 53" src="https://github.com/user-attachments/assets/5c08c7b6-7caa-433f-a648-72aaabdda277">

Fast search shows that people include this file in ignores: https://github.com/search?q=path%3A**%2Fknip**+vite-env.d.ts&type=code&ref=advsearch
In this PR append path to file in config list