### PR TITLE
Track Angular environment files as entry points

### DIFF
--- a/packages/knip/fixtures/plugins/angular2/angular.json
+++ b/packages/knip/fixtures/plugins/angular2/angular.json
@@ -60,7 +60,13 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.development.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/packages/knip/fixtures/plugins/angular2/src/browser.ts
+++ b/packages/knip/fixtures/plugins/angular2/src/browser.ts
@@ -1,0 +1,1 @@
+import {environment} from "./environments/environment";

--- a/packages/knip/fixtures/plugins/angular2/src/environments/environment.development.ts
+++ b/packages/knip/fixtures/plugins/angular2/src/environments/environment.development.ts
@@ -1,0 +1,1 @@
+export const environment = {}

--- a/packages/knip/fixtures/plugins/angular2/src/environments/environment.ts
+++ b/packages/knip/fixtures/plugins/angular2/src/environments/environment.ts
@@ -1,0 +1,1 @@
+export const environment = {}

--- a/packages/knip/src/plugins/angular/index.ts
+++ b/packages/knip/src/plugins/angular/index.ts
@@ -1,8 +1,8 @@
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
-import { type Input, toConfig, toDependency, toProductionEntry } from '../../util/input.js';
+import { type Input, toConfig, toDependency, toEntry, toProductionEntry } from '../../util/input.js';
 import { join } from '../../util/path.js';
 import { hasDependency } from '../../util/plugin.js';
-import type { AngularCLIWorkspaceConfiguration } from './types.js';
+import type { AngularCLIWorkspaceConfiguration, WebpackBrowserSchemaForBuildFacade } from './types.js';
 
 // https://angular.io/guide/workspace-config
 
@@ -26,7 +26,7 @@ const resolveConfig: ResolveConfig<AngularCLIWorkspaceConfiguration> = async (co
   for (const project of Object.values(config.projects)) {
     if (!project.architect) return [];
     for (const target of Object.values(project.architect)) {
-      const { options: opts } = target;
+      const { options: opts, configurations: configs } = target;
       const [packageName] = typeof target.builder === 'string' ? target.builder.split(':') : [];
       if (typeof packageName === 'string') inputs.add(toDependency(packageName));
       if (opts) {
@@ -47,12 +47,35 @@ const resolveConfig: ResolveConfig<AngularCLIWorkspaceConfiguration> = async (co
         if ('server' in opts && opts.server && typeof opts.server === 'string') {
           inputs.add(toProductionEntry(join(cwd, opts.server)));
         }
+        if ('fileReplacements' in opts && opts.fileReplacements && Array.isArray(opts.fileReplacements)) {
+          for (const fileReplacedBy of filesReplacedBy(opts.fileReplacements)) {
+            inputs.add(toEntry(fileReplacedBy));
+          }
+        }
+      }
+      if (configs) {
+        for (const [configName, config] of Object.entries(configs)) {
+          const isProductionConfig = configName === 'production';
+          if ('fileReplacements' in config && config.fileReplacements && Array.isArray(config.fileReplacements)) {
+            for (const fileReplacedBy of filesReplacedBy(config.fileReplacements)) {
+              inputs.add(isProductionConfig ? toProductionEntry(fileReplacedBy) : toEntry(fileReplacedBy));
+            }
+          }
+        }
       }
     }
   }
 
   return Array.from(inputs);
 };
+
+const filesReplacedBy = (
+  //👇 Using Webpack-based browser schema to support old `replaceWith` file replacements
+  fileReplacements: Exclude<WebpackBrowserSchemaForBuildFacade['fileReplacements'], undefined>
+): readonly string[] =>
+  fileReplacements.map(fileReplacement =>
+    'with' in fileReplacement ? fileReplacement.with : fileReplacement.replaceWith
+  );
 
 export default {
   title,

--- a/packages/knip/src/plugins/angular/types.ts
+++ b/packages/knip/src/plugins/angular/types.ts
@@ -1629,7 +1629,7 @@ interface AppShellTarget {
 /**
  * Browser target options
  */
-interface WebpackBrowserSchemaForBuildFacade {
+export interface WebpackBrowserSchemaForBuildFacade {
   /**
    * List of static application assets.
    */

--- a/packages/knip/test/plugins/angular2.test.ts
+++ b/packages/knip/test/plugins/angular2.test.ts
@@ -15,7 +15,7 @@ test('Find dependencies with the Angular plugin (2)', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 3,
-    total: 3,
+    processed: 5,
+    total: 5,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
Tracks Angular [environment specific files](https://angular.dev/tools/cli/environments#using-environment-specific-variables-in-your-app) as entry points.

Takes into account:
 - If file replacements are part of a production configuration or not to add them as production entries or not.
 - Previous syntax for Webpack-based browser application builder (`src/replaceWith` instead of `replace/with`).
 - File replacements out of `configurations`. As they're technically correct and work. However, it's not a common use case. The purpose of environment files is to apply different ones depending on the configuration, not apply them for all cases (hence part of the builder options). Also those aren't used if a configuration specifies some `fileReplacements`.
