### PR TITLE
Support resolving jest-junit file dependencies

### DIFF
--- a/packages/knip/fixtures/plugins/jest/customSuiteProperties.cjs
+++ b/packages/knip/fixtures/plugins/jest/customSuiteProperties.cjs
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/knip/fixtures/plugins/jest/jest.config.js
+++ b/packages/knip/fixtures/plugins/jest/jest.config.js
@@ -14,7 +14,11 @@ module.exports = {
   reporters: [
     'default',
     'jest-silent-reporter',
-    ['jest-junit', { outputDirectory: 'reports', outputName: 'report.xml' }],
+    ['jest-junit', {
+      outputDirectory: 'reports', outputName: 'report.xml',
+      testSuitePropertiesFile: 'customSuiteProperties.cjs',
+      testSuitePropertiesDirectory: '<rootDir>',
+     }],
     ['github-actions', { silent: false }],
     'summary',
   ],

--- a/packages/knip/fixtures/plugins/jest/junitProperties.js
+++ b/packages/knip/fixtures/plugins/jest/junitProperties.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/knip/fixtures/plugins/jest2/junitTestCaseProperties.js
+++ b/packages/knip/fixtures/plugins/jest2/junitTestCaseProperties.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/knip/fixtures/plugins/jest2/package.json
+++ b/packages/knip/fixtures/plugins/jest2/package.json
@@ -3,6 +3,7 @@
   "scripts": {},
   "devDependencies": {
     "jest": "*",
-    "@testing-library/jest-dom": "*"
+    "@testing-library/jest-dom": "*",
+    "jest-junit": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/jest2/project1/customProperties.cjs
+++ b/packages/knip/fixtures/plugins/jest2/project1/customProperties.cjs
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/knip/fixtures/plugins/jest2/project1/jest.config.js
+++ b/packages/knip/fixtures/plugins/jest2/project1/jest.config.js
@@ -4,4 +4,16 @@ module.exports = {
   rootDir: path.join(__dirname, '../'),
   displayName: 'project1',
   setupFilesAfterEnv: ['<rootDir>/project1/setupFiles/setup.js'],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: '<rootDir>',
+        outputName: 'junit-vcr.xml',
+        testCasePropertiesFile: 'customProperties.cjs',
+        testCasePropertiesDirectory: '<rootDir>/project1',
+      },
+    ],
+  ],
 };

--- a/packages/knip/src/plugins/jest/helpers.ts
+++ b/packages/knip/src/plugins/jest/helpers.ts
@@ -1,0 +1,55 @@
+import type { PluginOptions } from '../../types/config.js';
+import { dirname, isInternal, join, toAbsolute } from '../../util/path.js';
+import { load } from '../../util/plugin.js';
+import type { JestInitialOptions } from './types.js';
+
+export const resolveExtensibleConfig = async (configFilePath: string) => {
+  let config = await load(configFilePath);
+  if (config?.preset) {
+    const { preset } = config;
+    if (isInternal(preset)) {
+      const presetConfigPath = toAbsolute(preset, dirname(configFilePath));
+      const presetConfig = await resolveExtensibleConfig(presetConfigPath);
+      config = Object.assign({}, presetConfig, config);
+    }
+  }
+  return config;
+};
+
+const getStringPropOrFallback = (prop: unknown, fallback: string): string => {
+  return typeof prop === 'string' ? prop : fallback;
+};
+
+export const getReportersDependencies = (config: JestInitialOptions, options: PluginOptions) => {
+  // Resolve dependencies for jest-junit reporter config
+  const jUnitReporterDeps: string[] = [];
+  for (const reporter of config.reporters ?? []) {
+    if (typeof reporter !== 'string' && reporter[0] === 'jest-junit') {
+      const {
+        testCasePropertiesFile,
+        testCasePropertiesDirectory,
+        testSuitePropertiesFile,
+        testSuitePropertiesDirectory,
+      } = reporter[1];
+
+      const testCaseFileName = getStringPropOrFallback(testCasePropertiesFile, 'junitProperties.js');
+      const testCaseDirectory = getStringPropOrFallback(testCasePropertiesDirectory, options.rootCwd);
+      const testCaseFilePath = join(testCaseDirectory, testCaseFileName);
+
+      const testSuiteFileName = getStringPropOrFallback(testSuitePropertiesFile, 'junitTestCaseProperties.js');
+      const testSuiteDirectory = getStringPropOrFallback(testSuitePropertiesDirectory, options.rootCwd);
+      const testSuiteFilePath = join(testSuiteDirectory, testSuiteFileName);
+
+      jUnitReporterDeps.push(testCaseFilePath);
+      jUnitReporterDeps.push(testSuiteFilePath);
+    }
+  }
+
+  const reporters = config.reporters
+    ? config.reporters
+        .map(reporter => (typeof reporter === 'string' ? reporter : reporter[0]))
+        .filter(reporter => !['default', 'github-actions', 'summary'].includes(reporter))
+    : [];
+
+  return [...reporters, ...jUnitReporterDeps];
+};

--- a/packages/knip/src/plugins/jest/index.ts
+++ b/packages/knip/src/plugins/jest/index.ts
@@ -1,7 +1,8 @@
 import type { IsPluginEnabled, Plugin, PluginOptions, ResolveConfig, ResolveEntryPaths } from '../../types/config.js';
 import { type Input, toDeferResolve, toEntry } from '../../util/input.js';
