### PR TITLE
Track Angular's `server` builder option

### DIFF
--- a/packages/knip/src/plugins/angular/index.ts
+++ b/packages/knip/src/plugins/angular/index.ts
@@ -44,6 +44,9 @@ const resolveConfig: ResolveConfig<AngularCLIWorkspaceConfiguration> = async (co
         if ('tsConfig' in opts && typeof opts.tsConfig === 'string') {
           inputs.add(toConfig('typescript', opts.tsConfig, configFilePath));
         }
+        if ('server' in opts && opts.server && typeof opts.server === 'string') {
+          inputs.add(toProductionEntry(join(cwd, opts.server)));
+        }
       }
     }
   }

--- a/packages/knip/test/plugins/angular2.test.ts
+++ b/packages/knip/test/plugins/angular2.test.ts
@@ -15,7 +15,7 @@ test('Find dependencies with the Angular plugin (2)', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 2,
-    total: 2,
+    processed: 3,
+    total: 3,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
Tracks Angular's server side rendering server entrypoint file as a production file. 

Defined in Angular CLI's `@angular-devkit/build-angular:application` builder [`server` option](https://github.com/angular/angular-cli/blob/19.0.2/packages/angular/build/src/builders/application/schema.json#L19)

> [!NOTE]
> This is the first of a series of PRs to improve the Angular plugin so that it works out-of-the-box for freshly baked Angular apps.
> 
> Checkout the analysis and following steps in https://github.com/davidlj95/a19-knip
>
> I'll update types in the next PR, as seems many types have changed with recent updates.
