### PR TITLE
Avoid position to calculate CodeClimate fingerprint

### DIFF
--- a/packages/knip/src/reporters/codeclimate.ts
+++ b/packages/knip/src/reporters/codeclimate.ts
@@ -7,7 +7,7 @@ import { getTitle } from './util.js';
 
 export default async ({ report, issues }: ReporterOptions) => {
   const entries: codeclimate.Issue[] = [];
-  const hashes = new Set<string>()
+  const hashes = new Set<string>();
 
   for (const [type, isReportType] of Object.entries(report) as Entries<Report>) {
     if (!isReportType) {
@@ -109,23 +109,23 @@ function createLocation(filePath: string, line?: number, col?: number): codeclim
 function createFingerprint(filePath: string, message: string, hashes: Set<string>): string {
   const md5 = createHash('md5');
 
-  md5.update(filePath);
+  md5.update(toRelative(filePath));
   md5.update(message);
 
   // Create copy of hash since md5.digest() will finalize it, not allowing us to .update() again
-  let md5Tmp = md5.copy()
-  let hash = md5Tmp.digest('hex')
+  let md5Tmp = md5.copy();
+  let hash = md5Tmp.digest('hex');
 
   while (hashes.has(hash)) {
     // Hash collision. This happens if we encounter the same ESLint message in one file
     // multiple times. Keep generating new hashes until we get a unique one.
-    md5.update(hash)
+    md5.update(hash);
 
-    md5Tmp = md5.copy()
-    hash = md5Tmp.digest('hex')
+    md5Tmp = md5.copy();
+    hash = md5Tmp.digest('hex');
   }
 
-  hashes.add(hash)
+  hashes.add(hash);
 
   return md5.digest('hex');
 }

--- a/packages/knip/src/reporters/codeclimate.ts
+++ b/packages/knip/src/reporters/codeclimate.ts
@@ -7,6 +7,7 @@ import { getTitle } from './util.js';
 
 export default async ({ report, issues }: ReporterOptions) => {
   const entries: codeclimate.Issue[] = [];
+  const hashes = new Set<string>()
 
   for (const [type, isReportType] of Object.entries(report) as Entries<Report>) {
     if (!isReportType) {
@@ -27,7 +28,7 @@ export default async ({ report, issues }: ReporterOptions) => {
             categories: ['Duplication'],
             location: createLocation(filePath, symbol.line, symbol.col),
             severity: convertSeverity(issue.severity),
-            fingerprint: createFingerprint(filePath, symbol.symbol, symbol.pos),
+            fingerprint: createFingerprint(filePath, symbol.symbol, hashes),
           }))
         );
       } else {
@@ -38,7 +39,7 @@ export default async ({ report, issues }: ReporterOptions) => {
           categories: ['Bug Risk'],
           location: createLocation(filePath, issue.line, issue.col),
           severity: convertSeverity(issue.severity),
-          fingerprint: createFingerprint(filePath, issue.symbol, issue.pos),
+          fingerprint: createFingerprint(filePath, issue.symbol, hashes),
         });
       }
     }
@@ -105,12 +106,26 @@ function createLocation(filePath: string, line?: number, col?: number): codeclim
   };
 }
 
-function createFingerprint(filePath: string, message: string, pos?: number): string {
+function createFingerprint(filePath: string, message: string, hashes: Set<string>): string {
   const md5 = createHash('md5');
 
   md5.update(filePath);
   md5.update(message);
-  md5.update(pos?.toString() ?? '');
+
+  // Create copy of hash since md5.digest() will finalize it, not allowing us to .update() again
+  let md5Tmp = md5.copy()
+  let hash = md5Tmp.digest('hex')
+
+  while (hashes.has(hash)) {
+    // Hash collision. This happens if we encounter the same ESLint message in one file
+    // multiple times. Keep generating new hashes until we get a unique one.
+    md5.update(hash)
+
+    md5Tmp = md5.copy()
+    hash = md5Tmp.digest('hex')
+  }
+
+  hashes.add(hash)
 
   return md5.digest('hex');
 }


### PR DESCRIPTION
CodeClimate fingerprints should uniquely identify the issue. The problem with using positional information is that though it adds to the uniqueness, it significantly reduces the identification part.

To clarify, let’s say we have the following file:

```js
// file.js
export function used() {}

export function unused() {}
```

The function `unused` is detected as unused by knip. The hash is calculated from:
- `'/runner/file.js'` (filePath)
- `'unused'` (message)
- `54` (pos)

Let’s say this results in the hash `abc`.

This hash has two problematic factors:
1. It depends on an absolute path, which is system dependant. For example a GitLab users may switch to a different runner or Docker image.
2. If any characters are inserted or deleted before `unused`, the fingerprint changes.

Let’s say the user now makes a change:

```diff
  // file.js
  export function used() {}
+ // Some inserted text

  export function unused() {}
```

The new hash is calculated from:
- `'/runner/file.js'` (filePath)
- `'unused'` (message)
- `76` (pos)

Let’s say this results in the hash `def`.

Now the GitLab merge request  UI will tell the user that the first problem with `hash` is resolved. Also a new problem is introduced with a hash `def`.

By omitting the positional information, the same hash would be preserved, and the GitLab UI will tell the user the merge request didn’t affect the results.

I also added an implementation to ensure hashes are always unique in a single run. This is based on
[eslint-formatter-gitlab#48](https://gitlab.com/remcohaszing/eslint-formatter-gitlab/-/merge_requests/48).

Also noteworthy is that it’s best to avoid changing the fingerprint formula between versions if possible. That would cause GitLab to also declare all previous issues were resolved, but new similar ones are detected.

No tests were modified, because the hashes are explicitly omitted from testing.