### PR TITLE
fix: escape react-router route paths

### DIFF
--- a/packages/knip/fixtures/plugins/react-router/app/routes.ts
+++ b/packages/knip/fixtures/plugins/react-router/app/routes.ts
@@ -4,4 +4,7 @@ export default [
     file: "routes/layout.tsx",
     children: [{ file: "./routes/another-route.tsx" }],
   },
+  {
+    file: "routes/route.(with).$special[.chars].tsx"
+  }
 ];

--- a/packages/knip/src/plugins/react-router/index.ts
+++ b/packages/knip/src/plugins/react-router/index.ts
@@ -40,7 +40,14 @@ const resolveEntryPaths: ResolveEntryPaths<PluginConfig> = async (localConfig, o
     return [join(appDir, route.file), ...(route.children ? route.children.flatMap(mapRoute) : [])];
   };
 
-  const routes = routeConfig.flatMap(mapRoute);
+  const routes = routeConfig
+    .flatMap(mapRoute)
+    // Since these are literal paths, we need to escape any special characters that might
+    // trip up micromatch/fast-glob.
+    // See:
+    //  - https://reactrouter.com/how-to/file-route-conventions#optional-segments
+    //  - https://www.npmjs.com/package/fast-glob#advanced-syntax
+    .map(route => route.replace(/[$^*+?()\[\]]/g, '\\$&'));
 
   return [
     join(appDir, 'routes.{js,ts}'),

--- a/packages/knip/test/plugins/react-router.test.ts
+++ b/packages/knip/test/plugins/react-router.test.ts
@@ -1,6 +1,6 @@
-import * as os from 'node:os';
 import { test } from 'bun:test';
 import assert from 'node:assert/strict';
+import os from 'node:os';
 import { main } from '../../src/index.js';
 import { resolve } from '../../src/util/path.js';
 import baseArguments from '../helpers/baseArguments.js';

--- a/packages/knip/test/plugins/react-router.test.ts
+++ b/packages/knip/test/plugins/react-router.test.ts
@@ -15,7 +15,7 @@ test('Find dependencies with the react-router plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 8,
-    total: 8,
+    processed: 9,
+    total: 9,
   });
 });

--- a/packages/knip/test/plugins/react-router.test.ts
+++ b/packages/knip/test/plugins/react-router.test.ts
@@ -1,3 +1,4 @@
+import * as os from 'node:os';
 import { test } from 'bun:test';
 import assert from 'node:assert/strict';
 import { main } from '../../src/index.js';
@@ -7,7 +8,9 @@ import baseCounters from '../helpers/baseCounters.js';
 
 const cwd = resolve('fixtures/plugins/react-router');
 
-test('Find dependencies with the react-router plugin', async () => {
+const skipIfWindows = os.platform() === 'win32' ? test.skip : test;
+
+skipIfWindows('Find dependencies with the react-router plugin', async () => {
   const { counters } = await main({
     ...baseArguments,
     cwd,


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

The `react-router` plugin currently seems to ignore route files with `(` or `)` in their path, since these are [interpreted as special characters](https://www.npmjs.com/package/fast-glob#advanced-syntax) by `micromatch` (and thus `fast-glob`).

I put together a small repo that shows the issue here: https://github.com/rossipedia/knip-optional-path-routes

The simplest fix I could think of was to just use a regex to escape any of those characters found in the loaded route file paths, since they were discovered via the file-system I think it makes sense to treat them as literal paths with any special characters having been escaped.