### PR TITLE
🔀 Don't follow symlinks by default

### DIFF
--- a/packages/knip/src/index.ts
+++ b/packages/knip/src/index.ts
@@ -288,6 +288,7 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
           ignoreExportsUsedInFile: chief.config.ignoreExportsUsedInFile,
           isReportClassMembers,
           tags,
+          workspacePkgNames: chief.availableWorkspacePkgNames,
         },
         isGitIgnored,
         isPackageNameInternalWorkspace,

--- a/packages/knip/src/util/resolve.ts
+++ b/packages/knip/src/util/resolve.ts
@@ -7,10 +7,11 @@ import { toPosix } from './path.js';
 // @ts-ignore error TS2345 (not in latest): Argument of type 'typeof import("node:fs")' is not assignable to parameter of type 'BaseFileSystem'.
 const fileSystem = new ER.CachedInputFileSystem(fs, 9999999);
 
-export const createSyncResolver = (extensions: string[]) => {
+export const createSyncResolver = (extensions: string[], symlinks = true) => {
   const resolver = ER.create.sync({
     fileSystem,
     extensions,
+    symlinks,
     conditionNames: ['require', 'import', 'node', 'default'],
   });
 
@@ -22,6 +23,10 @@ export const createSyncResolver = (extensions: string[]) => {
   };
 };
 
-const resolveSync = createSyncResolver([...DEFAULT_EXTENSIONS, '.json']);
+const resolveSync = createSyncResolver([...DEFAULT_EXTENSIONS, '.json'], false);
+
+const resolveSyncFollowSymlinks = createSyncResolver([...DEFAULT_EXTENSIONS, '.json'], true);
 
 export const _resolveSync = timerify(resolveSync);
+
+export const _resolveSyncFollowSymlinks = timerify(resolveSyncFollowSymlinks);

--- a/packages/knip/test/module-resolution-non-std-absolute.test.ts
+++ b/packages/knip/test/module-resolution-non-std-absolute.test.ts
@@ -14,10 +14,12 @@ test('Resolve non-standard absolute specifiers', async () => {
   });
 
   assert(issues.unlisted['self/index.ts']['other']);
+  assert(issues.unlisted['self/index.ts']['other/absolute.css']);
+  assert(issues.unlisted['self/index.ts']['other/absolute.svg']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    unlisted: 1,
+    unlisted: 3,
     processed: 1,
     total: 1,
   });


### PR DESCRIPTION
Let's try to keep/make it simple by not following symlinks by default. That should allow things like `npm link` etc. without Knip going awry.

It has a few consequences for some internal logic, but the first tests are looking good.

You can install and try with the version that the pkg-pr-new bot shows below. It says `bun` but you can use any package manager.