### PR TITLE
feat: add Gitlab Code Quality Reporter

### DIFF
--- a/packages/docs/src/content/docs/features/reporters.md
+++ b/packages/docs/src/content/docs/features/reporters.md
@@ -11,6 +11,7 @@ Knip provides the following built-in reporters:
 - [`disclosure`][1]
 - [`json`][2]
 - [`markdown`][3]
+- [`gitlab`][5]
 - `symbol` (default)
 
 Example usage:
@@ -156,6 +157,30 @@ my-package     package.json
 
 </details>
 
+### GitLab
+
+The built-in `gitlab` reporter is meant to be used with GitLab CI/CD. It reports
+in the GitLab Code Quality Report JSON format. Example usage:
+
+```text
+$ knip --reporter gitlab
+
+[
+  {
+    "check_name":"Unused exports",
+    "description":"isUnused",
+    "severity":"major",
+    "fingerprint":"e9789995c1fe9f7d75eed6a0c0f89e84",
+    "location": {
+      "path":"path/to/file.ts",
+      "lines": {
+        "begin":6
+      }
+    }
+  }
+]
+```
+
 ## Custom Reporters
 
 When the provided built-in reporters are not sufficient, a custom local reporter
@@ -257,3 +282,4 @@ knip --preprocessor ./preprocess.ts
 [2]: #json
 [3]: #markdown
 [4]: ../reference/issue-types.md
+[5]: #gitlab

--- a/packages/docs/src/content/docs/features/reporters.md
+++ b/packages/docs/src/content/docs/features/reporters.md
@@ -11,7 +11,7 @@ Knip provides the following built-in reporters:
 - [`disclosure`][1]
 - [`json`][2]
 - [`markdown`][3]
-- [`gitlab`][5]
+- [`codeclimate`][5]
 - `symbol` (default)
 
 Example usage:
@@ -157,26 +157,30 @@ my-package     package.json
 
 </details>
 
-### GitLab
+### CodeClimate
 
-The built-in `gitlab` reporter is meant to be used with GitLab CI/CD. It reports
-in the GitLab Code Quality Report JSON format. Example usage:
+The built-in `codeclimate` reporter generates output in the Code Climate Report JSON format. Example usage:
 
 ```text
-$ knip --reporter gitlab
+$ knip --reporter codeclimate
 
 [
   {
+    "type":"issue",
     "check_name":"Unused exports",
     "description":"isUnused",
-    "severity":"major",
-    "fingerprint":"e9789995c1fe9f7d75eed6a0c0f89e84",
+    "categories":["Bug Risk"],
     "location": {
       "path":"path/to/file.ts",
-      "lines": {
-        "begin":6
+      "positions": {
+        "begin": {
+          "line":6,
+          "column":1
+        }
       }
     }
+    "severity":"major",
+    "fingerprint":"e9789995c1fe9f7d75eed6a0c0f89e84",
   }
 ]
 ```
@@ -282,4 +286,4 @@ knip --preprocessor ./preprocess.ts
 [2]: #json
 [3]: #markdown
 [4]: ../reference/issue-types.md
-[5]: #gitlab
+[5]: #codeclimate

--- a/packages/knip/src/reporters/codeclimate.ts
+++ b/packages/knip/src/reporters/codeclimate.ts
@@ -32,18 +32,16 @@ export default async ({ report, issues }: ReporterOptions) => {
       continue;
     }
 
-    if (type === 'files') {
-      continue;
-    }
+    const fixedType = type === 'files' ? '_files' : type;
 
