### PR TITLE
Fix knip chrasing due to invalid picocolors version

### DIFF
--- a/packages/knip/package.json
+++ b/packages/knip/package.json
@@ -66,7 +66,7 @@
     "jiti": "^2.3.3",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",
-    "picocolors": "^1.0.0",
+    "picocolors": "^1.1.0",
     "picomatch": "^4.0.1",
     "pretty-ms": "^9.0.0",
     "smol-toml": "^1.3.0",


### PR DESCRIPTION
Fix for https://github.com/webpro-nl/knip/issues/820
