### PR TITLE
fix: Fix incorrect rootPath resolution in jest plugin

### DIFF
--- a/packages/knip/src/plugins/jest/index.ts
+++ b/packages/knip/src/plugins/jest/index.ts
@@ -112,7 +112,7 @@ const resolveDependencies = async (config: JestInitialOptions, options: PluginOp
 const resolveEntryPaths: ResolveEntryPaths<JestConfig> = async (localConfig, options) => {
   const { configFileDir } = options;
   if (typeof localConfig === 'function') localConfig = await localConfig();
-  const rootDir = localConfig.rootDir ? join(configFileDir, localConfig.rootDir) : configFileDir;
+  const rootDir = localConfig.rootDir ?? configFileDir;
   const replaceRootDir = (name: string) => name.replace(/<rootDir>/, rootDir);
   return (localConfig.testMatch ?? []).map(replaceRootDir).map(toEntry);
 };
@@ -120,8 +120,7 @@ const resolveEntryPaths: ResolveEntryPaths<JestConfig> = async (localConfig, opt
 const resolveConfig: ResolveConfig<JestConfig> = async (localConfig, options) => {
   const { configFileDir } = options;
   if (typeof localConfig === 'function') localConfig = await localConfig();
-  const rootDir = localConfig.rootDir ? join(configFileDir, localConfig.rootDir) : configFileDir;
-
+  const rootDir = localConfig.rootDir ??  configFileDir;
   const replaceRootDir = (name: string) => name.replace(/<rootDir>/, rootDir);
 
   const inputs = await resolveDependencies(localConfig, options);


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
## This PR
Stops joining contructing a jest config rootDir via `join(configFileDir, localConfig.rootDir)` 
when a localConfig rootDir is defined. Instead, we always prefer the local config rootDir and fall back to `configFileDir`.

I tried for a while to write a unit test for this but I couldn't figure out how to override the default jest plugin config in a unit-test to point it to a jest config file in a subfolder that can reference a parent via `rootDir`. If anyone knows how to do that or otherwise test this properly so we can have a unit-test that triggers this bug, that would be great!


## Context

I noticed that jest setup files that used the `'<rootDir>/...'` alias in places like `setupFilesAfterEnv` were resolving incorrectly. For example,

when I specify

```
config: ['tests/framework/e2e/jest-configs/jest.config.base.ts']
```

in the jest plugin, 


Where `jest.config.base.ts` contains:


```
// abs path to repo root (/Users/me/work/repo/)
rootDir: REPO_ROOT_PATH,
setupFilesAfterEnv: [
    '<rootDir>/tests/framework/e2e/setup-files/setup.base.ts',
  ],
```

I get the following incorrect resolve:

```
'deferResolve:/Users/me/work/repo/tests/framework/e2e/jest-configs/Users/me/work/repo/tests/framework/e2e/setup-files/setup.base.ts (tests/framework/e2e/jest-configs/jest.config.base.ts)'
```

Where it was joining 
- the directory of the config file path (`/Users/me/work/repo/tests/framework/e2e/jest-configs/`) 
- with the specified `rootDir` in the config file (`/Users/me/work/repo/`)
- and then adding the rest of the path (`tests/framework/e2e/setup-files/setup.base.ts`)

This is happening
- here https://github.com/tryggvigy/knip/blob/main/packages/knip/src/plugins/jest/index.ts#L115
- and here https://github.com/tryggvigy/knip/blob/main/packages/knip/src/plugins/jest/index.ts#L123

I might be wrong, I don't have all the context, but this feels like wrong behaviour.

