### PR TITLE
Do not crash when running npm init @knip/config on a repository not using git

### DIFF
--- a/packages/create-config/index.js
+++ b/packages/create-config/index.js
@@ -13,7 +13,7 @@ const getPackageManager = () => {
   // get the root of the repository
   let repositoryRoot = "";
   try {
-    repositoryRoot = execSync('git rev-parse --show-toplevel').toString().trim();
+    repositoryRoot = execSync('git rev-parse --show-toplevel', { stdio: [null, null, 'ignore'] }).toString().trim();
   } catch {}
 
   if (fileExists(path.join(repositoryRoot, 'bun.lockb'))) return 'bun';

--- a/packages/create-config/index.js
+++ b/packages/create-config/index.js
@@ -11,9 +11,11 @@ const fileExists = filePath => {
 
 const getPackageManager = () => {
   // get the root of the repository
-  let repositoryRoot = "";
+  let repositoryRoot = '';
   try {
-    repositoryRoot = execSync('git rev-parse --show-toplevel', { stdio: [null, null, 'ignore'] }).toString().trim();
+    repositoryRoot = execSync('git rev-parse --show-toplevel', { stdio: [null, null, 'ignore'] })
+      .toString()
+      .trim();
   } catch {}
 
   if (fileExists(path.join(repositoryRoot, 'bun.lockb'))) return 'bun';

--- a/packages/create-config/index.js
+++ b/packages/create-config/index.js
@@ -11,7 +11,10 @@ const fileExists = filePath => {
 
 const getPackageManager = () => {
   // get the root of the repository
-  const repositoryRoot = execSync('git rev-parse --show-toplevel').toString().trim();
+  let repositoryRoot = "";
+  try {
+    repositoryRoot = execSync('git rev-parse --show-toplevel').toString().trim();
+  } catch {}
 
   if (fileExists(path.join(repositoryRoot, 'bun.lockb'))) return 'bun';
   if (fileExists(path.join(repositoryRoot, 'yarn.lock'))) return 'yarn';


### PR DESCRIPTION
Pull request #738 introduced a call to `git rev-parse` which crashes when trying to run `npm init @knip/config` on a repository not using git. This pull request swallows errors from `git rev-parse` and reverts to the previous behavior in case calling `git rev-parse` throws an exception. The `stdio` option is to hide stderr, otherwise we get a scary error message (`fatal: not a git repository (or any of the parent directories): .git`).

I’ve tried it on an SVN repository and it seems to work as expected. Closes #752.