### PR TITLE
Add Astro middleware and actions

### DIFF
--- a/packages/knip/src/plugins/astro/index.ts
+++ b/packages/knip/src/plugins/astro/index.ts
@@ -12,7 +12,12 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 
 const entry = ['astro.config.{js,cjs,mjs,ts}', 'src/content/config.ts'];
 
-const production = ['src/pages/**/*.{astro,mdx,js,ts}', 'src/content/**/*.mdx'];
+const production = [
+  'src/pages/**/*.{astro,mdx,js,ts}',
+  'src/content/**/*.mdx',
+  'src/middleware.{js,ts}',
+  'src/actions/index.{js,ts}',
+];
 
 const resolve: Resolve = options => {
   const { manifest, isProduction } = options;


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

This PR adds new entry files to the Astro plugin, supporting:

- https://docs.astro.build/en/guides/actions/
- https://docs.astro.build/en/guides/middleware/
