### PR TITLE
Support command arrays in moonrepo plugin

### DIFF
--- a/packages/knip/src/plugins/moonrepo/index.ts
+++ b/packages/knip/src/plugins/moonrepo/index.ts
@@ -19,7 +19,6 @@ const resolveConfig: ResolveConfig<MoonConfiguration> = async (config, options) 
   const inputs = tasks
     .map((task) => task.command)
     .filter((command) => command)
-    // Depending on the usage and version of moon, the command can be an array or a string
     .map((command) => {
       if (Array.isArray(command)) {
         return command.map((c) => c.replace("$workspaceRoot", options.rootCwd));

--- a/packages/knip/src/plugins/moonrepo/index.ts
+++ b/packages/knip/src/plugins/moonrepo/index.ts
@@ -17,11 +17,22 @@ const config = ['moon.yml', '.moon/tasks.yml', '.moon/tasks/*.yml'];
 const resolveConfig: ResolveConfig<MoonConfiguration> = async (config, options) => {
   const tasks = config.tasks ? Object.values(config.tasks) : [];
   const inputs = tasks
-    .map(task => task.command)
-    .filter(command => command)
-    .map(command => command.replace('$workspaceRoot', options.rootCwd))
-    .map(command => command.replace('$projectRoot', options.cwd))
-    .flatMap(command => options.getInputsFromScripts(command));
+    .map((task) => task.command)
+    .filter((command) => command)
+    // Depending on the usage and version of moon, the command can be an array or a string
+    .map((command) => {
+      if (Array.isArray(command)) {
+        return command.map((c) => c.replace("$workspaceRoot", options.rootCwd));
+      }
+      return command.replace("$workspaceRoot", options.rootCwd);
+    })
+    .map((command) => {
+      if (Array.isArray(command)) {
+        return command.map((c) => c.replace("$projectRoot", options.cwd));
+      }
+      return command.replace("$projectRoot", options.cwd);
+    })
+    .flatMap((command) => options.getInputsFromScripts(command));
   return [...inputs];
 };
 

--- a/packages/knip/src/plugins/moonrepo/types.ts
+++ b/packages/knip/src/plugins/moonrepo/types.ts
@@ -1,7 +1,7 @@
 export interface MoonConfiguration {
   tasks?: {
     [taskName: string]: {
-      command: string;
+      command: string | string[];
     };
   };
 }


### PR DESCRIPTION
I required this change in order for knip to work with my `moonrepo` monorepo on the latest version. I believe it's some combination of how you structure your moon.yml file and the version of moon that you use. This should support both old/new.

Before this change I'd get the following error:

```bash
❯ pnpm run knip

> monorepo@ knip /Users/slexaxton/monorepo
> knip

Analyzing workspace ....
file:///Users/slexaxton/monorepo/node_modules/.pnpm/knip@5.44.0_@types+node@22.13.1_typescript@5.7.3/node_modules/knip/dist/plugins/moonrepo/index.js:12
        .map(command => command.replace('$workspaceRoot', options.rootCwd))
                                ^

TypeError: command.replace is not a function
    at file:///Users/slexaxton/monorepo/node_modules/.pnpm/knip@5.44.0_@types+node@22.13.1_typescript@5.7.3/node_modules/knip/dist/plugins/moonrepo/index.js:12:33
    at Array.map (<anonymous>)
    at Object.resolveConfig (file:///Users/slexaxton/monorepo/node_modules/.pnpm/knip@5.44.0_@types+node@22.13.1_typescript@5.7.3/node_modules/knip/dist/plugins/moonrepo/index.js:12:10)
    at runPlugin (file:///Users/slexaxton/monorepo/node_modules/.pnpm/knip@5.44.0_@types+node@22.13.1_typescript@5.7.3/node_modules/knip/dist/WorkspaceWorker.js:253:77)
    at async WorkspaceWorker.findDependenciesByPlugins (file:///Users/slexaxton/monorepo/node_modules/.pnpm/knip@5.44.0_@types+node@22.13.1_typescript@5.7.3/node_modules/knip/dist/WorkspaceWorker.js:282:13)
    at async main (file:///Users/slexaxton/monorepo/node_modules/.pnpm/knip@5.44.0_@types+node@22.13.1_typescript@5.7.3/node_modules/knip/dist/index.js:119:41)
    at async run (file:///Users/slexaxton/monorepo/node_modules/.pnpm/knip@5.44.0_@types+node@22.13.1_typescript@5.7.3/node_modules/knip/dist/cli.js:26:83)
    at async file:///Users/slexaxton/monorepo/node_modules/.pnpm/knip@5.44.0_@types+node@22.13.1_typescript@5.7.3/node_modules/knip/dist/cli.js:104:1

Node.js v22.14.0
 ELIFECYCLE  Command failed with exit code 1.
```