### PR TITLE
Add support for nx command shorthand to nx plugin

### DIFF
--- a/packages/knip/fixtures/plugins/nx/libs/b/project.json
+++ b/packages/knip/fixtures/plugins/nx/libs/b/project.json
@@ -25,6 +25,9 @@
     },
     "tsc": {
       "executor": "./tools/executors/tsc:tsc"
+    },
+    "lint": {
+      "command": "biome lint ."
     }
   }
 }

--- a/packages/knip/src/plugins/nx/index.ts
+++ b/packages/knip/src/plugins/nx/index.ts
@@ -55,8 +55,13 @@ const resolveConfig: ResolveConfig<NxProjectConfiguration | NxConfigRoot> = asyn
     .map(executor => executor?.split(':')[0]);
 
   const scripts = targets
-    .filter(target => target.executor === 'nx:run-commands')
-    .flatMap(target => target.options?.commands ?? (target.options?.command ? [target.options.command] : []));
+    .filter(target => target.executor === 'nx:run-commands' || target.command)
+    .flatMap(target => {
+      if (target.command) return [target.command];
+      if (target.options?.command) return [target.options.command];
+      if (target.options?.commands) return target.options.commands;
+      return [];
+    });
 
   const inputs = options.getInputsFromScripts(scripts);
 

--- a/packages/knip/src/plugins/nx/types.ts
+++ b/packages/knip/src/plugins/nx/types.ts
@@ -1,6 +1,7 @@
 export interface NxProjectConfiguration {
   targets?: {
     [targetName: string]: {
+      command?: string;
       executor?: string;
       options?: {
         command?: string;

--- a/packages/knip/test/plugins/nx.test.ts
+++ b/packages/knip/test/plugins/nx.test.ts
@@ -26,10 +26,11 @@ test('Find dependencies with the Nx plugin', async () => {
   assert(issues.binaries['package.json']['nx']);
   assert(issues.binaries['libs/b/project.json']['webpack']);
   assert(issues.binaries['libs/b/project.json']['compodoc']);
+  assert(issues.binaries['libs/b/project.json']['biome']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    binaries: 4,
+    binaries: 5,
     devDependencies: 6,
     unlisted: 3,
     processed: 0,


### PR DESCRIPTION
Nx supports a shorthand for defining commands, without the need to specify an executor. It's documented under Examples > Shorthand here: https://nx.dev/nx-api/nx/executors/run-commands