### PR TITLE
Stylelint plugin - fix issue where "customSyntax" property is not recognised as a resolved dependency

### DIFF
--- a/packages/knip/fixtures/plugins/stylelint/.stylelintrc
+++ b/packages/knip/fixtures/plugins/stylelint/.stylelintrc
@@ -1,4 +1,5 @@
 {
+  "customsyntax": "postcss-less",
   "extends": ["stylelint-config-standard", "./myExtendableConfig"],
   "plugins": ["stylelint-order"],
   "rules": {

--- a/packages/knip/fixtures/plugins/stylelint/.stylelintrc
+++ b/packages/knip/fixtures/plugins/stylelint/.stylelintrc
@@ -1,5 +1,5 @@
 {
-  "customsyntax": "postcss-less",
+  "customSyntax": "postcss-less",
   "extends": ["stylelint-config-standard", "./myExtendableConfig"],
   "plugins": ["stylelint-order"],
   "rules": {

--- a/packages/knip/src/plugins/stylelint/index.ts
+++ b/packages/knip/src/plugins/stylelint/index.ts
@@ -14,10 +14,11 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 const config = ['package.json', ...toCosmiconfig('stylelint')];
 
 const resolve = (config: StyleLintConfig | BaseStyleLintConfig): string[] => {
-  const extend = config.extends ? [config.extends].flat().filter(id => !isInternal(id)) : [];
-  const plugins = config.plugins ? [config.plugins].flat().filter(id => !isInternal(id)) : [];
+  const extend = config.extends ? [config.extends].flat() : [];
+  const plugins = config.plugins ? [config.plugins].flat() : [];
+  const customSyntax = config.customSyntax ? [config.customSyntax] : [];
   const overrideConfigs = 'overrides' in config ? config.overrides.flatMap(resolve) : [];
-  return [...extend, ...plugins, ...overrideConfigs];
+  return [...extend, ...plugins, ...overrideConfigs, ...customSyntax].filter(id => !isInternal(id));
 };
 
 const resolveConfig: ResolveConfig<StyleLintConfig> = config => resolve(config);

--- a/packages/knip/src/plugins/stylelint/types.ts
+++ b/packages/knip/src/plugins/stylelint/types.ts
@@ -1,4 +1,5 @@
 export type BaseStyleLintConfig = {
+  customSyntax?: string;
   extends?: string | string[];
   plugins?: string[];
 };

--- a/packages/knip/test/plugins/stylelint.test.ts
+++ b/packages/knip/test/plugins/stylelint.test.ts
@@ -22,7 +22,7 @@ test('Find dependencies with the stylelint plugin', async () => {
   assert.deepEqual(counters, {
     ...baseCounters,
     devDependencies: 1,
-    unlisted: 3,
+    unlisted: 4,
     processed: 0,
     total: 0,
   });

--- a/packages/knip/test/plugins/stylelint.test.ts
+++ b/packages/knip/test/plugins/stylelint.test.ts
@@ -14,6 +14,7 @@ test('Find dependencies with the stylelint plugin', async () => {
   });
 
   assert(issues.devDependencies['package.json']['stylelint']);
+  assert(issues.unlisted['.stylelintrc']['postcss-less']);
   assert(issues.unlisted['.stylelintrc']['stylelint-config-standard']);
   assert(issues.unlisted['.stylelintrc']['stylelint-order']);
   assert(issues.unlisted['.stylelintrc']['stylelint-config-html/html']);


### PR DESCRIPTION
Closes #799 
 
Adds `customSyntax` to the stylelint plugin. Includes a test case. 