### PR TITLE
Configure MDX IntelliSense

### DIFF
--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "mdx": {
+    "plugins": ["remark-directive", "remark-frontmatter", "remark-gfm"]
+  }
 }


### PR DESCRIPTION
By default the MDX language server uses `remark-frontmatter` and `remark-gfm`. However, knip uses `remark-directive` as well. This leads to syntax errors in the editor. By explicitly specifying these plugins in `tsconfig.json`, we instruct the language server to load this plugin too, making the syntax errors disappear.
