### PR TITLE
Delete principal from array after usage for GC

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -24,6 +24,8 @@ gh repo fork webpro-nl/knip --clone
 cd knip
 bun install
 cd packages/knip
+npm run build
+npm run test
 ```
 
 Depending on the goals and the way you like to work, below are a few things that

--- a/packages/knip/src/index.ts
+++ b/packages/knip/src/index.ts
@@ -283,7 +283,7 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
     worker.onDispose();
   }
 
-  let principals: Array<ProjectPrincipal | undefined> | undefined = factory.getPrincipals();
+  const principals: Array<ProjectPrincipal | undefined> = factory.getPrincipals();
   debugLog('*', `Created ${principals.length} programs for ${workspaces.length} workspaces`);
 
   const graph: DependencyGraph = new Map();
@@ -398,7 +398,9 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
       if (principal) factory.deletePrincipal(principal);
     }
   }
-  principals = undefined;
+
+  // Release the memory / empty the array that may be be filled with undefined's now.
+  principals.length = 0;
 
   const ignoreExportsUsedInFile = chief.config.ignoreExportsUsedInFile;
   const isExportedItemReferenced = (exportedItem: Export | ExportMember) =>


### PR DESCRIPTION
On a large number of files, knip is crashing with out-of-memory. This is caused by the fact that all of the source file text and programs are being held for the entirety of the processing.

There is an explicit factory.deletePrincipal being done after every principal is processed, in the `!isIsolateWorkspaces && isSkipLibs && !isWatch` case, but the `principals` array is still holding onto the principal, so the memory is not released.

As we iterate through the principals, I clear the entry if it is deleted. I chose to set the principals entry to `undefined`, rather than manipulating the list, for code simplicity.

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
