### PR TITLE
Add new content configuration entry for Astro

### DIFF
--- a/packages/knip/src/plugins/astro/index.ts
+++ b/packages/knip/src/plugins/astro/index.ts
@@ -10,7 +10,7 @@ const enablers = ['astro'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const entry = ['astro.config.{js,cjs,mjs,ts}', 'src/content/config.ts'];
+const entry = ['astro.config.{js,cjs,mjs,ts}', 'src/content/config.ts', 'src/content.config.ts'];
 
 const production = [
   'src/pages/**/*.{astro,mdx,js,ts}',


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Hi there 👋 

Astro v5 changed the location of the content collection config from `src/content/config.ts` to `src/content.config.ts`, although it still support the old location.

From the [official migration page](https://docs.astro.build/en/guides/upgrade-to/v5/#legacy-v20-content-collections-api):

![image](https://github.com/user-attachments/assets/93fe81fa-98fe-45fb-a350-46ba9c612dae)

