### PR TITLE
docs: update entry/project defaults with production mode

### DIFF
--- a/packages/docs/src/content/docs/explanations/entry-files.md
+++ b/packages/docs/src/content/docs/explanations/entry-files.md
@@ -25,10 +25,10 @@ entry files. Here's the default configuration in full:
 ```json
 {
   "entry": [
-    "{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
-    "src/{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"
+    "{index,cli,main}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+    "src/{index,cli,main}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"
   ],
-  "project": ["**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"]
+  "project": ["**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}!"]
 }
 ```
 

--- a/packages/docs/src/content/docs/guides/configuring-project-files.md
+++ b/packages/docs/src/content/docs/guides/configuring-project-files.md
@@ -217,10 +217,10 @@ To reiterate, the default `entry` and `project` files for each workspace:
 ```json
 {
   "entry": [
-    "{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
-    "src/{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"
+    "{index,cli,main}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+    "src/{index,cli,main}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"
   ],
-  "project": ["**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"]
+  "project": ["**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}!"]
 }
 ```
 


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Defaults that appear in docs are not exactly the [defaults used](https://github.com/webpro-nl/knip/blob/5.38.2/packages/knip/src/ConfigurationChief.ts#L34-L40).

`projects` defaults in docs do not include the final `!` . Hence readers could understand all files are not production files by default.

Updates defaults found in docs to reflect the actual defaults used by the implementation.

> Also sorts `index,cli,main` to match implementation to be nitty :P

Btw, didn't find any place in docs saying that all project files are considered production files by default. Should that be added somewhere? Or it's this new defaults update enough maybe?

