### PR TITLE
Add 'instrumentation-client' to next plugin entry points

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -16,7 +16,7 @@ const config = ['next.config.{js,ts,cjs,mjs}'];
 const defaultPageExtensions = ['{js,jsx,ts,tsx}'];
 
 const productionEntryFilePatterns = [
-  '{instrumentation,middleware}.{js,ts}',
+  '{instrumentation,instrumentation-client,middleware}.{js,ts}',
   'app/global-error.{js,jsx,ts,tsx}',
   'app/**/{error,layout,loading,not-found,page,template,default}.{js,jsx,ts,tsx}',
   'app/**/route.{js,jsx,ts,tsx}',


### PR DESCRIPTION
In version v15.3, Next.js introduced a new [Client Instrumentation Hook](https://nextjs.org/blog/next-15-3#client-instrumentation-hook) instrumentation-client.js|ts. I reported this change in #1034.

This PR closes #1034.