### PR TITLE
Add SST plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,7 @@
   "[json]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome"
-  },
+  "[typescript]": {},
   "[typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"

--- a/packages/knip/fixtures/plugins/sst/empty-config/package.json
+++ b/packages/knip/fixtures/plugins/sst/empty-config/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixtures/sst",
+  "version": "*",
+  "devDependencies": {
+    "sst": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-lambdas/package.json
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-lambdas/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixtures/sst",
+  "version": "*",
+  "devDependencies": {
+    "sst": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-lambdas/src/lambdas/my-handler.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-lambdas/src/lambdas/my-handler.ts
@@ -1,0 +1,1 @@
+import {d} from "dependencyFromHandler";

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-lambdas/src/stacks/my-stack.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-lambdas/src/stacks/my-stack.ts
@@ -1,0 +1,17 @@
+import { d } from "dependencyFromStack";
+import { use, StackContext, Function, FunctionProps } from "sst/constructs";
+
+export function MyStack({ stack, app }: StackContext) {
+
+  // Create single Lambda handler
+  const handlerProps: FunctionProps = {
+    handler: "src/handlers/my-handler.handlerFn",
+    permissions: ["perm1", "perm2"]
+  };
+
+  const handler = new Function(stack, "MyHandler", handlerProps);
+
+  return {
+    handler
+  };
+}

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-lambdas/sst.config.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-lambdas/sst.config.ts
@@ -1,0 +1,17 @@
+import { SSTConfig } from "sst";
+import { d } from "dependencyFromConfig";
+import { MyStack } from "./src/stacks/my-stack";
+// import a stack
+
+export default {
+  config(_input) {
+    return {
+      name: "MyService",
+      region: "eu-west-2",
+      stage: "production",
+    };
+  },
+  stacks(app) {
+    app.stack(MyStack);
+  },
+} satisfies SSTConfig;

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-src-nested/package.json
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-src-nested/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixtures/sst",
+  "version": "*",
+  "devDependencies": {
+    "sst": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-src-nested/src/handlers/crud/my-handler.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-src-nested/src/handlers/crud/my-handler.ts
@@ -1,0 +1,1 @@
+import {d} from "dependencyFromHandler";

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-src-nested/src/stacks/my-stack.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-src-nested/src/stacks/my-stack.ts
@@ -1,0 +1,17 @@
+import { d } from "dependencyFromStack";
+import { use, StackContext, Function, FunctionProps } from "sst/constructs";
+
+export function MyStack({ stack, app }: StackContext) {
+
+  // Create single Lambda handler
+  const handlerProps: FunctionProps = {
+    handler: "src/handlers/my-handler.handlerFn",
+    permissions: ["perm1", "perm2"]
+  };
+
+  const handler = new Function(stack, "MyHandler", handlerProps);
+
+  return {
+    handler
+  };
+}

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-src-nested/sst.config.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-src-nested/sst.config.ts
@@ -1,0 +1,17 @@
+import { SSTConfig } from "sst";
+import { d } from "dependencyFromConfig";
+import { MyStack } from "./src/stacks/my-stack";
+// import a stack
+
+export default {
+  config(_input) {
+    return {
+      name: "MyService",
+      region: "eu-west-2",
+      stage: "production",
+    };
+  },
+  stacks(app) {
+    app.stack(MyStack);
+  },
+} satisfies SSTConfig;

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-src/package.json
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-src/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixtures/sst",
+  "version": "*",
+  "devDependencies": {
+    "sst": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-src/src/handlers/my-handler.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-src/src/handlers/my-handler.ts
@@ -1,0 +1,1 @@
+import {d} from "dependencyFromHandler";

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-src/src/stacks/my-stack.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-src/src/stacks/my-stack.ts
@@ -1,0 +1,17 @@
+import { d } from "dependencyFromStack";
+import { use, StackContext, Function, FunctionProps } from "sst/constructs";
+
+export function MyStack({ stack, app }: StackContext) {
+
+  // Create single Lambda handler
+  const handlerProps: FunctionProps = {
+    handler: "src/handlers/my-handler.handlerFn",
+    permissions: ["perm1", "perm2"]
+  };
+
+  const handler = new Function(stack, "MyHandler", handlerProps);
+
+  return {
+    handler
+  };
+}

--- a/packages/knip/fixtures/plugins/sst/one-handler-in-src/sst.config.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler-in-src/sst.config.ts
@@ -1,0 +1,17 @@
+import { SSTConfig } from "sst";
+import { d } from "dependencyFromConfig";
+import { MyStack } from "./src/stacks/my-stack";
+// import a stack
+
+export default {
+  config(_input) {
+    return {
+      name: "MyService",
+      region: "eu-west-2",
+      stage: "production",
+    };
+  },
+  stacks(app) {
+    app.stack(MyStack);
+  },
+} satisfies SSTConfig;

--- a/packages/knip/fixtures/plugins/sst/one-handler/handlers/my-handler.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler/handlers/my-handler.ts
@@ -1,0 +1,1 @@
+import {d} from "dependencyFromHandler";

--- a/packages/knip/fixtures/plugins/sst/one-handler/package.json
+++ b/packages/knip/fixtures/plugins/sst/one-handler/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixtures/sst",
+  "version": "*",
+  "devDependencies": {
+    "sst": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/sst/one-handler/sst.config.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler/sst.config.ts
@@ -1,0 +1,17 @@
+import { SSTConfig } from "sst";
+import { d } from "dependencyFromConfig";
+import { MyStack } from "./stacks/my-stack";
+// import a stack
+
+export default {
+  config(_input) {
+    return {
+      name: "MyService",
+      region: "eu-west-2",
+      stage: "production",
+    };
+  },
+  stacks(app) {
+    app.stack(MyStack);
+  },
+} satisfies SSTConfig;

--- a/packages/knip/fixtures/plugins/sst/one-handler/stacks/my-stack.ts
+++ b/packages/knip/fixtures/plugins/sst/one-handler/stacks/my-stack.ts
@@ -1,0 +1,17 @@
+import { d } from "dependencyFromStack";
+import { use, StackContext, Function, FunctionProps } from "sst/constructs";
+
+export function MyStack({ stack, app }: StackContext) {
+
+  // Create single Lambda handler
+  const handlerProps: FunctionProps = {
+    handler: "src/handlers/my-handler.handlerFn",
+    permissions: ["perm1", "perm2"]
+  };
+
+  const handler = new Function(stack, "MyHandler", handlerProps);
+
+  return {
+    handler
+  };
+}

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -546,6 +546,10 @@
           "title": "size-limit plugin configuration (https://knip.dev/reference/plugins/size-limit)",
           "$ref": "#/definitions/plugin"
         },
+        "sst": {
+          "title": "sst plugin configuration (https://knip.dev/reference/plugins/sst)",
+          "$ref": "#/definitions/plugin"
+        },
         "storybook": {
           "title": "Storybook plugin configuration (https://knip.dev/reference/plugins/storybook)",
           "$ref": "#/definitions/plugin"

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -64,6 +64,7 @@ import { default as semanticRelease } from './semantic-release/index.js';
 import { default as sentry } from './sentry/index.js';
 import { default as simpleGitHooks } from './simple-git-hooks/index.js';
 import { default as sizeLimit } from './size-limit/index.js';
+import { default as sst } from './sst/index.js';
 import { default as storybook } from './storybook/index.js';
 import { default as stryker } from './stryker/index.js';
 import { default as stylelint } from './stylelint/index.js';
@@ -157,6 +158,7 @@ export const Plugins = {
   sentry,
   'simple-git-hooks': simpleGitHooks,
   'size-limit': sizeLimit,
+  sst,
   storybook,
   stryker,
   stylelint,

--- a/packages/knip/src/plugins/sst/index.ts
+++ b/packages/knip/src/plugins/sst/index.ts
@@ -1,0 +1,24 @@
+import type { IsPluginEnabled, Plugin } from "../../types/config.js";
+import { hasDependency } from "../../util/plugin.js";
+
+// link to sst docs
+
+const title = "sst";
+
+const enablers = ["sst"];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) =>
+  hasDependency(dependencies, enablers);
+
+const entry = [
+  "sst.config.{js,cjs,mjs,ts}",
+  "{handlers,lambdas}/*.{js,cjs,mjs,ts}",
+  "src/{handlers,lambdas}/*.{js,cjs,mjs,ts}",
+];
+
+export default {
+  title,
+  enablers,
+  isEnabled,
+  entry,
+} satisfies Plugin;

--- a/packages/knip/src/plugins/sst/index.ts
+++ b/packages/knip/src/plugins/sst/index.ts
@@ -12,8 +12,8 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) =>
 
 const entry = [
   "sst.config.{js,cjs,mjs,ts}",
-  "{handlers,lambdas}/*.{js,cjs,mjs,ts}",
-  "src/{handlers,lambdas}/*.{js,cjs,mjs,ts}",
+  "{handlers,lambdas}/**/*.{js,cjs,mjs,ts}",
+  "src/{handlers,lambdas}/**/*.{js,cjs,mjs,ts}",
 ];
 
 export default {

--- a/packages/knip/src/plugins/sst/types.ts
+++ b/packages/knip/src/plugins/sst/types.ts
@@ -1,0 +1,4 @@
+export type PluginConfig = {
+  plugins?: string[];
+  entryPathsOrPatterns?: string[];
+};

--- a/packages/knip/src/schema/plugins.ts
+++ b/packages/knip/src/schema/plugins.ts
@@ -78,6 +78,7 @@ export const pluginsSchema = z.object({
   sentry: pluginSchema,
   'simple-git-hooks': pluginSchema,
   'size-limit': pluginSchema,
+  sst: pluginSchema,
   storybook: pluginSchema,
   stryker: pluginSchema,
   stylelint: pluginSchema,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -65,6 +65,7 @@ export type PluginName =
   | 'sentry'
   | 'simple-git-hooks'
   | 'size-limit'
+  | 'sst'
   | 'storybook'
   | 'stryker'
   | 'stylelint'
@@ -158,6 +159,7 @@ export const pluginNames = [
   'sentry',
   'simple-git-hooks',
   'size-limit',
+  'sst',
   'storybook',
   'stryker',
   'stylelint',

--- a/packages/knip/test/plugins/sst.test.ts
+++ b/packages/knip/test/plugins/sst.test.ts
@@ -1,23 +1,31 @@
-import { test } from 'bun:test';
-import assert from 'node:assert/strict';
-import { main } from '../../src/index.js';
-import { resolve } from '../../src/util/path.js';
-import baseArguments from '../helpers/baseArguments.js';
-import baseCounters from '../helpers/baseCounters.js';
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { main } from "../../src/index.js";
+import { resolve } from "../../src/util/path.js";
+import baseArguments from "../helpers/baseArguments.js";
+import baseCounters from "../helpers/baseCounters.js";
 
-const cwdEmptyConfig = resolve('fixtures/plugins/sst/empty-config');
-const cwdOneHandler = resolve('fixtures/plugins/sst/one-handler');
-const cwdOneHandlerInSrcLambdas = resolve('fixtures/plugins/sst/one-handler-in-lambdas');
-const cwdOneHandlerInSrcHandlers = resolve('fixtures/plugins/sst/one-handler-in-src');
+const cwdEmptyConfig = resolve("fixtures/plugins/sst/empty-config");
+const cwdOneHandler = resolve("fixtures/plugins/sst/one-handler");
+const cwdOneHandlerInSrcLambdas = resolve(
+  "fixtures/plugins/sst/one-handler-in-lambdas"
+);
+const cwdOneHandlerInSrcHandlers = resolve(
+  "fixtures/plugins/sst/one-handler-in-src"
+);
 
-test('Find dependencies with the sst plugin with empty config', async () => {
+const cwdOneHandlerInSrcHandlersNested = resolve(
+  "fixtures/plugins/sst/one-handler-in-src-nested"
+);
+
+test("Find dependencies with the sst plugin with empty config", async () => {
   const { issues, counters } = await main({
     ...baseArguments,
     cwd: cwdEmptyConfig,
   });
 
-//   console.log('issues', issues);
-//   console.log('counters', counters);
+  //   console.log('issues', issues);
+  //   console.log('counters', counters);
 
   assert.deepEqual(counters, {
     ...baseCounters,
@@ -27,71 +35,94 @@ test('Find dependencies with the sst plugin with empty config', async () => {
   });
 });
 
-test('Find dependencies with the sst plugin with one handler', async () => {
-    const { issues, counters } = await main({
-      ...baseArguments,
-      cwd: cwdOneHandler,
-    });
-  
-//    console.log('issues', issues);
-    
-    assert.partialDeepStrictEqual(issues, {
-        unlisted: {
-            "sst.config.ts": {
-                dependencyFromConfig: {} // an example dependency listed in the config
-            },
-            "stacks/my-stack.ts": {
-                dependencyFromStack: {} // an example dependency listed in the stack
-            },
-            "handlers/my-handler.ts": {
-                dependencyFromHandler: {} // an example dependency listed in the handler
-            }
-        }
-    });
+test("Find dependencies with the sst plugin with one handler", async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd: cwdOneHandler,
   });
 
-  test('Find dependencies with the sst plugin with one handler in src/handlers folder', async () => {
-    const { issues, counters } = await main({
-      ...baseArguments,
-      cwd: cwdOneHandlerInSrcHandlers,
-    });
-  
-//    console.log('issues', issues);
-    
-    assert.partialDeepStrictEqual(issues, {
-        unlisted: {
-            "sst.config.ts": {
-                dependencyFromConfig: {} // an example dependency listed in the config
-            },
-            "src/stacks/my-stack.ts": {
-                dependencyFromStack: {} // an example dependency listed in the stack
-            },
-            "src/handlers/my-handler.ts": {
-                dependencyFromHandler: {} // an example dependency listed in the handler
-            }
-        }
-    });
+  //    console.log('issues', issues);
+
+  assert.partialDeepStrictEqual(issues, {
+    unlisted: {
+      "sst.config.ts": {
+        dependencyFromConfig: {}, // an example dependency listed in the config
+      },
+      "stacks/my-stack.ts": {
+        dependencyFromStack: {}, // an example dependency listed in the stack
+      },
+      "handlers/my-handler.ts": {
+        dependencyFromHandler: {}, // an example dependency listed in the handler
+      },
+    },
+  });
+});
+
+test("Find dependencies with the sst plugin with one handler in src/handlers folder", async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd: cwdOneHandlerInSrcHandlers,
   });
 
-  test('Find dependencies with the sst plugin with one handler in src/lambdas folder', async () => {
-    const { issues, counters } = await main({
-      ...baseArguments,
-      cwd: cwdOneHandlerInSrcLambdas,
-    });
-  
-//    console.log('issues', issues);
-    
-    assert.partialDeepStrictEqual(issues, {
-        unlisted: {
-            "sst.config.ts": {
-                dependencyFromConfig: {} // an example dependency listed in the config
-            },
-            "src/stacks/my-stack.ts": {
-                dependencyFromStack: {} // an example dependency listed in the stack
-            },
-            "src/lambdas/my-handler.ts": {
-                dependencyFromHandler: {} // an example dependency listed in the handler
-            }
-        }
-    });
+  //    console.log('issues', issues);
+
+  assert.partialDeepStrictEqual(issues, {
+    unlisted: {
+      "sst.config.ts": {
+        dependencyFromConfig: {}, // an example dependency listed in the config
+      },
+      "src/stacks/my-stack.ts": {
+        dependencyFromStack: {}, // an example dependency listed in the stack
+      },
+      "src/handlers/my-handler.ts": {
+        dependencyFromHandler: {}, // an example dependency listed in the handler
+      },
+    },
   });
+});
+
+test("Find dependencies with the sst plugin with one handler nested in src/handlers subfolder", async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd: cwdOneHandlerInSrcHandlersNested,
+  });
+
+  //    console.log('issues', issues);
+
+  assert.partialDeepStrictEqual(issues, {
+    unlisted: {
+      "sst.config.ts": {
+        dependencyFromConfig: {}, // an example dependency listed in the config
+      },
+      "src/stacks/my-stack.ts": {
+        dependencyFromStack: {}, // an example dependency listed in the stack
+      },
+      "src/handlers/crud/my-handler.ts": {
+        dependencyFromHandler: {}, // an example dependency listed in the handler
+      },
+    },
+  });
+});
+
+test("Find dependencies with the sst plugin with one handler in src/lambdas folder", async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd: cwdOneHandlerInSrcLambdas,
+  });
+
+  //    console.log('issues', issues);
+
+  assert.partialDeepStrictEqual(issues, {
+    unlisted: {
+      "sst.config.ts": {
+        dependencyFromConfig: {}, // an example dependency listed in the config
+      },
+      "src/stacks/my-stack.ts": {
+        dependencyFromStack: {}, // an example dependency listed in the stack
+      },
+      "src/lambdas/my-handler.ts": {
+        dependencyFromHandler: {}, // an example dependency listed in the handler
+      },
+    },
+  });
+});

--- a/packages/knip/test/plugins/sst.test.ts
+++ b/packages/knip/test/plugins/sst.test.ts
@@ -1,0 +1,97 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+
+const cwdEmptyConfig = resolve('fixtures/plugins/sst/empty-config');
+const cwdOneHandler = resolve('fixtures/plugins/sst/one-handler');
+const cwdOneHandlerInSrcLambdas = resolve('fixtures/plugins/sst/one-handler-in-lambdas');
+const cwdOneHandlerInSrcHandlers = resolve('fixtures/plugins/sst/one-handler-in-src');
+
+test('Find dependencies with the sst plugin with empty config', async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd: cwdEmptyConfig,
+  });
+
+//   console.log('issues', issues);
+//   console.log('counters', counters);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    devDependencies: 1,
+    processed: 1,
+    total: 1,
+  });
+});
+
+test('Find dependencies with the sst plugin with one handler', async () => {
+    const { issues, counters } = await main({
+      ...baseArguments,
+      cwd: cwdOneHandler,
+    });
+  
+//    console.log('issues', issues);
+    
+    assert.partialDeepStrictEqual(issues, {
+        unlisted: {
+            "sst.config.ts": {
+                dependencyFromConfig: {} // an example dependency listed in the config
+            },
+            "stacks/my-stack.ts": {
+                dependencyFromStack: {} // an example dependency listed in the stack
+            },
+            "handlers/my-handler.ts": {
+                dependencyFromHandler: {} // an example dependency listed in the handler
+            }
+        }
+    });
+  });
+
+  test('Find dependencies with the sst plugin with one handler in src/handlers folder', async () => {
+    const { issues, counters } = await main({
+      ...baseArguments,
+      cwd: cwdOneHandlerInSrcHandlers,
+    });
+  
+//    console.log('issues', issues);
+    
+    assert.partialDeepStrictEqual(issues, {
+        unlisted: {
+            "sst.config.ts": {
+                dependencyFromConfig: {} // an example dependency listed in the config
+            },
+            "src/stacks/my-stack.ts": {
+                dependencyFromStack: {} // an example dependency listed in the stack
+            },
+            "src/handlers/my-handler.ts": {
+                dependencyFromHandler: {} // an example dependency listed in the handler
+            }
+        }
+    });
+  });
+
+  test('Find dependencies with the sst plugin with one handler in src/lambdas folder', async () => {
+    const { issues, counters } = await main({
+      ...baseArguments,
+      cwd: cwdOneHandlerInSrcLambdas,
+    });
+  
+//    console.log('issues', issues);
+    
+    assert.partialDeepStrictEqual(issues, {
+        unlisted: {
+            "sst.config.ts": {
+                dependencyFromConfig: {} // an example dependency listed in the config
+            },
+            "src/stacks/my-stack.ts": {
+                dependencyFromStack: {} // an example dependency listed in the stack
+            },
+            "src/lambdas/my-handler.ts": {
+                dependencyFromHandler: {} // an example dependency listed in the handler
+            }
+        }
+    });
+  });


### PR DESCRIPTION
Added a v1 sst plugin.

Loads lambda handlers from:
/handlers/*
/lambdas/*
/src/handlers/*
/src/lambdas/*

Work left for a v2 plugin to read the sst lambda setup and explicitly load the lambda handlers as entry points