### PR TITLE
chore: update gitattributes with more file types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,16 @@
+# Convert all files to use "\n" line endings.
 * text eol=lf
 
-*.png binary
-*.jpg binary
-*.jpeg binary
+# Specify the file type for some binary files to prevent Git from changing the line endings upon
+# cloning the repository.
 *.gif binary
 *.ico binary
+*.jpeg binary
+*.jpg binary
+*.png binary
+*.otf binary
 *.mov binary
-*.mp4 binary
 *.mp3 binary
+*.mp4 binary
 *.webm binary
+*.webp binary


### PR DESCRIPTION
This PR:
- Adds webp and otf, because "assets/cow-with-orange-scissors-van-gogh-style.webp" and "packages/docs/public/fonts/SourceSansPro-Regular.otf" are in the repo.
- Adds comments explaining why the values are there.
- Alphabetizes the list.