### PR TITLE
fix: Fix custom stylelint plugin causes knip crash

### DIFF
--- a/packages/knip/fixtures/plugins/stylelint/.stylelintrc
+++ b/packages/knip/fixtures/plugins/stylelint/.stylelintrc
@@ -10,7 +10,8 @@
       "files": [
         "**/*.html"
       ],
-      "extends": ["stylelint-config-html/html", "stylelint-config-standard"]
+      "extends": ["stylelint-config-html/html", "stylelint-config-standard"],
+      "plugins": ["stylelint-order"]
     }
   ]
 }

--- a/packages/knip/fixtures/plugins/stylelint2/myCustomPlugin.js
+++ b/packages/knip/fixtures/plugins/stylelint2/myCustomPlugin.js
@@ -1,0 +1,1 @@
+export default {}

--- a/packages/knip/fixtures/plugins/stylelint2/stylelint.config.js
+++ b/packages/knip/fixtures/plugins/stylelint2/stylelint.config.js
@@ -1,14 +1,19 @@
 const less = require('postcss-less');
 const stylus = require('postcss-styl');
+const myCustomPlugin = require('./myCustomPlugin');
 
 /** @type {import('stylelint').Config} */
 const config = {
   customSyntax: less,
   extends: [require.resolve('stylelint-config-recommended'), './myExtendableConfig'],
+  plugins: ['./myCustomPlugin.js'],
   rules: {
     'alpha-value-notation': 'number',
   },
   overrides: [
+    {
+      plugins: ['./myCustomPlugin.js', myCustomPlugin],
+    },
     {
       files: ['**/*.html'],
       extends: ['stylelint-config-html/html', 'stylelint-config-standard'],

--- a/packages/knip/src/plugins/stylelint/index.ts
+++ b/packages/knip/src/plugins/stylelint/index.ts
@@ -16,7 +16,7 @@ const config = ['package.json', ...toCosmiconfig('stylelint')];
 
 const resolve = (config: StyleLintConfig | BaseStyleLintConfig): Input[] => {
   const extend = config.extends ?? [];
-  const plugins = config.plugins ?? [];
+  const plugins = config.plugins?.flatMap((plugin) => typeof plugin === 'string' ? [plugin] : []) ?? [];
   const customSyntax: string[] = typeof config.customSyntax === 'string' ? [config.customSyntax] : [];
 
   const overrideConfigs = 'overrides' in config ? config.overrides.flatMap(resolve) : [];

--- a/packages/knip/src/plugins/stylelint/index.ts
+++ b/packages/knip/src/plugins/stylelint/index.ts
@@ -16,7 +16,7 @@ const config = ['package.json', ...toCosmiconfig('stylelint')];
 
 const resolve = (config: StyleLintConfig | BaseStyleLintConfig): Input[] => {
   const extend = config.extends ?? [];
-  const plugins = config.plugins?.flatMap((plugin) => typeof plugin === 'string' ? [plugin] : []) ?? [];
+  const plugins = config.plugins?.flatMap(plugin => (typeof plugin === 'string' ? [plugin] : [])) ?? [];
   const customSyntax: string[] = typeof config.customSyntax === 'string' ? [config.customSyntax] : [];
 
   const overrideConfigs = 'overrides' in config ? config.overrides.flatMap(resolve) : [];

--- a/packages/knip/src/plugins/stylelint/types.ts
+++ b/packages/knip/src/plugins/stylelint/types.ts
@@ -1,7 +1,7 @@
 export type BaseStyleLintConfig = {
   customSyntax?: unknown;
   extends?: string | string[];
-  plugins?: string[];
+  plugins?: unknown[];
 };
 
 export type StyleLintConfig = BaseStyleLintConfig & {

--- a/packages/knip/test/plugins/stylelint2.test.ts
+++ b/packages/knip/test/plugins/stylelint2.test.ts
@@ -15,7 +15,7 @@ test('Find dependencies with the stylelint plugin (2)', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 4,
-    total: 4,
+    processed: 5,
+    total: 5,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

close https://github.com/webpro-nl/knip/issues/963
