### PR TITLE
Allow for windows cmd commands

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -48,6 +48,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'chown',
   'chmod',
   'cksum',
+  'cmd',
   'comm',
   'command',
   'corepack',


### PR DESCRIPTION
This changes allows for functions like these ones without getting an error:

```json
{
  "clean": "bun run clean:win || bun run clean:lin",
  "clean:win": "node -e \"process.exit(process.platform === 'win32' ? 0 : 1)\" && cmd /c del /Q dockstatapi.db* && echo 'success'",
  "clean:lin": "node -e \"process.exit(process.platform !== 'win32' ? 0 : 1)\" && rm -f dockstatapi.db* && echo 'success'"
}
```

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
