### PR TITLE
Track Angular scripts build option

### DIFF
--- a/packages/knip/fixtures/plugins/angular/angular.json
+++ b/packages/knip/fixtures/plugins/angular/angular.json
@@ -32,7 +32,9 @@
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [
+              "src/script.js"
+            ]
           },
           "configurations": {
             "production": {

--- a/packages/knip/src/plugins/angular/index.ts
+++ b/packages/knip/src/plugins/angular/index.ts
@@ -50,6 +50,12 @@ const resolveConfig: ResolveConfig<AngularCLIWorkspaceConfiguration> = async (co
             inputs.add(toEntry(fileReplacedBy));
           }
         }
+        if ('scripts' in opts && opts.scripts && Array.isArray(opts.scripts)) {
+          for (const scriptStringOrObject of opts.scripts as AngularScriptsBuildOption) {
+            const script = typeof scriptStringOrObject === 'string' ? scriptStringOrObject : scriptStringOrObject.input;
+            inputs.add(toProductionEntry(script));
+          }
+        }
       }
       if (configs) {
         for (const [configName, config] of Object.entries(configs)) {
@@ -66,6 +72,8 @@ const resolveConfig: ResolveConfig<AngularCLIWorkspaceConfiguration> = async (co
 
   return Array.from(inputs);
 };
+
+type AngularScriptsBuildOption = Exclude<WebpackBrowserSchemaForBuildFacade['scripts'], undefined>;
 
 const filesReplacedBy = (
   //👇 Using Webpack-based browser schema to support old `replaceWith` file replacements

--- a/packages/knip/test/plugins/angular.test.ts
+++ b/packages/knip/test/plugins/angular.test.ts
@@ -20,7 +20,7 @@ test('Find dependencies with the Angular plugin', async () => {
     ...baseCounters,
     unlisted: 1,
     unresolved: 1,
-    processed: 1,
-    total: 1,
+    processed: 2,
+    total: 2,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
Several Angular CLI builders allow to specify a [`scripts` option](https://github.com/angular/angular-cli/blob/19.0.6/packages/angular/build/src/builders/application/schema.json#L78) in its configuration. Those files will be included in the build and optionally added to `index.html`. Track them as production entries\*.

> \* Though they may not be production entries! They'll probably be production entries if they are part of the `build` target. 
> Same happens for other configuration options. Like `main`, which can be specified in many `build` targets but also on non-production `test` target. 
> Options `browser`, `ssr.entry` or `server` could also be specified in other targets other than `build` and they won't probably be production entries. Opening another PR for that


