### PR TITLE
Mark mdx-components as an entry file for Next.js

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -23,6 +23,7 @@ const productionEntryFilePatterns = [
   'app/{manifest,sitemap,robots}.{js,ts}',
   'app/**/{icon,apple-icon}.{js,jsx,ts,tsx}',
   'app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}',
+  'mdx-components.{js,jsx,ts,tsx}',
 ];
 
 const getEntryFilePatterns = (pageExtensions = defaultPageExtensions) => {


### PR DESCRIPTION
When using `@next/mdx`, the user must define a module named `mdx-components`.
