### PR TITLE
Skip indexing into a gh action if its not an array

### DIFF
--- a/packages/knip/src/plugins/github-actions/index.ts
+++ b/packages/knip/src/plugins/github-actions/index.ts
@@ -41,6 +41,7 @@ const resolveConfig: ResolveConfig = async (config, options) => {
   const jobs = findByKeyDeep<Job>(config, 'steps');
 
   for (const steps of jobs) {
+    if (!Array.isArray(steps.steps)) continue;
     const action = steps.steps.find(
       step => step.uses?.startsWith('actions/checkout@') && typeof step.with?.path === 'string' && !step.with.repository
     );


### PR DESCRIPTION
Skip checking a github action step if its not an array as its possibly a templated string.
In gh actions a valid config is `${{ toJSON(steps) }}` which breaks the plugins parsing. if we see a string we should just skip those steps

