### PR TITLE
Use codeclimate-types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "@knip/root",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
+        "codeclimate-types": "^0.3.1",
         "installed-check": "^9.3.0",
       },
     },
@@ -703,6 +704,8 @@
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "codeclimate-types": ["codeclimate-types@0.3.1", "", {}, "sha512-JCAaPG3tAYlVQQE9NP5kgsXBxPfSmflUI7manmbllUd9TN+1p/SXZkOsMAlPXCp3gcqNVL0itxMjcgKF0nBmJg=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
       "name": "@knip/root",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "codeclimate-types": "^0.3.1",
         "installed-check": "^9.3.0",
       },
     },
@@ -77,6 +76,7 @@
         "@types/picomatch": "3.0.1",
         "@types/webpack": "^5.28.5",
         "@wdio/types": "^9.5.0",
+        "codeclimate-types": "^0.3.1",
         "glob": "^10.4.2",
         "release-it": "^19.0.0-next.1",
         "type-fest": "^4.31.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "codeclimate-types": "^0.3.1",
     "installed-check": "^9.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "codeclimate-types": "^0.3.1",
     "installed-check": "^9.3.0"
   }
 }

--- a/packages/knip/package.json
+++ b/packages/knip/package.json
@@ -89,6 +89,7 @@
     "@types/picomatch": "3.0.1",
     "@types/webpack": "^5.28.5",
     "@wdio/types": "^9.5.0",
+    "codeclimate-types": "^0.3.1",
     "glob": "^10.4.2",
     "release-it": "^19.0.0-next.1",
     "type-fest": "^4.31.0",

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate.test.ts
@@ -15,7 +15,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exports',
       description: 'unusedNumber',
       categories: ['Bug Risk'],