-    for (const issue of flatten(issues[type] as IssueRecords)) {
+    for (const issue of flatten(issues[fixedType] as IssueRecords)) {
       const { filePath } = issue;
 
-      if (type === 'duplicates' && issue.symbols) {
+      if (fixedType === 'duplicates' && issue.symbols) {
         entries.push(
           ...issue.symbols.map(symbol => ({
             type: 'issue' as const,
-            check_name: getTitle(type),
+            check_name: getTitle(fixedType),
             description: getSymbolDescription({ symbol, parentSymbol: issue.parentSymbol }),
             categories: ['Duplication'],
             location: {
@@ -62,7 +60,7 @@ export default async ({ report, issues }: ReporterOptions) => {
       } else {
         entries.push({
           type: 'issue' as const,
-          check_name: getTitle(type),
+          check_name: getTitle(fixedType),
           description: getIssueDescription(issue),
           categories: ['Bug Risk'],
           location: {

--- a/packages/knip/src/reporters/gitlab.ts
+++ b/packages/knip/src/reporters/gitlab.ts
@@ -1,0 +1,128 @@
+import { createHash } from 'node:crypto';
+import type { Entries } from 'type-fest';
+import type { Issue, IssueRecords, IssueSeverity, IssueSymbol, Report, ReporterOptions } from '../types/issues.js';
+import { getTitle } from './util.js';
+
+/**
+ * Entry for GitLab Code Quality report. See: https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format
+ */
+interface CodeQualityEntry {
+  check_name: string;
+  description: string;
+  severity: 'info' | 'minor' | 'major' | 'critical' | 'blocker';
+  fingerprint: string;
+  location: {
+    path: string;
+    lines: {
+      begin: number;
+    };
+  };
+}
+
+export default async ({ report, issues }: ReporterOptions) => {
+  const entries: CodeQualityEntry[] = [];
+  const hashes = new Set<string>();
+
+  for (const [type, isReportType] of Object.entries(report) as Entries<Report>) {
+    if (!isReportType) {
+      continue;
+    }
+
+    if (type === 'files' || type === '_files') {
+      continue;
+    }
+
+    for (const issue of flatten(issues[type] as IssueRecords)) {
+      const { filePath } = issue;
+
+      if (type === 'duplicates' && issue.symbols) {
+        entries.push(
+          ...issue.symbols.map(symbol => ({
+            check_name: getTitle(type),
+            description: getSymbolDescription({ symbol, parentSymbol: issue.parentSymbol }),
+            severity: convertSeverity(issue.severity),
+            fingerprint: createFingerprint(filePath, symbol.symbol, hashes),
+            location: {
+              path: filePath,
+              lines: {
+                begin: symbol.line ?? 0,
+              },
+            },
+          }))
+        );
+      } else {
+        entries.push({
+          check_name: getTitle(type),
+          description: getIssueDescription(issue),
+          severity: convertSeverity(issue.severity),
+          fingerprint: createFingerprint(filePath, issue.symbol, hashes),
+          location: {
+            path: filePath,
+            lines: {
+              begin: issue.line ?? 0,
+            },
+          },
+        });
+      }
+    }
+  }
+
+  const output = JSON.stringify(entries);
+
+  // See: https://github.com/nodejs/node/issues/6379
+  // @ts-expect-error _handle is private
+  process.stdout._handle?.setBlocking?.(true);
+  process.stdout.write(`${output}\n`);
+};
+
+function flatten(issues: IssueRecords): Issue[] {
+  return Object.values(issues).flatMap(Object.values);
+}
+
+function convertSeverity(severity?: IssueSeverity): CodeQualityEntry['severity'] {
+  switch (severity) {
+    case undefined:
+      return 'info';
+
+    case 'error':
+      return 'major';
+
+    case 'warn':
+      return 'minor';
+
+    case 'off':
+      return 'info';
+  }
+}
+
+function getIssueDescription({ symbol, symbols, parentSymbol }: Issue) {
+  const symbolDescription = symbols ? `${symbols.map(s => s.symbol).join(', ')}` : symbol;
+
+  return `${symbolDescription}${parentSymbol ? ` (${parentSymbol})` : ''}`;
+}
+
+function getSymbolDescription({ symbol, parentSymbol }: { symbol: IssueSymbol; parentSymbol?: string }) {
+  return `${symbol.symbol}${parentSymbol ? ` (${parentSymbol})` : ''}`;
+}
+
+function createFingerprint(filePath: string, message: string, hashes: Set<string>): string {
+  const md5 = createHash('md5');
+
+  md5.update(filePath);
+  md5.update(message);
+
+  let md5Copy = md5.copy();
+  let hash = md5Copy.digest('hex');
+
+  // To avoid hash collision, we keep generating new hashes until we get a unique one.
+  while (hashes.has(hash)) {
+    md5.update(hash);
+
+    md5Copy = md5.copy();
+    hash = md5Copy.digest('hex');
+  }
+
+  hashes.add(hash);
+
+  return hash;
+}

--- a/packages/knip/src/reporters/index.ts
+++ b/packages/knip/src/reporters/index.ts
@@ -1,7 +1,7 @@
+import codeclimate from './codeclimate.js';
 import codeowners from './codeowners.js';
 import compact from './compact.js';
 import disclosure from './disclosure.js';
-import gitlab from './gitlab.js';
 import json from './json.js';
 import markdown from './markdown.js';
 import symbols from './symbols.js';
@@ -11,7 +11,7 @@ export default {
   compact,
   codeowners,
   disclosure,
-  gitlab,
+  codeclimate,
   json,
   markdown,
 };

--- a/packages/knip/src/reporters/index.ts
+++ b/packages/knip/src/reporters/index.ts
@@ -1,6 +1,7 @@
 import codeowners from './codeowners.js';
 import compact from './compact.js';
 import disclosure from './disclosure.js';
+import gitlab from './gitlab.js';
 import json from './json.js';
 import markdown from './markdown.js';
 import symbols from './symbols.js';
@@ -10,6 +11,7 @@ export default {
   compact,
   codeowners,
   disclosure,
+  gitlab,
   json,
   markdown,
 };

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate.test.ts
@@ -1,0 +1,150 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { resolve } from '../../../src/util/path.js';
+import { execFactory } from '../../helpers/exec.js';
+
+const cwd = resolve('fixtures/exports');
+
+const exec = execFactory(cwd);
+
+test('knip --reporter codeclimate (exports & types)', () => {
+  const json = [
+    {
+      type: 'issue',
+      check_name: 'Unused exports',
+      description: 'unusedNumber',
+      categories: ['Bug Risk'],
+      location: { path: 'my-module.ts', positions: { begin: { line: 23, column: 14 } } },
+      severity: 'major',
+      fingerprint: 'a692865478fa9a80269bc6f50131f440',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exports',
+      description: 'unusedFunction',
+      categories: ['Bug Risk'],
+      location: { path: 'my-module.ts', positions: { begin: { line: 24, column: 14 } } },
+      severity: 'major',
+      fingerprint: 'd6ea731db7a014e709a16b66d20e72cb',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exports',
+      description: 'default',
+      categories: ['Bug Risk'],
+      location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 8 } } },
+      severity: 'major',
+      fingerprint: '11e005cbcb18fcb3fae5ac241f5da2e6',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exports',
+      description: 'renamedExport',
+      categories: ['Bug Risk'],
+      location: { path: 'named-exports.ts', positions: { begin: { line: 6, column: 30 } } },
+      severity: 'major',
+      fingerprint: 'abff03707fc1ceebfb71d845b316bee9',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exports',
+      description: 'namedExport',
+      categories: ['Bug Risk'],
+      location: { path: 'named-exports.ts', positions: { begin: { line: 7, column: 15 } } },
+      severity: 'major',
+      fingerprint: 'a2548d2c445f76e38f55ee90392cee81',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exports',
+      description: 'unusedZero',
+      categories: ['Bug Risk'],
+      location: { path: 'dynamic-import.ts', positions: { begin: { line: 3, column: 14 } } },
+      severity: 'major',
+      fingerprint: 'c3d8f583d65359d4964b927781f57007',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exports',
+      description: 'unusedInMix',
+      categories: ['Bug Risk'],
+      location: { path: 'my-mix.ts', positions: { begin: { line: 1, column: 14 } } },
+      severity: 'major',
+      fingerprint: 'fdd3be9d72cdd55b9665876fa3a143e9',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exports',
+      description: 'NamedExport',
+      categories: ['Bug Risk'],
+      location: { path: 'default.ts', positions: { begin: { line: 1, column: 14 } } },
+      severity: 'major',
+      fingerprint: '2090022d9ccab3f3c476df5c57f2777c',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exports',
+      description: 'nsUnusedKey (MyNamespace)',
+      categories: ['Bug Risk'],
+      location: { path: 'my-namespace.ts', positions: { begin: { line: 3, column: 14 } } },
+      severity: 'major',
+      fingerprint: '231d97dfc8c9f9963e86f64521d8288c',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exported types',
+      description: 'MyAnyType',
+      categories: ['Bug Risk'],
+      location: { path: 'my-module.ts', positions: { begin: { line: 28, column: 13 } } },
+      severity: 'major',
+      fingerprint: '55523efc0469cbb3bf74c0b0518d0fd4',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exported types',
+      description: 'MyEnum',
+      categories: ['Bug Risk'],
+      location: { path: 'types.ts', positions: { begin: { line: 3, column: 13 } } },
+      severity: 'major',
+      fingerprint: '5a3687b379ef7ae0c7c51091244332a7',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exported types',
+      description: 'MyType',
+      categories: ['Bug Risk'],
+      location: { path: 'types.ts', positions: { begin: { line: 8, column: 14 } } },
+      severity: 'major',
+      fingerprint: '6de1187542653bff43089174077c28e8',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exported types',
+      description: 'MyNamespace (MyNamespace)',
+      categories: ['Bug Risk'],
+      location: { path: 'my-namespace.ts', positions: { begin: { line: 5, column: 18 } } },
+      severity: 'major',
+      fingerprint: 'e60cdcadefb9f088ccec0dbaf4138643',
+    },
+    {
+      type: 'issue',
+      check_name: 'Duplicate exports',
+      description: 'exportedResult',
+      categories: ['Duplication'],
+      location: { path: 'my-module.ts', positions: { begin: { line: 26, column: 13 } } },
+      severity: 'major',
+      fingerprint: '092294dad3e67ff1e91a16e261ce1ada',
+    },
+    {
+      type: 'issue',
+      check_name: 'Duplicate exports',
+      description: 'default',
+      categories: ['Duplication'],
+      location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 15 } } },
+      severity: 'major',
+      fingerprint: 'd34a32bd4291a9638f6ee1bdfd77702f',
+    },
+  ];
+
+  assert.equal(exec('knip --reporter codeclimate').stdout, `${JSON.stringify(json)}\n`);
+});

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate.test.ts
@@ -1,5 +1,4 @@
-import { test } from 'bun:test';
-import assert from 'node:assert/strict';
+import { expect, test } from 'bun:test';
 import { resolve } from '../../../src/util/path.js';
 import { execFactory } from '../../helpers/exec.js';
 
@@ -16,7 +15,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-module.ts', positions: { begin: { line: 23, column: 14 } } },
       severity: 'major',
-      fingerprint: 'a692865478fa9a80269bc6f50131f440',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -25,7 +24,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-module.ts', positions: { begin: { line: 24, column: 14 } } },
       severity: 'major',
-      fingerprint: 'd6ea731db7a014e709a16b66d20e72cb',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -34,7 +33,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 8 } } },
       severity: 'major',
-      fingerprint: '11e005cbcb18fcb3fae5ac241f5da2e6',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -43,7 +42,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'named-exports.ts', positions: { begin: { line: 6, column: 30 } } },
       severity: 'major',
-      fingerprint: 'abff03707fc1ceebfb71d845b316bee9',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -52,7 +51,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'named-exports.ts', positions: { begin: { line: 7, column: 15 } } },
       severity: 'major',
-      fingerprint: 'a2548d2c445f76e38f55ee90392cee81',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -61,7 +60,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'dynamic-import.ts', positions: { begin: { line: 3, column: 14 } } },
       severity: 'major',
-      fingerprint: 'c3d8f583d65359d4964b927781f57007',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -70,7 +69,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-mix.ts', positions: { begin: { line: 1, column: 14 } } },
       severity: 'major',
-      fingerprint: 'fdd3be9d72cdd55b9665876fa3a143e9',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -79,7 +78,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'default.ts', positions: { begin: { line: 1, column: 14 } } },
       severity: 'major',
