### PR TITLE
Update compilers.md.

### DIFF
--- a/packages/docs/src/content/docs/features/compilers.md
+++ b/packages/docs/src/content/docs/features/compilers.md
@@ -115,6 +115,10 @@ function getStyleBlockContent(block: SFCStyleBlock | null): string[] {
   return [block.content];
 }
 
+function getStyleImports(content: string): string {
+  return [...content.matchAll(/(?<=@)import[^;]+/g)].join('\n');
+}
+
 const config = {
   compilers: {
     vue: (text: string, filename: string) => {


### PR DESCRIPTION
Adds the missing `getStyleImports` function to the Vue example.

See [#733](https://github.com/webpro-nl/knip/issues/733).