-      location: { path: 'my-module.ts', positions: { begin: { line: 23, column: 14 } } },
+      location: { path: 'my-module.ts', positions: { begin: { line: 23, column: 14 }, end: { line: 23, column: 14 } } },
       severity: 'major',
     },
     {
@@ -23,7 +23,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exports',
       description: 'unusedFunction',
       categories: ['Bug Risk'],
-      location: { path: 'my-module.ts', positions: { begin: { line: 24, column: 14 } } },
+      location: { path: 'my-module.ts', positions: { begin: { line: 24, column: 14 }, end: { line: 24, column: 14 } } },
       severity: 'major',
     },
     {
@@ -31,7 +31,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exports',
       description: 'default',
       categories: ['Bug Risk'],
-      location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 8 } } },
+      location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 8 }, end: { line: 30, column: 8 } } },
       severity: 'major',
     },
     {
@@ -39,7 +39,10 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exports',
       description: 'renamedExport',
       categories: ['Bug Risk'],
-      location: { path: 'named-exports.ts', positions: { begin: { line: 6, column: 30 } } },
+      location: {
+        path: 'named-exports.ts',
+        positions: { begin: { line: 6, column: 30 }, end: { line: 6, column: 30 } },
+      },
       severity: 'major',
     },
     {
@@ -47,7 +50,10 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exports',
       description: 'namedExport',
       categories: ['Bug Risk'],
-      location: { path: 'named-exports.ts', positions: { begin: { line: 7, column: 15 } } },
+      location: {
+        path: 'named-exports.ts',
+        positions: { begin: { line: 7, column: 15 }, end: { line: 7, column: 15 } },
+      },
       severity: 'major',
     },
     {
@@ -55,7 +61,10 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exports',
       description: 'unusedZero',
       categories: ['Bug Risk'],
-      location: { path: 'dynamic-import.ts', positions: { begin: { line: 3, column: 14 } } },
+      location: {
+        path: 'dynamic-import.ts',
+        positions: { begin: { line: 3, column: 14 }, end: { line: 3, column: 14 } },
+      },
       severity: 'major',
     },
     {
@@ -63,7 +72,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exports',
       description: 'unusedInMix',
       categories: ['Bug Risk'],
-      location: { path: 'my-mix.ts', positions: { begin: { line: 1, column: 14 } } },
+      location: { path: 'my-mix.ts', positions: { begin: { line: 1, column: 14 }, end: { line: 1, column: 14 } } },
       severity: 'major',
     },
     {
@@ -71,7 +80,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exports',
       description: 'NamedExport',
       categories: ['Bug Risk'],
-      location: { path: 'default.ts', positions: { begin: { line: 1, column: 14 } } },
+      location: { path: 'default.ts', positions: { begin: { line: 1, column: 14 }, end: { line: 1, column: 14 } } },
       severity: 'major',
     },
     {
@@ -79,7 +88,10 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exports',
       description: 'nsUnusedKey (MyNamespace)',
       categories: ['Bug Risk'],
-      location: { path: 'my-namespace.ts', positions: { begin: { line: 3, column: 14 } } },
+      location: {
+        path: 'my-namespace.ts',
+        positions: { begin: { line: 3, column: 14 }, end: { line: 3, column: 14 } },
+      },
       severity: 'major',
     },
     {
@@ -87,7 +99,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exported types',
       description: 'MyAnyType',
       categories: ['Bug Risk'],
-      location: { path: 'my-module.ts', positions: { begin: { line: 28, column: 13 } } },
+      location: { path: 'my-module.ts', positions: { begin: { line: 28, column: 13 }, end: { line: 28, column: 13 } } },
       severity: 'major',
     },
     {
@@ -95,7 +107,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exported types',
       description: 'MyEnum',
       categories: ['Bug Risk'],
-      location: { path: 'types.ts', positions: { begin: { line: 3, column: 13 } } },
+      location: { path: 'types.ts', positions: { begin: { line: 3, column: 13 }, end: { line: 3, column: 13 } } },
       severity: 'major',
     },
     {
@@ -103,7 +115,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exported types',
       description: 'MyType',
       categories: ['Bug Risk'],
-      location: { path: 'types.ts', positions: { begin: { line: 8, column: 14 } } },
+      location: { path: 'types.ts', positions: { begin: { line: 8, column: 14 }, end: { line: 8, column: 14 } } },
       severity: 'major',
     },
     {
@@ -111,7 +123,10 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Unused exported types',
       description: 'MyNamespace (MyNamespace)',
       categories: ['Bug Risk'],
-      location: { path: 'my-namespace.ts', positions: { begin: { line: 5, column: 18 } } },
+      location: {
+        path: 'my-namespace.ts',
+        positions: { begin: { line: 5, column: 18 }, end: { line: 5, column: 18 } },
+      },
       severity: 'major',
     },
     {
@@ -119,7 +134,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Duplicate exports',
       description: 'exportedResult',
       categories: ['Duplication'],
-      location: { path: 'my-module.ts', positions: { begin: { line: 26, column: 13 } } },
+      location: { path: 'my-module.ts', positions: { begin: { line: 26, column: 13 }, end: { line: 26, column: 13 } } },
       severity: 'major',
     },
     {
@@ -127,7 +142,7 @@ test('knip --reporter codeclimate (exports & types)', () => {
       check_name: 'Duplicate exports',
       description: 'default',
       categories: ['Duplication'],
-      location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 15 } } },
+      location: { path: 'my-module.ts', positions: { begin: { line: 30, column: 15 }, end: { line: 30, column: 15 } } },
       severity: 'major',
     },
   ];

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate2.test.ts
@@ -39,7 +39,7 @@ test('knip --reporter codeclimate (files, unlisted & unresolved)', () => {
       check_name: 'Unresolved imports',
       description: './unresolved',
       categories: ['Bug Risk'],
-      location: { path: 'src/index.ts', positions: { begin: { line: 8, column: 23 } } },
+      location: { path: 'src/index.ts', positions: { begin: { line: 8, column: 23 }, end: { line: 8, column: 23 } } },
       severity: 'major',
     },
   ];

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate3.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate3.test.ts
@@ -15,7 +15,7 @@ test('knip --reporter codeclimate (enum members)', () => {
       check_name: 'Unused exported enum members',
       description: 'B_Unused (MyEnum)',
       categories: ['Bug Risk'],
-      location: { path: 'members.ts', positions: { begin: { line: 9, column: 3 } } },
+      location: { path: 'members.ts', positions: { begin: { line: 9, column: 3 }, end: { line: 9, column: 3 } } },
       severity: 'major',
     },
     {
@@ -23,7 +23,7 @@ test('knip --reporter codeclimate (enum members)', () => {
       check_name: 'Unused exported enum members',
       description: 'D_Key (MyEnum)',
       categories: ['Bug Risk'],
-      location: { path: 'members.ts', positions: { begin: { line: 11, column: 3 } } },
+      location: { path: 'members.ts', positions: { begin: { line: 11, column: 3 }, end: { line: 11, column: 3 } } },
       severity: 'major',
     },
   ];

--- a/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
+++ b/packages/knip/test/cli/reporter/cli-reporter-codeclimate4.test.ts
@@ -23,7 +23,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       check_name: 'Unused dependencies',
       description: '@tootallnate/once',
       categories: ['Bug Risk'],
-      location: { path: 'package.json', positions: { begin: { line: 8, column: 6 } } },
+      location: { path: 'package.json', positions: { begin: { line: 8, column: 6 }, end: { line: 8, column: 6 } } },
       severity: 'major',
     },
     {
@@ -31,7 +31,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       check_name: 'Unused dependencies',
       description: 'fs-extra',
       categories: ['Bug Risk'],
-      location: { path: 'package.json', positions: { begin: { line: 10, column: 6 } } },
+      location: { path: 'package.json', positions: { begin: { line: 10, column: 6 }, end: { line: 10, column: 6 } } },
       severity: 'major',
     },
     {
@@ -39,7 +39,7 @@ test('knip --reporter codeclimate (dependencies)', () => {
       check_name: 'Unused devDependencies',
       description: 'mocha',
       categories: ['Bug Risk'],
-      location: { path: 'package.json', positions: { begin: { line: 23, column: 6 } } },
+      location: { path: 'package.json', positions: { begin: { line: 23, column: 6 }, end: { line: 23, column: 6 } } },
       severity: 'major',
     },
     {


### PR DESCRIPTION
This replaces the custom CodeClimate types with the `codeclimate-types` package. Reusing existing types is less error prone that maintaining them internally.

This change uncovered that end positions were missing. This doesn’t affect GitLab, which doesn’t use this information (yet), but it might affect other tooling that expects it.