-      fingerprint: '2090022d9ccab3f3c476df5c57f2777c',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -88,7 +87,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-namespace.ts', positions: { begin: { line: 3, column: 14 } } },
       severity: 'major',
-      fingerprint: '231d97dfc8c9f9963e86f64521d8288c',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -97,7 +96,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-module.ts', positions: { begin: { line: 28, column: 13 } } },
       severity: 'major',
-      fingerprint: '55523efc0469cbb3bf74c0b0518d0fd4',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -106,7 +105,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'types.ts', positions: { begin: { line: 3, column: 13 } } },
       severity: 'major',
-      fingerprint: '5a3687b379ef7ae0c7c51091244332a7',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -115,7 +114,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'types.ts', positions: { begin: { line: 8, column: 14 } } },
       severity: 'major',
-      fingerprint: '6de1187542653bff43089174077c28e8',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -124,7 +123,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-namespace.ts', positions: { begin: { line: 5, column: 18 } } },
       severity: 'major',
-      fingerprint: 'e60cdcadefb9f088ccec0dbaf4138643',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -133,7 +132,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Duplication'],
       location: { path: 'my-module.ts', positions: { begin: { line: 26, column: 13 } } },
       severity: 'major',
-      fingerprint: '092294dad3e67ff1e91a16e261ce1ada',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -142,9 +141,11 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Duplication'],
       location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 15 } } },
       severity: 'major',
