### PR TITLE
Mark tanstack-router entries as production

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "npm.packageManager": "bun",
   "[javascript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },

--- a/packages/knip/src/plugins/tanstack-router/index.ts
+++ b/packages/knip/src/plugins/tanstack-router/index.ts
@@ -1,5 +1,5 @@
 import type { IsPluginEnabled, Plugin, ResolveEntryPaths, ResolveFromAST } from '../../types/config.js';
-import { toEntry } from '../../util/input.js';
+import { toProductionEntry } from '../../util/input.js';
 import { extname, join } from '../../util/path.js';
 import { hasDependency } from '../../util/plugin.js';
 import { getCustomConfig } from './resolveFromAST.js';
@@ -25,12 +25,12 @@ const production = ['./src/routeTree.gen.ts', './src/routes/**/*.{ts,tsx}', '!sr
 const getEntryPatterns = (config: TanstackRouterConfig) => {
   const dir = config.routesDirectory ?? 'src/routes';
   const entries = [
-    toEntry(join(config.generatedRouteTree ?? './src/routeTree.gen.ts')),
-    toEntry(join(dir, '**', `${config.routeFilePrefix ?? ''}*`)),
-    toEntry(join(`!${dir}`, '**', `${config.routeFileIgnorePrefix ?? '-'}*`)),
+    toProductionEntry(join(config.generatedRouteTree ?? './src/routeTree.gen.ts')),
+    toProductionEntry(join(dir, '**', `${config.routeFilePrefix ?? ''}*`)),
+    toProductionEntry(join(`!${dir}`, '**', `${config.routeFileIgnorePrefix ?? '-'}*`)),
   ];
   if (config.routeFileIgnorePattern) {
-    entries.push(toEntry(join(`!${dir}`, '**', `*${config.routeFileIgnorePattern}*`)));
+    entries.push(toProductionEntry(join(`!${dir}`, '**', `*${config.routeFileIgnorePattern}*`)));
   }
   return entries;
 };

--- a/packages/knip/test/plugins/tanstack-router.test.ts
+++ b/packages/knip/test/plugins/tanstack-router.test.ts
@@ -11,6 +11,7 @@ test('Find dependencies with the tanstack-router plugin', async () => {
   const { issues, counters } = await main({
     ...baseArguments,
     cwd,
+    isProduction: true,
   });
 
   assert(issues.files.has(join(cwd, 'routes/-unused.ts')));
@@ -18,7 +19,8 @@ test('Find dependencies with the tanstack-router plugin', async () => {
   assert.deepEqual(counters, {
     ...baseCounters,
     files: 1,
-    processed: 6,
-    total: 6,
+    processed: 5,
+    total: 5,
+    dependencies: 3,
   });
 });


### PR DESCRIPTION
Following discord discussion: https://discord.com/channels/1143209786612125696/1143209787140620310/threads/1364557464711856148

The new `tanstack-router` plugin automatically adds new entry files. As far as I can tell, all those files should be considered "production entries" (none of them are test, config, storybook, ...)



<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
