### PR TITLE
fix(create-config): updated script for latest Yarn version

### DIFF
--- a/packages/create-config/index.js
+++ b/packages/create-config/index.js
@@ -28,12 +28,6 @@ const getWorkspaceFlag = pm => {
   if (pm === 'pnpm') {
     return fileExists('pnpm-workspace.yaml') ? '-w' : undefined;
   }
-
-  if (pm === 'yarn') {
-    const packageJsonPath = path.join(process.cwd(), 'package.json');
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-    return packageJson.workspaces && packageJson.workspaces.length > 0 ? '-W' : undefined;
-  }
 };
 
 const main = () => {

--- a/packages/create-config/index.js
+++ b/packages/create-config/index.js
@@ -46,10 +46,10 @@ const main = () => {
 
   const cmd = [pm, 'add', getWorkspaceFlag(pm), '-D', 'knip', 'typescript', '@types/node'].filter(Boolean).join(' ');
 
-  execSync(cmd);
+  execSync(cmd, { stdio: "inherit" });
   console.info('✓ Install Knip');
 
-  execSync('npm pkg set scripts.knip=knip');
+  execSync('npm pkg set scripts.knip=knip', { stdio: "inherit" });
   console.info('✓ Add knip to package.json#scripts');
 
   console.info(`✓ Run "${pm} run knip" to run knip`);

--- a/packages/create-config/index.js
+++ b/packages/create-config/index.js
@@ -19,7 +19,11 @@ const getPackageManager = () => {
   } catch {}
 
   if (fileExists(path.join(repositoryRoot, 'bun.lockb'))) return 'bun';
-  if (fileExists(path.join(repositoryRoot, 'yarn.lock'))) return 'yarn';
+  if (fileExists(path.join(repositoryRoot, 'yarn.lock'))) {
+    // Read the first 128 bytes to determine yarn version
+    const yarnLock = readFileSync(path.join(repositoryRoot, 'yarn.lock'), 'utf-8');
+    return yarnLock.slice(0, 128).includes('yarn lockfile v1') ? 'yarn' : 'yarn-berry';
+  }
   if (fileExists(path.join(repositoryRoot, 'pnpm-lock.yaml'))) return 'pnpm';
   return 'npm';
 };
@@ -27,6 +31,13 @@ const getPackageManager = () => {
 const getWorkspaceFlag = pm => {
   if (pm === 'pnpm') {
     return fileExists('pnpm-workspace.yaml') ? '-w' : undefined;
+  }
+
+  // Yarn v1 only, Yarn v2+ does not need a workspace flag
+  if (pm === 'yarn') {
+    const packageJsonPath = path.join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    return packageJson.workspaces && packageJson.workspaces.length > 0 ? '-W' : undefined;
   }
 };
 
@@ -36,17 +47,19 @@ const main = () => {
     return;
   }
 
+  // Differentiate yarn v1 and v2+ but call them both with `yarn`
   const pm = getPackageManager();
+  const bin = pm === 'yarn-berry' ? 'yarn' : pm;
 
-  const cmd = [pm, 'add', getWorkspaceFlag(pm), '-D', 'knip', 'typescript', '@types/node'].filter(Boolean).join(' ');
+  const cmd = [bin, 'add', getWorkspaceFlag(pm), '-D', 'knip', 'typescript', '@types/node'].filter(Boolean).join(' ');
 
-  execSync(cmd, { stdio: "inherit" });
+  execSync(cmd, { stdio: 'inherit' });
   console.info('✓ Install Knip');
 
-  execSync('npm pkg set scripts.knip=knip', { stdio: "inherit" });
+  execSync('npm pkg set scripts.knip=knip', { stdio: 'inherit' });
   console.info('✓ Add knip to package.json#scripts');
 
-  console.info(`✓ Run "${pm} run knip" to run knip`);
+  console.info(`✓ Run "${bin} run knip" to run knip`);
 };
 
 main();


### PR DESCRIPTION
Hi! I'm trying out knip but I failed to make it work. This PR should make the error readable:

```
Error: Command failed: yarn add -W -D knip typescript @types/node
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:882:11)
    at execSync (node:child_process:954:15)
    at main (file:///private/var/folders/nq/5sbqxy457yj6_x1_28c_x2sr0000gp/T/xfs-c03b4532/dlx-61726/node_modules/@knip/create-config/index.js:49:3)
    at file:///private/var/folders/nq/5sbqxy457yj6_x1_28c_x2sr0000gp/T/xfs-c03b4532/dlx-61726/node_modules/@knip/create-config/index.js:58:1
    at ModuleJob.run (node:internal/modules/esm/module_job:273:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:600:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:98:5) {
  status: 1,
  signal: null,
  output: [
    null,
    Buffer(246) [Uint8Array] [
       27,  91,  51,  49, 109,  27,  91,  49, 109,  85, 110, 107,
      110, 111, 119, 110,  32,  83, 121, 110, 116,  97, 120,  32,
       69, 114, 114, 111, 114,  27,  91,  50,  50, 109,  27,  91,
       51,  57, 109,  58,  32,  85, 110, 115, 117, 112, 112, 111,
      114, 116, 101, 100,  32, 111, 112, 116, 105, 111, 110,  32,
      110,  97, 109, 101,  32,  40,  34,  45,  87,  34,  41,  46,
       10,  10,  36,  32, 121,  97, 114, 110,  32,  97, 100, 100,
       32,  91,  45,  45, 106, 115, 111, 110,  93,  32,  91,  45,
       70,  44,  45,  45,
      ... 146 more items
    ],
    Buffer(0) [Uint8Array] []
  ],
  pid: 61736,
  stdout: Buffer(246) [Uint8Array] [
     27,  91,  51,  49, 109,  27,  91,  49, 109,  85, 110, 107,
    110, 111, 119, 110,  32,  83, 121, 110, 116,  97, 120,  32,
     69, 114, 114, 111, 114,  27,  91,  50,  50, 109,  27,  91,
     51,  57, 109,  58,  32,  85, 110, 115, 117, 112, 112, 111,
    114, 116, 101, 100,  32, 111, 112, 116, 105, 111, 110,  32,
    110,  97, 109, 101,  32,  40,  34,  45,  87,  34,  41,  46,
     10,  10,  36,  32, 121,  97, 114, 110,  32,  97, 100, 100,
     32,  91,  45,  45, 106, 115, 111, 110,  93,  32,  91,  45,
     70,  44,  45,  45,
    ... 146 more items
  ],
  stderr: Buffer(0) [Uint8Array] []
}
```

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
