### PR TITLE
Add support for Babel plugins used in Vite/React config

### DIFF
--- a/packages/knip/fixtures/plugins/vite/package.json
+++ b/packages/knip/fixtures/plugins/vite/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "*",
+    "@emotion/babel-plugin": "*",
     "vite": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/vite/vite.config.ts
+++ b/packages/knip/fixtures/plugins/vite/vite.config.ts
@@ -2,5 +2,11 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      babel: {
+        plugins: ['@emotion/babel-plugin'],
+      },
+    }),
+  ],
 });

--- a/packages/knip/src/plugins/vite/index.ts
+++ b/packages/knip/src/plugins/vite/index.ts
@@ -1,6 +1,12 @@
-import type { IsPluginEnabled, Plugin } from '../../types/config.js';
+import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
+import { type Input, toEntry } from '../../util/input.js';
+import { join } from '../../util/path.js';
 import { hasDependency } from '../../util/plugin.js';
-import { resolveConfig, resolveEntryPaths } from '../vitest/index.js';
+import { getDependenciesFromConfig } from '../babel/index.js';
+import type { BabelConfigObj } from '../babel/types.js';
+import { findConfigDependencies, getConfigs, resolveEntryPaths } from '../vitest/index.js';
+import type { ViteConfig, ViteConfigOrFn, VitestWorkspaceConfig } from '../vitest/types.js';
+import type { BabelPlugin } from './types.js';
 
 // https://vitejs.dev/config/
 
@@ -11,6 +17,52 @@ const enablers = ['vite', 'vitest'];
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
 export const config = ['vite.config.{js,mjs,ts,cjs,mts,cts}'];
+
+const hasReactBabelPlugins = (config: ViteConfig) => {
+  if (!config?.plugins?.length) {
+    return false;
+  }
+
+  for (const plugin of config.plugins) {
+    if (typeof plugin === 'function') {
+      const pluginConfig = plugin() as BabelPlugin;
+      if (pluginConfig?.babel?.plugins) {
+        return true;
+      }
+    } else if (Array.isArray(plugin)) {
+      const [pluginObj] = plugin as [BabelPlugin];
+      if (pluginObj?.babel?.plugins) {
+        return true;
+      }
+    } else if (typeof plugin === 'object' && plugin !== null) {
+      const pluginObj = plugin as BabelPlugin;
+      if (pluginObj?.babel?.plugins) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const resolveConfig: ResolveConfig<ViteConfigOrFn | VitestWorkspaceConfig> = async (localConfig, options) => {
+  const inputs = new Set<Input>();
+  const configs = await getConfigs(localConfig);
+  for (const cfg of configs) {
+    for (const dependency of findConfigDependencies(cfg, options)) inputs.add(dependency);
+    if (hasReactBabelPlugins(cfg)) {
+      const babelPlugins = getDependenciesFromConfig((cfg as { plugins: BabelConfigObj }).plugins);
+      for (const plugin of babelPlugins) inputs.add(plugin);
+    }
+    const entry = cfg.build?.lib?.entry ?? [];
+    const dir = join(options.configFileDir, cfg.test?.root ?? '.');
+    const deps = (typeof entry === 'string' ? [entry] : Object.values(entry))
+      .map(specifier => join(dir, specifier))
+      .map(toEntry);
+    for (const dependency of deps) inputs.add(dependency);
+  }
+  return Array.from(inputs);
+};
 
 export default {
   title,

--- a/packages/knip/src/plugins/vite/types.ts
+++ b/packages/knip/src/plugins/vite/types.ts
@@ -1,0 +1,5 @@
+export interface BabelPlugin {
+  babel?: {
+    plugins: string[];
+  };
+}

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -27,7 +27,7 @@ const hasScriptWithCoverage = (scripts: PackageJson['scripts']) =>
       })
     : false;
 
-const findConfigDependencies = (localConfig: ViteConfig, options: PluginOptions) => {
+export const findConfigDependencies = (localConfig: ViteConfig, options: PluginOptions) => {
   const { manifest, configFileDir } = options;
   const testConfig = localConfig.test;
 
@@ -48,7 +48,7 @@ const findConfigDependencies = (localConfig: ViteConfig, options: PluginOptions)
   return [...[...environments, ...reporters, ...coverage].map(toDependency), ...setupFiles, ...globalSetup];
 };
 
-const getConfigs = async (localConfig: ViteConfigOrFn | VitestWorkspaceConfig) => {
+export const getConfigs = async (localConfig: ViteConfigOrFn | VitestWorkspaceConfig) => {
   const configs: ViteConfig[] = [];
   for (const config of [localConfig].flat()) {
     if (config && typeof config !== 'string') {

--- a/packages/knip/test/plugins/vite.test.ts
+++ b/packages/knip/test/plugins/vite.test.ts
@@ -15,6 +15,7 @@ test('Find dependencies with the Vite plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
+    devDependencies: 1,
     processed: 2,
     total: 2,
   });


### PR DESCRIPTION
Fixes #903

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
