### PR TITLE
Add support for (experimental) TypeScript ESLint config

### DIFF
--- a/packages/knip/src/plugins/eslint/index.ts
+++ b/packages/knip/src/plugins/eslint/index.ts
@@ -20,7 +20,7 @@ const isEnabled: IsPluginEnabled = ({ dependencies, manifest, config }) =>
 
 const packageJsonPath = 'eslintConfig';
 
-const entry = ['eslint.config.{js,cjs,mjs}'];
+const entry = ['eslint.config.{js,cjs,cts,mjs,mts,ts}'];
 
 const config = ['.eslintrc', '.eslintrc.{js,json,cjs}', '.eslintrc.{yml,yaml}', 'package.json'];
 


### PR DESCRIPTION
ESLint recently added experimental support for TypeScript config files. [ESLint Docs : TypeScript Configuration Files ](https://eslint.org/docs/latest/use/configure/configuration-files#typescript-configuration-files).

This adds support for those new file formats.

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
