### PR TITLE
Add `amplify` to `IGNORED_GLOBAL_BINARIES`

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -35,6 +35,7 @@ export const PROTOCOL_VIRTUAL = 'virtual:';
 // In other words, https://www.npmjs.com/package/[name] is NOT the expected dependency
 // Package may exist in npm registry, but last publish is at least 6 years ago
 export const IGNORED_GLOBAL_BINARIES = new Set([
+  'amplify',
   'aws',
   'base64',
   'basename',


### PR DESCRIPTION
Amplify is an AWS app framework. It has two generations (gen1 and gen2).

Setup docs for gen1 suggest installing `amplify` command globally:
https://docs.amplify.aws/gen1/javascript/tools/cli/start/set-up-cli/
`npm install -g @aws-amplify/cli`
Installing this package locally does not make sense because it contains a binary that weights a few _hundred_ megs.

They completely changed the architecture in Amplify gen2 (which is pretty recent):
https://docs.amplify.aws/javascript/start/quickstart/
New CLI is called `ampx` and originates from `@aws-amplify/backend-cli`. I haven’t used Amplify gen2 but I _guess_ that this dependency is now meant to be local (which makes sense).

---

This PR is addressing a false positive for Amplify gen1.

```
Unlisted binaries (1)
amplify  package.json    
```

It’s used in `package.json` scripts:

```json
{
  "scripts": {
    "codegen": "amplify codegen",
    "...": "..."
  }
}
```


<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
