### PR TITLE
Add pm2-runtime to IGNORED_GLOBAL_BINARIES constant

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -92,6 +92,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'nproc',
   'npx',
   'paste',
+  'pm2-runtime',
   'pnpm',
   'pnpx',
   'pr',


### PR DESCRIPTION
I'm proposing we add `pm2-runtime` to the list of `IGNORED_GLOBAL_BINARIES` based on [this documentation](https://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/) which indicates that `pm2` should be installed globally inside of Docker containers and invoked using the `pm2-runtime` binary.

In my specific use case we have a script in our `package.json` file called `workers:prod` which uses this binary, e.g. `pm2-runtime start pm2.config.js`, which will fail the `knip --include binaries` check since its not added to our package and is only necessary in our production environment.

I'm curious if others have a strong feeling for or against including this entry.
