### PR TITLE
Add documentation for unplugin-icons imports issue

### DIFF
--- a/packages/docs/src/content/docs/reference/known-issues.md
+++ b/packages/docs/src/content/docs/reference/known-issues.md
@@ -70,6 +70,28 @@ import ArrowIcon from '../icons/Arrow'; // → Does NOT resolve to ../icons/Arro
 The recommendation is to always add the extension when importing such files,
 similar to how standard ES Modules work.
 
+## `unplugin-icons` imports
+
+[unplugin-icons](https://github.com/antfu/unplugin-icons) uses virtual imports
+to import icons from icon sets as components. Knip cannot resolve these imports
+and will report them as unused.
+
+To fix this, you can use the [`paths` configuration option][13] to tell Knip
+where to find the icon types.
+
+For example:
+
+```json title="knip.json"
+{
+  "paths": {
+    "~icons/*": ["node_modules/unplugin-icons/types/[framework].d.ts"]
+  }
+}
+```
+
+where `[framework]` is the name of the framework you're using (see [this
+list][14] for available types).
+
 [1]: #exceptions-from-config-files
 [2]: #false-positives-with-external-libs
 [3]: #definitely-typed-packages-in-dependencies
@@ -82,3 +104,5 @@ similar to how standard ES Modules work.
 [10]: https://github.com/unjs/jiti/issues/174
 [11]: https://github.com/webpro-nl/knip/issues/565
 [12]: ../guides/handling-issues.mdx#external-libraries
+[13]: ./configuration.md#paths
+[14]: https://github.com/unplugin/unplugin-icons/tree/main/types


### PR DESCRIPTION
As mentioned in #811, the imports for icons when using the `unplugin-icons` package are virtual and cannot be resolved by Knip so this PR documents the "workaround" of using the `paths` config option to point to the types so that they can be resolved properly.

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
