### PR TITLE
Do not treat trailing `#` in gitignore as comment

### DIFF
--- a/packages/knip/src/util/glob-core.ts
+++ b/packages/knip/src/util/glob-core.ts
@@ -54,7 +54,7 @@ export const parseAndConvertGitignorePatterns = (patterns: string, ancestor?: st
     .split(/\r?\n/)
     .filter(line => line.trim() && !line.startsWith('#'))
     .flatMap(line => {
-      const pattern = line.replace(/(?<!\\)#.*/, '').trim();
+      const pattern = line.replace(/^\\(?=#)/, '').trim();
       if (ancestor && matchFrom) {
         if (pattern.match(matchFrom)) return [pattern.replace(matchFrom, '$1')];
         if (pattern.startsWith('/**/')) return [pattern.slice(1)];

--- a/packages/knip/test/util/parse-and-convert-gitignore-patterns.test.ts
+++ b/packages/knip/test/util/parse-and-convert-gitignore-patterns.test.ts
@@ -24,3 +24,12 @@ test('parseAndConvertGitignorePatterns (ancestor)', async () => {
     { negated: false, patterns: ['c', 'c/**'] },
   ]);
 });
+
+test('parseAndConvertGitignorePatterns (hashes)', async () => {
+  const gitignorePatterns = ['#comment', 'ends-with-hash#', String.raw`\#starts-with-hash`];
+  const globPatterns = parse(gitignorePatterns.join(EOL));
+  assert.deepEqual(globPatterns, [
+    { negated: false, patterns: ['**/ends-with-hash#', '**/ends-with-hash#/**'] },
+    { negated: false, patterns: ['**/#starts-with-hash', '**/#starts-with-hash/**'] },
+  ]);
+});


### PR DESCRIPTION
Just started using `knip` today and it was instrumental in some really nice cleanup in our codebase. I hit #795 right off the bat, though, and it took me a while to figure out what was going on. I figured I could say "thanks" by opening up a quick PR to fix the issue!

The logic in the gitignore parser that strips trailing `# ...` off of `.gitignore` lines appears to be wrong. In my testing, you cannot add a comment to the end of a `.gitignore` line in this manner (syntax highlighting be damned):

```gitignore
# this is a comment
dist # this is not a comment
```

This tracks with [git's documentation](https://git-scm.com/docs/gitignore) (emphasis mine) as well as my own messing around with git:

> A line **starting** with # serves as a comment. Put a backslash (`\`) in front of the **first** hash for patterns that begin with a hash.

The previous parsing logic (added in https://github.com/webpro-nl/knip/commit/e455527fb2cc58981775ad538f5d4a64a3c70b5b) stripped all non-backslashed `#...` out. I updated the logic to only strip a leading `\`, if it's in front of a hash, so the following cases will be handled properly:

```gitignore
trailing-hash-ignore#
\#leading-hash-ignore
just#some-file
```