### PR TITLE
Mark commitlint/cli as used dependency when config exists

### DIFF
--- a/packages/knip/src/plugins/commitlint/index.ts
+++ b/packages/knip/src/plugins/commitlint/index.ts
@@ -32,7 +32,9 @@ const resolveConfig: ResolveConfig<CommitLintConfig> = async config => {
         ? [parserPreset.path ?? parserPreset]
         : []
     : [];
-  return [...extendsConfigs, ...plugins, ...formatter, ...parserPresetPaths].map(id => toDependency(id));
+  return ['@commitlint/cli', ...extendsConfigs, ...plugins, ...formatter, ...parserPresetPaths].map(id =>
+    toDependency(id)
+  );
 };
 
 export default {

--- a/packages/knip/test/plugins/commitlint.test.ts
+++ b/packages/knip/test/plugins/commitlint.test.ts
@@ -27,7 +27,7 @@ test('Find dependencies with the Commitizen plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    devDependencies: 1,
+    devDependencies: 0,
     unlisted: 9,
     processed: 1,
     total: 1,


### PR DESCRIPTION
When using Knip with a `.commitlintrc` or `.commitlintrc.json` configuration file, it incorrectly reports `@commitlint/cli` as an unused dependency, despite the presence of a valid configuration file.

The issue occurs because Knip establishes a connection between configuration files and plugin names rather than directly with the package names listed in enablers.

For most plugins like `stylelint` and `prettier`, this works fine because:

1. The plugin name matches the actual NPM package name
2. The configuration file gets properly associated with the package

However, for commitlint there's a mismatch:

1. The plugin name is `commitlint`
2. The actual package name is `@commitlint/cli`

When Knip finds a `.commitlintrc` file, it correctly identifies it as a configuration for the `commitlint` plugin but fails to mark `@commitlint/cli` as used because it cannot establish the relationship between the plugin name and the scoped package name.