-import { dirname, isInternal, join, toAbsolute } from '../../util/path.js';
-import { hasDependency, load } from '../../util/plugin.js';
+import { isInternal, join, toAbsolute } from '../../util/path.js';
+import { hasDependency } from '../../util/plugin.js';
+import { getReportersDependencies, resolveExtensibleConfig } from './helpers.js';
 import type { JestConfig, JestInitialOptions } from './types.js';
 
 // https://jestjs.io/docs/configuration
@@ -16,19 +17,6 @@ const isEnabled: IsPluginEnabled = ({ dependencies, manifest }) =>
 const config = ['jest.config.{js,ts,mjs,cjs,json}', 'package.json'];
 
 const entry = ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'];
-
-const resolveExtensibleConfig = async (configFilePath: string) => {
-  let config = await load(configFilePath);
-  if (config?.preset) {
-    const { preset } = config;
-    if (isInternal(preset)) {
-      const presetConfigPath = toAbsolute(preset, dirname(configFilePath));
-      const presetConfig = await resolveExtensibleConfig(presetConfigPath);
-      config = Object.assign({}, presetConfig, config);
-    }
-  }
-  return config;
-};
 
 const resolveDependencies = async (config: JestInitialOptions, options: PluginOptions): Promise<Input[]> => {
   const { configFileDir } = options;
@@ -65,40 +53,7 @@ const resolveDependencies = async (config: JestInitialOptions, options: PluginOp
         ? [config.testEnvironment]
         : [];
   const resolvers = config.resolver ? [config.resolver] : [];
-
-  // Resolve dependencies for jest-junit reporter config
-  const jUnitReporterDeps: Array<string> = [];
-  for (const reporter of config.reporters ?? []) {
-    if (typeof reporter !== 'string' && reporter[0] === 'jest-junit') {
-      const {
-        testCasePropertiesFile,
-        testCasePropertiesDirectory,
-        testSuitePropertiesFile,
-        testSuitePropertiesDirectory,
-      } = reporter[1];
-      const testCaseFileName =
-        typeof testCasePropertiesFile === 'string' ? testCasePropertiesFile : 'junitProperties.js';
-      const testCaseDirectory =
-        typeof testCasePropertiesDirectory === 'string' ? testCasePropertiesDirectory : options.rootCwd;
-      const testSuiteFileName =
-        typeof testSuitePropertiesFile === 'string' ? testSuitePropertiesFile : 'junitTestCaseProperties.js';
-      const testSuiteDirectory =
-        typeof testSuitePropertiesDirectory === 'string' ? testSuitePropertiesDirectory : options.rootCwd;
-      const testCaseFilePath = join(testCaseDirectory, testCaseFileName);
-      const testSuiteFilePath = join(testSuiteDirectory, testSuiteFileName);
-      jUnitReporterDeps.push(testCaseFilePath);
-      jUnitReporterDeps.push(testSuiteFilePath);
-    }
-  }
-
-  let reporters = config.reporters
-    ? config.reporters
-        .map(reporter => (typeof reporter === 'string' ? reporter : reporter[0]))
-        .filter(reporter => !['default', 'github-actions', 'summary'].includes(reporter))
-    : [];
-
-  reporters = [...reporters, ...jUnitReporterDeps];
-
+  const reporters = getReportersDependencies(config, options);
   const watchPlugins =
     config.watchPlugins?.map(watchPlugin => (typeof watchPlugin === 'string' ? watchPlugin : watchPlugin[0])) ?? [];
   const transform = config.transform

--- a/packages/knip/test/plugins/jest.test.ts
+++ b/packages/knip/test/plugins/jest.test.ts
@@ -31,7 +31,7 @@ test('Find dependencies with the Jest plugin', async () => {
     devDependencies: 1,
     unlisted: 3,
     unresolved: 9,
-    processed: 6,
-    total: 6,
+    processed: 8,
+    total: 8,
   });
 });

--- a/packages/knip/test/plugins/jest2.test.ts
+++ b/packages/knip/test/plugins/jest2.test.ts
@@ -28,7 +28,7 @@ test('Find dependencies with the Jest plugin', async () => {
     devDependencies: 1,
     unlisted: 0,
     unresolved: 0,
-    processed: 5,
-    total: 5,
+    processed: 7,
+    total: 7,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

## This PR

Adds support for resolving dependencies from `jest-junit` reporter configuration.
See https://github.com/jest-community/jest-junit?tab=readme-ov-file#configuration

Files declared through the combination of
```
testCasePropertiesFile,
testCasePropertiesDirectory,
testSuitePropertiesFile,
testSuitePropertiesDirectory,
```

from `jest-jsunit` configuration are now correctly reported as used.

## Things to consider

- The code is a bit involved. We might want to consider moving resolving reporters like this to it's own file or directory separate from the plugin?
- I'm pretty sure according to the docs that both files are always required when `jest-jsunit` is used. They both have default values in the configuration. But could be good to just double check so we don't report unused files incorrectly if these files don't exist and should not exist. I'm not sure if jest-jsunit can work with the absence of properties file or a suit properties file or both.