### PR TITLE
Always run config resolver

### DIFF
--- a/packages/knip/src/WorkspaceWorker.ts
+++ b/packages/knip/src/WorkspaceWorker.ts
@@ -289,7 +289,6 @@ export class WorkspaceWorker {
       const plugin = Plugins[pluginName];
       const hasResolveEntryPaths = typeof plugin.resolveEntryPaths === 'function';
       const hasResolveConfig = typeof plugin.resolveConfig === 'function';
-      const shouldRunConfigResolver = hasResolveConfig && (!isProduction || (isProduction && 'production' in plugin));
       const hasResolve = typeof plugin.resolve === 'function';
       const config = this.getConfigForPlugin(pluginName);
 
@@ -319,7 +318,7 @@ export class WorkspaceWorker {
           configFileDir: dirname(configFilePath),
           configFileName: basename(configFilePath),
         };
-        if (hasResolveEntryPaths || shouldRunConfigResolver) {
+        if (hasResolveEntryPaths || hasResolveConfig) {
           const isManifest = basename(configFilePath) === 'package.json';
           const fd = isManifest ? undefined : this.cache.getFileDescriptor(configFilePath);
 
@@ -336,7 +335,7 @@ export class WorkspaceWorker {
                 for (const entryPath of entryPaths) configEntryPaths.push(entryPath);
                 data.resolveEntryPaths = entryPaths;
               }
-              if (shouldRunConfigResolver) {
+              if (hasResolveConfig) {
                 const inputs = (await plugin.resolveConfig?.(config, opts)) ?? [];
                 for (const input of inputs) {
                   if (isConfigPattern(input))


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
After [upgrading Knip to latest version 5.41.1 from 5.38.2 in an Angular project](https://github.com/davidlj95/website/pull/921) found out that a file that was previously correctly tracked as production entry was suddenly appearing as unused file (specifically, `src/main.ts`) when using knip in production mode. I've been working with the Angular plugin recently, so first thought was I may have messed up something. That file is added as production entry because appears in `browser` option of the `build` target in `angular.json`. 

However, that piece of code hasn't changed and the file should be added as production entry. After manually bisecting which version introduced the bug, seems it appears in [5.39.2](https://github.com/webpro-nl/knip/releases/tag/5.39.2). In there, there's a [plugin housekeeping commit](https://github.com/webpro-nl/knip/commit/770685bcdda2125db9f324a9dccec4887a3580cb) that removes the empty `production` array from the plugin. However, [due to a check when running plugins](https://github.com/webpro-nl/knip/blob/5.41.1/packages/knip/src/WorkspaceWorker.ts#L292), the `resolveConfig` function won't be executed when running in production mode if no `production` key is present in the plugin. Hence when removing that empty `production` array from the Angular plugin, the `resolveConfig` function wasn't ran and the production entry `src/main.ts` wasn't added.

Given the issue, I could have brought back the `production` empty array to the Angular plugin. However, I think that it's better to always run the `resolveConfig` function if is defined. Both in production and non-production modes. Because several plugins actually use the `toProductionEntry` function as part of `resolveConfig`. So this issue could happen in the case that `production` key is removed and all production entries are added as part of `resolveConfig`. Let me know if there's something else I may be missing though!
