### PR TITLE
fix: ensure augmentWorkspace honors tsConfig rootDir

### DIFF
--- a/packages/knip/src/util/to-source-path.ts
+++ b/packages/knip/src/util/to-source-path.ts
@@ -13,7 +13,7 @@ const matchExt = /(\.d)?\.(m|c)?(j|t)s$/;
 
 export const augmentWorkspace = (workspace: Workspace, dir: string, compilerOptions: CompilerOptions) => {
   const srcDir = join(dir, 'src');
-  workspace.srcDir = (compilerOptions.rootDir ?? isDirectory(srcDir)) ? srcDir : dir;
+  workspace.srcDir = compilerOptions.rootDir ?? (isDirectory(srcDir) ? srcDir : dir);
   workspace.outDir = compilerOptions.outDir || workspace.srcDir;
 };
 


### PR DESCRIPTION
I _think_ this fixes logic that has a bug but due to incorrect parenthesis in a ternary with a nullish coalescing operator. When a `rootDir` is specified in tsconfig.json that is something other than the value `"src"`, the `rootDir` config is not honored. In my case, I _do_ have a `src` dir, but it's unrelated to my TypeScript source which is located elsewhere (where my `rootDir` poins to). Knip ends up forcing the workspace `srcDir` value to `"src"` due to this bug combined with the presence of a `src` directory.

I attempted to add a test, but I'm not so familiar with the codebase and could not seem to exercise the right code paths 😞, but can give it another try if needed.