### PR TITLE
jest: support custom testEnvironment

### DIFF
--- a/packages/knip/fixtures/plugins/jest2/jest.config.js
+++ b/packages/knip/fixtures/plugins/jest2/jest.config.js
@@ -1,3 +1,5 @@
 module.exports = {
   displayName: 'dev',
+    testEnvironment:
+    '<rootDir>/jest.environment.js',
 };

--- a/packages/knip/fixtures/plugins/jest2/jest.environment.js
+++ b/packages/knip/fixtures/plugins/jest2/jest.environment.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/knip/src/plugins/jest/index.ts
+++ b/packages/knip/src/plugins/jest/index.ts
@@ -58,7 +58,14 @@ const resolveDependencies = async (config: JestInitialOptions, options: PluginOp
 
   const runner = config.runner ? [config.runner] : [];
   const runtime = config.runtime && config.runtime !== 'jest-circus' ? [config.runtime] : [];
-  const environments = config.testEnvironment === 'jsdom' ? ['jest-environment-jsdom'] : [];
+
+  let environments: Array<string> = [];
+  if (config.testEnvironment === 'jsdom') {
+    environments = ['jest-environment-jsdom'];
+  } else if (config.testEnvironment) {
+    environments = [config.testEnvironment];
+  }
+
   const resolvers = config.resolver ? [config.resolver] : [];
   const reporters = config.reporters
     ? config.reporters

--- a/packages/knip/src/plugins/jest/index.ts
+++ b/packages/knip/src/plugins/jest/index.ts
@@ -58,14 +58,12 @@ const resolveDependencies = async (config: JestInitialOptions, options: PluginOp
 
   const runner = config.runner ? [config.runner] : [];
   const runtime = config.runtime && config.runtime !== 'jest-circus' ? [config.runtime] : [];
-
-  let environments: Array<string> = [];
-  if (config.testEnvironment === 'jsdom') {
-    environments = ['jest-environment-jsdom'];
-  } else if (config.testEnvironment) {
-    environments = [config.testEnvironment];
-  }
-
+  const environments =
+    config.testEnvironment === 'jsdom'
+      ? ['jest-environment-jsdom']
+      : config.testEnvironment
+        ? [config.testEnvironment]
+        : [];
   const resolvers = config.resolver ? [config.resolver] : [];
   const reporters = config.reporters
     ? config.reporters

--- a/packages/knip/test/plugins/jest2.test.ts
+++ b/packages/knip/test/plugins/jest2.test.ts
@@ -19,13 +19,16 @@ test('Find dependencies with the Jest plugin', async () => {
   // <rootDir> to reference the root directory.
   assert(!issues.files.has(join(cwd, 'project1/setupFiles/setup.js')));
 
+  // Correctly identifies a local `testEnvironment` file.
+  assert(!issues.files.has(join(cwd, 'jest.environment.js')));
+
   assert.deepEqual(counters, {
     ...baseCounters,
     files: 0,
     devDependencies: 1,
     unlisted: 0,
     unresolved: 0,
-    processed: 4,
-    total: 4,
+    processed: 5,
+    total: 5,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

## This PR

Adds support for custom `testEnvironment` files like:
```ts
  testEnvironment:
    '<rootDir>/tests/framework/e2e/jest-environments/E2EEnvironment.ts',
```

I get a unit test failure on the cli version when running the tests locally. Maybe it'll pass in CI. Anyone know how to fix that?
<img width="506" alt="image" src="https://github.com/user-attachments/assets/e98424fe-9bd5-410f-b326-4257836ba569">
