### PR TITLE
fix: add `scp` to `IGNORED_GLOBAL_BINARIES`

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -99,6 +99,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'pwd',
   'rm',
   'rmdir',
+  'scp',
   'seq',
   'set',
   'sha1sum',


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Closes #862