-      fingerprint: 'd34a32bd4291a9638f6ee1bdfd77702f',
+      fingerprint: expect.any(String),
     },
   ];
 
-  assert.equal(exec('knip --reporter codeclimate').stdout, `${JSON.stringify(json)}\n`);
+  const actual = JSON.parse(exec('knip --reporter codeclimate').stdout);
+
+  expect(actual).toStrictEqual(json);
 });

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate.test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from 'bun:test';
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
 import { resolve } from '../../../src/util/path.js';
+import { assertAndRemoveProperty } from '../../helpers/assertAndRemoveProperty.js';
 import { execFactory } from '../../helpers/exec.js';
 
 const cwd = resolve('fixtures/exports');
@@ -15,7 +17,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-module.ts', positions: { begin: { line: 23, column: 14 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -24,7 +25,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-module.ts', positions: { begin: { line: 24, column: 14 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -33,7 +33,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 8 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -42,7 +41,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'named-exports.ts', positions: { begin: { line: 6, column: 30 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -51,7 +49,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'named-exports.ts', positions: { begin: { line: 7, column: 15 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -60,7 +57,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'dynamic-import.ts', positions: { begin: { line: 3, column: 14 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -69,7 +65,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-mix.ts', positions: { begin: { line: 1, column: 14 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -78,7 +73,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'default.ts', positions: { begin: { line: 1, column: 14 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -87,7 +81,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-namespace.ts', positions: { begin: { line: 3, column: 14 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -96,7 +89,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-module.ts', positions: { begin: { line: 28, column: 13 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -105,7 +97,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'types.ts', positions: { begin: { line: 3, column: 13 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -114,7 +105,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'types.ts', positions: { begin: { line: 8, column: 14 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -123,7 +113,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Bug Risk'],
       location: { path: 'my-namespace.ts', positions: { begin: { line: 5, column: 18 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -132,7 +121,6 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Duplication'],
       location: { path: 'my-module.ts', positions: { begin: { line: 26, column: 13 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -141,11 +129,16 @@ test('knip --reporter codeclimate (exports & types)', () => {
       categories: ['Duplication'],
       location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 15 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
   ];
 
-  const actual = JSON.parse(exec('knip --reporter codeclimate').stdout);
+  const issues = JSON.parse(exec('knip --reporter codeclimate').stdout) as {
+    fingerprint: string;
+    [key: string]: unknown;
+  }[];
+  const issuesWithoutFingerprints = issues.map(issue => {
+    return assertAndRemoveProperty(issue, 'fingerprint', fingerprint => assert.match(fingerprint, /[a-f0-9]{32}/));
+  });
 
-  expect(actual).toStrictEqual(json);
+  assert.deepEqual(issuesWithoutFingerprints, json);
 });

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from 'bun:test';
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
 import { resolve } from '../../../src/util/path.js';
+import { assertAndRemoveProperty } from '../../helpers/assertAndRemoveProperty.js';
 import { execFactory } from '../../helpers/exec.js';
 
 const cwd = resolve('fixtures/module-resolution-non-std');
@@ -15,7 +17,6 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       categories: ['Bug Risk'],
       location: { path: 'src/index.ts', positions: { begin: { line: 0, column: 0 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -24,7 +25,6 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       categories: ['Bug Risk'],
       location: { path: 'src/index.ts', positions: { begin: { line: 0, column: 0 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -33,11 +33,16 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       categories: ['Bug Risk'],
       location: { path: 'src/index.ts', positions: { begin: { line: 8, column: 23 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
   ];
 
-  const actual = JSON.parse(exec('knip --reporter codeclimate').stdout);
+  const issues = JSON.parse(exec('knip --reporter codeclimate').stdout) as {
+    fingerprint: string;
+    [key: string]: unknown;
+  }[];
+  const issuesWithoutFingerprints = issues.map(issue => {
+    return assertAndRemoveProperty(issue, 'fingerprint', fingerprint => assert.match(fingerprint, /[a-f0-9]{32}/));
+  });
 
-  expect(actual).toStrictEqual(json);
+  assert.deepEqual(issuesWithoutFingerprints, json);
 });

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
@@ -1,0 +1,42 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { resolve } from '../../../src/util/path.js';
+import { execFactory } from '../../helpers/exec.js';
+
+const cwd = resolve('fixtures/module-resolution-non-std');
+
+const exec = execFactory(cwd);
+
+test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
+  const json = [
+    {
+      type: 'issue',
+      check_name: 'Unlisted dependencies',
+      description: 'unresolved',
+      categories: ['Bug Risk'],
+      location: { path: 'src/index.ts', positions: { begin: { line: 0, column: 0 } } },
+      severity: 'major',
+      fingerprint: 'b1b545760301bdc48bed7e04d45efc78',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unlisted dependencies',
+      description: '@org/unresolved',
+      categories: ['Bug Risk'],
+      location: { path: 'src/index.ts', positions: { begin: { line: 0, column: 0 } } },
+      severity: 'major',
+      fingerprint: 'ada204238b38158fad8bff20699311d2',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unresolved imports',
+      description: './unresolved',
+      categories: ['Bug Risk'],
+      location: { path: 'src/index.ts', positions: { begin: { line: 8, column: 23 } } },
+      severity: 'major',
+      fingerprint: '848e2712798120c3a315e9880c516093',
+    },
+  ];
+
+  assert.equal(exec('knip --reporter codeclimate').stdout, `${JSON.stringify(json)}\n`);
+});

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
@@ -14,7 +14,7 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       categories: ['Bug Risk'],
       check_name: 'Unused files',
       description: 'src/unused.ts',
-      location: { path: 'src/unused.ts', positions: { begin: { column: 0, line: 0 } } },
+      location: { path: 'src/unused.ts', lines: { begin: 0, end: 0 } },
       severity: 'major',
       type: 'issue',
     },
@@ -23,7 +23,7 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       check_name: 'Unlisted dependencies',
       description: 'unresolved',
       categories: ['Bug Risk'],
-      location: { path: 'src/index.ts', positions: { begin: { line: 0, column: 0 } } },
+      location: { path: 'src/index.ts', lines: { begin: 0, end: 0 } },
       severity: 'major',
     },
     {
@@ -31,7 +31,7 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       check_name: 'Unlisted dependencies',
       description: '@org/unresolved',
       categories: ['Bug Risk'],
-      location: { path: 'src/index.ts', positions: { begin: { line: 0, column: 0 } } },
+      location: { path: 'src/index.ts', lines: { begin: 0, end: 0 } },
       severity: 'major',
     },
     {

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
@@ -11,6 +11,14 @@ const exec = execFactory(cwd);
 test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
   const json = [
     {
+      categories: ['Bug Risk'],
+      check_name: 'Unused files',
+      description: 'src/unused.ts',
+      location: { path: 'src/unused.ts', positions: { begin: { column: 0, line: 0 } } },
+      severity: 'major',
+      type: 'issue',
+    },
+    {
       type: 'issue',
       check_name: 'Unlisted dependencies',
       description: 'unresolved',

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
@@ -1,5 +1,4 @@
-import { test } from 'bun:test';
-import assert from 'node:assert/strict';
+import { expect, test } from 'bun:test';
 import { resolve } from '../../../src/util/path.js';
 import { execFactory } from '../../helpers/exec.js';
 
@@ -16,7 +15,7 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       categories: ['Bug Risk'],
       location: { path: 'src/index.ts', positions: { begin: { line: 0, column: 0 } } },
       severity: 'major',
-      fingerprint: 'b1b545760301bdc48bed7e04d45efc78',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -25,7 +24,7 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       categories: ['Bug Risk'],
       location: { path: 'src/index.ts', positions: { begin: { line: 0, column: 0 } } },
       severity: 'major',
-      fingerprint: 'ada204238b38158fad8bff20699311d2',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -34,9 +33,11 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       categories: ['Bug Risk'],
       location: { path: 'src/index.ts', positions: { begin: { line: 8, column: 23 } } },
       severity: 'major',
-      fingerprint: '848e2712798120c3a315e9880c516093',
+      fingerprint: expect.any(String),
     },
   ];
 
-  assert.equal(exec('knip --reporter codeclimate').stdout, `${JSON.stringify(json)}\n`);
+  const actual = JSON.parse(exec('knip --reporter codeclimate').stdout);
+
+  expect(actual).toStrictEqual(json);
 });

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate3.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate3.test.ts
@@ -1,5 +1,4 @@
-import { test } from 'bun:test';
-import assert from 'node:assert/strict';
+import { expect, test } from 'bun:test';
 import { resolve } from '../../../src/util/path.js';
 import { execFactory } from '../../helpers/exec.js';
 
@@ -16,7 +15,7 @@ test('knip --reporter codeclimate (enum members)', () => {
       categories: ['Bug Risk'],
       location: { path: 'members.ts', positions: { begin: { line: 9, column: 3 } } },
       severity: 'major',
-      fingerprint: '784fc56ef59f32b5a65c79285b011268',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -25,9 +24,11 @@ test('knip --reporter codeclimate (enum members)', () => {
       categories: ['Bug Risk'],
       location: { path: 'members.ts', positions: { begin: { line: 11, column: 3 } } },
       severity: 'major',
-      fingerprint: '56c0c3061c62aba497eef68826c072b0',
+      fingerprint: expect.any(String),
     },
   ];
 
-  assert.equal(exec('knip --reporter codeclimate').stdout, `${JSON.stringify(json)}\n`);
+  const actual = JSON.parse(exec('knip --reporter codeclimate').stdout);
+
+  expect(actual).toStrictEqual(json);
 });

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate3.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate3.test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from 'bun:test';
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
 import { resolve } from '../../../src/util/path.js';
+import { assertAndRemoveProperty } from '../../helpers/assertAndRemoveProperty.js';
 import { execFactory } from '../../helpers/exec.js';
 
 const cwd = resolve('fixtures/enum-members');
@@ -15,7 +17,6 @@ test('knip --reporter codeclimate (enum members)', () => {
       categories: ['Bug Risk'],
       location: { path: 'members.ts', positions: { begin: { line: 9, column: 3 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -24,11 +25,16 @@ test('knip --reporter codeclimate (enum members)', () => {
       categories: ['Bug Risk'],
       location: { path: 'members.ts', positions: { begin: { line: 11, column: 3 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
   ];
 
-  const actual = JSON.parse(exec('knip --reporter codeclimate').stdout);
+  const issues = JSON.parse(exec('knip --reporter codeclimate').stdout) as {
+    fingerprint: string;
+    [key: string]: unknown;
+  }[];
+  const issuesWithoutFingerprints = issues.map(issue => {
+    return assertAndRemoveProperty(issue, 'fingerprint', fingerprint => assert.match(fingerprint, /[a-f0-9]{32}/));
+  });
 
-  expect(actual).toStrictEqual(json);
+  assert.deepEqual(issuesWithoutFingerprints, json);
 });

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate3.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate3.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { resolve } from '../../../src/util/path.js';
+import { execFactory } from '../../helpers/exec.js';
+
+const cwd = resolve('fixtures/enum-members');
+
+const exec = execFactory(cwd);
+
+test('knip --reporter codeclimate (enum members)', () => {
+  const json = [
+    {
+      type: 'issue',
+      check_name: 'Unused exported enum members',
+      description: 'B_Unused (MyEnum)',
+      categories: ['Bug Risk'],
+      location: { path: 'members.ts', positions: { begin: { line: 9, column: 3 } } },
+      severity: 'major',
+      fingerprint: '784fc56ef59f32b5a65c79285b011268',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused exported enum members',
+      description: 'D_Key (MyEnum)',
+      categories: ['Bug Risk'],
+      location: { path: 'members.ts', positions: { begin: { line: 11, column: 3 } } },
+      severity: 'major',
+      fingerprint: '56c0c3061c62aba497eef68826c072b0',
+    },
+  ];
+
+  assert.equal(exec('knip --reporter codeclimate').stdout, `${JSON.stringify(json)}\n`);
+});

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
@@ -1,5 +1,4 @@
-import { test } from 'bun:test';
-import assert from 'node:assert/strict';
+import { expect, test } from 'bun:test';
 import { resolve } from '../../../src/util/path.js';
 import { execFactory } from '../../helpers/exec.js';
 
@@ -16,7 +15,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 8, column: 6 } } },
       severity: 'major',
-      fingerprint: '4fc6300461b1aadeecb624d9314baa75',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -25,7 +24,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 10, column: 6 } } },
       severity: 'major',
-      fingerprint: 'eabdb26f569d090d21b27541673fd724',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -34,7 +33,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 23, column: 6 } } },
       severity: 'major',
-      fingerprint: '2b41bc7a87140c799edc2db0eeb5bcf3',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -43,7 +42,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 0, column: 0 } } },
       severity: 'major',
-      fingerprint: '12de7239cea598891f097ca87dd1b98b',
+      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -52,9 +51,11 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 0, column: 0 } } },
       severity: 'major',
-      fingerprint: '4ce470537162948a05d651a7cc80447e',
+      fingerprint: expect.any(String),
     },
   ];
 
-  assert.equal(exec('knip --reporter codeclimate').stdout, `${JSON.stringify(json)}\n`);
+  const actual = JSON.parse(exec('knip --reporter codeclimate').stdout);
+
+  expect(actual).toStrictEqual(json);
 });

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
@@ -11,6 +11,14 @@ const exec = execFactory(cwd);
 test('knip --reporter codeclimate (dependencies)', () => {
   const json = [
     {
+      categories: ['Bug Risk'],
+      check_name: 'Unused files',
+      description: 'unused-module.ts',
+      location: { path: 'unused-module.ts', positions: { begin: { column: 0, line: 0 } } },
+      severity: 'major',
+      type: 'issue',
+    },
+    {
       type: 'issue',
       check_name: 'Unused dependencies',
       description: '@tootallnate/once',

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
@@ -14,7 +14,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       check_name: 'Unused files',
       description: 'unused-module.ts',
-      location: { path: 'unused-module.ts', positions: { begin: { column: 0, line: 0 } } },
+      location: { path: 'unused-module.ts', lines: { begin: 0, end: 0 } },
       severity: 'major',
       type: 'issue',
     },
@@ -47,7 +47,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       check_name: 'Unlisted binaries',
       description: 'jest',
       categories: ['Bug Risk'],
-      location: { path: 'package.json', positions: { begin: { line: 0, column: 0 } } },
+      location: { path: 'package.json', lines: { begin: 0, end: 0 } },
       severity: 'major',
     },
     {
@@ -55,7 +55,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       check_name: 'Unlisted binaries',
       description: 'start-server',
       categories: ['Bug Risk'],
-      location: { path: 'package.json', positions: { begin: { line: 0, column: 0 } } },
+      location: { path: 'package.json', lines: { begin: 0, end: 0 } },
       severity: 'major',
     },
   ];

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from 'bun:test';
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
 import { resolve } from '../../../src/util/path.js';
+import { assertAndRemoveProperty } from '../../helpers/assertAndRemoveProperty.js';
 import { execFactory } from '../../helpers/exec.js';
 
 const cwd = resolve('fixtures/dependencies');
@@ -15,7 +17,6 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 8, column: 6 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -24,7 +25,6 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 10, column: 6 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -33,7 +33,6 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 23, column: 6 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -42,7 +41,6 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 0, column: 0 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
     {
       type: 'issue',
@@ -51,11 +49,16 @@ test('knip --reporter codeclimate (dependencies)', () => {
       categories: ['Bug Risk'],
       location: { path: 'package.json', positions: { begin: { line: 0, column: 0 } } },
       severity: 'major',
-      fingerprint: expect.any(String),
     },
   ];
 
-  const actual = JSON.parse(exec('knip --reporter codeclimate').stdout);
+  const issues = JSON.parse(exec('knip --reporter codeclimate').stdout) as {
+    fingerprint: string;
+    [key: string]: unknown;
+  }[];
+  const issuesWithoutFingerprints = issues.map(issue => {
+    return assertAndRemoveProperty(issue, 'fingerprint', fingerprint => assert.match(fingerprint, /[a-f0-9]{32}/));
+  });
 
-  expect(actual).toStrictEqual(json);
+  assert.deepEqual(issuesWithoutFingerprints, json);
 });

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { resolve } from '../../../src/util/path.js';
+import { execFactory } from '../../helpers/exec.js';
+
+const cwd = resolve('fixtures/dependencies');
+
+const exec = execFactory(cwd);
+
+test('knip --reporter codeclimate (dependencies)', () => {
+  const json = [
+    {
+      type: 'issue',
+      check_name: 'Unused dependencies',
+      description: '@tootallnate/once',
+      categories: ['Bug Risk'],
+      location: { path: 'package.json', positions: { begin: { line: 8, column: 6 } } },
+      severity: 'major',
+      fingerprint: '4fc6300461b1aadeecb624d9314baa75',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused dependencies',
+      description: 'fs-extra',
+      categories: ['Bug Risk'],
+      location: { path: 'package.json', positions: { begin: { line: 10, column: 6 } } },
+      severity: 'major',
+      fingerprint: 'eabdb26f569d090d21b27541673fd724',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unused devDependencies',
+      description: 'mocha',
+      categories: ['Bug Risk'],
+      location: { path: 'package.json', positions: { begin: { line: 23, column: 6 } } },
+      severity: 'major',
+      fingerprint: '2b41bc7a87140c799edc2db0eeb5bcf3',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unlisted binaries',
+      description: 'jest',
+      categories: ['Bug Risk'],
+      location: { path: 'package.json', positions: { begin: { line: 0, column: 0 } } },
+      severity: 'major',
+      fingerprint: '12de7239cea598891f097ca87dd1b98b',
+    },
+    {
+      type: 'issue',
+      check_name: 'Unlisted binaries',
+      description: 'start-server',
+      categories: ['Bug Risk'],
+      location: { path: 'package.json', positions: { begin: { line: 0, column: 0 } } },
+      severity: 'major',
+      fingerprint: '4ce470537162948a05d651a7cc80447e',
+    },
+  ];
+
+  assert.equal(exec('knip --reporter codeclimate').stdout, `${JSON.stringify(json)}\n`);
+});

--- a/packages/knip/test/helpers/assertAndRemoveProperty.ts
+++ b/packages/knip/test/helpers/assertAndRemoveProperty.ts
@@ -1,0 +1,12 @@
+function assertAndRemoveProperty<TIn extends object, TProp extends keyof TIn>(
+  obj: TIn,
+  propName: TProp,
+  assertProperty: (value: TIn[TProp]) => void
+): Omit<TIn, TProp> {
+  const { [propName]: value, ...rest } = obj;
+  assertProperty(value);
+
+  return rest;
+}
+
+export { assertAndRemoveProperty };


### PR DESCRIPTION
This adds a built-in reporter for the GitLab Code Quality Report format.

I took the json reporter as template and adapted it to print json in the GitLab format.

Because this format does not support reporting multiple issues in one entry, I decided to create multiple entries for the 'duplicates' issue type.