### PR TITLE
#798 exclude built-in cypress reporters from dependency check

### DIFF
--- a/packages/knip/fixtures/plugins/cypress-builtin-reporter/cypress.config.ts
+++ b/packages/knip/fixtures/plugins/cypress-builtin-reporter/cypress.config.ts
@@ -1,0 +1,12 @@
+import { nxE2EPreset } from '@nrwl/cypress/plugins/cypress-preset';
+import { defineConfig } from 'cypress';
+
+const cypressJsonConfig = {};
+
+export default defineConfig({
+  reporter: "junit",
+  e2e: {
+    ...nxE2EPreset(__dirname, {}),
+    ...cypressJsonConfig,
+  },
+});

--- a/packages/knip/fixtures/plugins/cypress-builtin-reporter/cypress/support/commands.ts
+++ b/packages/knip/fixtures/plugins/cypress-builtin-reporter/cypress/support/commands.ts
@@ -1,0 +1,7 @@
+import { faker } from '@faker-js/faker';
+
+function login() {
+  return faker;
+}
+
+Cypress.Commands.add('login', login);

--- a/packages/knip/fixtures/plugins/cypress-builtin-reporter/cypress/support/e2e.ts
+++ b/packages/knip/fixtures/plugins/cypress-builtin-reporter/cypress/support/e2e.ts
@@ -1,0 +1,2 @@
+import '@testing-library/cypress/add-commands';
+import './commands';

--- a/packages/knip/fixtures/plugins/cypress-builtin-reporter/node_modules/@nrwl/cypress/plugins/cypress-preset.js
+++ b/packages/knip/fixtures/plugins/cypress-builtin-reporter/node_modules/@nrwl/cypress/plugins/cypress-preset.js
@@ -1,0 +1,1 @@
+export const nxE2EPreset = (p, c) => ({});

--- a/packages/knip/fixtures/plugins/cypress-builtin-reporter/node_modules/cypress/index.js
+++ b/packages/knip/fixtures/plugins/cypress-builtin-reporter/node_modules/cypress/index.js
@@ -1,0 +1,1 @@
+export const defineConfig = c => c;

--- a/packages/knip/fixtures/plugins/cypress-builtin-reporter/node_modules/cypress/package.json
+++ b/packages/knip/fixtures/plugins/cypress-builtin-reporter/node_modules/cypress/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "cypress"
+}

--- a/packages/knip/fixtures/plugins/cypress-builtin-reporter/package.json
+++ b/packages/knip/fixtures/plugins/cypress-builtin-reporter/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixtures/cypress",
+  "devDependencies": {
+    "cypress": "*",
+    "cypress-multi-reporters": "*",
+    "mocha-junit-reporter": "*",
+    "mochawesome": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/cypress-builtin-reporter/package.json
+++ b/packages/knip/fixtures/plugins/cypress-builtin-reporter/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fixtures/cypress",
+  "name": "@fixtures/cypress-builtin-reporter",
   "devDependencies": {
     "cypress": "*",
     "cypress-multi-reporters": "*",

--- a/packages/knip/fixtures/plugins/cypress-builtin-reporter/reporter-config.json
+++ b/packages/knip/fixtures/plugins/cypress-builtin-reporter/reporter-config.json
@@ -1,0 +1,4 @@
+{
+    "reporterEnabled": "mochawesome, mocha-junit-reporter ,  @testing-library/my-fake-reporter"
+}
+  

--- a/packages/knip/src/plugins/cypress/helpers.ts
+++ b/packages/knip/src/plugins/cypress/helpers.ts
@@ -7,6 +7,10 @@ interface ReporterConfig {
   reporterEnabled: string;
 }
 
+// see https://docs.cypress.io/guides/tooling/reporters
+const BUILT_IN_REPORTERS: ReadonlyArray<string> = ['spec', 'junit', 'teamcity'] as const;
+const IS_NOT_BUILT_IN_REPORTER = (reporter: string) => !BUILT_IN_REPORTERS.includes(reporter);
+
 export const resolveDependencies = async (config: CypressConfig, options: PluginOptions) => {
   const { reporter } = config;
   const { configFileDir } = options;
@@ -33,5 +37,5 @@ export const resolveDependencies = async (config: CypressConfig, options: Plugin
       }
     }
   }
-  return [...reporters];
+  return [...reporters].filter(IS_NOT_BUILT_IN_REPORTER);
 };

--- a/packages/knip/test/plugins/cypress-builtin-reporter.test.ts
+++ b/packages/knip/test/plugins/cypress-builtin-reporter.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+
+const cwd = resolve('fixtures/plugins/cypress-multi-reporter');
+
+test('Exclude built-in cypress reporters from dependency checks', async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert(!issues.unlisted['cypress.config.ts']['junit']);
+});


### PR DESCRIPTION
Closes #798 

Filters out built-in dependencies when checking Cypress reporter packages
