### PR TITLE
Mark simple-git-hooks as used dependency when config exists

### DIFF
--- a/packages/knip/src/plugins/simple-git-hooks/index.ts
+++ b/packages/knip/src/plugins/simple-git-hooks/index.ts
@@ -1,5 +1,6 @@
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
 import type { Input } from '../../util/input.js';
+import { toDependency } from '../../util/input.js';
 import { hasDependency } from '../../util/plugin.js';
 import type { SimpleGitHooksConfig } from './types.js';
 
@@ -24,7 +25,7 @@ const resolveConfig: ResolveConfig<SimpleGitHooksConfig> = async (config, option
     for (const id of options.getInputsFromScripts(hook)) inputs.add(id);
   }
 
-  return Array.from(inputs);
+  return [toDependency('simple-git-hooks'), ...Array.from(inputs)];
 };
 
 export default {

--- a/packages/knip/test/plugins/simple-git-hooks.test.ts
+++ b/packages/knip/test/plugins/simple-git-hooks.test.ts
@@ -15,12 +15,11 @@ test('Find dependencies with the simple-git-hooks plugin', async () => {
 
   assert(issues.binaries['package.json']['eslint']);
   assert(issues.binaries['package.json']['lint-staged']);
-  assert(issues.devDependencies['package.json']['simple-git-hooks']);
   assert(issues.devDependencies['package.json']['lint-staged']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 2,
-    devDependencies: 2,
+    devDependencies: 1,
   });
 });


### PR DESCRIPTION
Hello!

I get an error when using knip:

```
Unused devDependencies (1)
simple-git-hooks  package.json:66:6
```

The plugin does not seem to be working correctly at the moment. This PR marks the simple-git-hooks dependency as used when the config exists.

