### PR TITLE
Support size-limit plugins usage

### DIFF
--- a/packages/knip/fixtures/plugins/size-limit/package.json
+++ b/packages/knip/fixtures/plugins/size-limit/package.json
@@ -4,6 +4,10 @@
     "size": "size-limit"
   },
   "dependencies": {
-    "size-limit": "*"
+    "size-limit": "*",
+    "@size-limit/preset-app": "*"
+  },
+  "devDependencies": {
+    "@size-limit/file": "*"
   }
 }

--- a/packages/knip/src/plugins/size-limit/index.ts
+++ b/packages/knip/src/plugins/size-limit/index.ts
@@ -1,4 +1,5 @@
-import type { IsPluginEnabled, Plugin } from '../../types/config.js';
+import type { IsPluginEnabled, Plugin, Resolve } from '../../types/config.js';
+import { toDependency } from '../../util/input.js';
 import { toLilconfig } from '../../util/plugin-config.js';
 import { hasDependency } from '../../util/plugin.js';
 
@@ -17,9 +18,21 @@ const config = [
   ...toLilconfig('size-limit', { configDir: false, additionalExtensions: ['ts', 'mts', 'cts'], rcSuffix: '' }),
 ];
 
+const resolve: Resolve = options => {
+  const allDeps = [
+    ...Object.keys(options.manifest.dependencies || {}),
+    ...Object.keys(options.manifest.devDependencies || {}),
+  ];
+
+  const sizeLimitDeps = allDeps.filter(dep => dep.startsWith('@size-limit/'));
+
+  return sizeLimitDeps.map(dep => toDependency(dep));
+};
+
 export default {
   title,
   enablers,
   isEnabled,
   config,
+  resolve,
 } satisfies Plugin;


### PR DESCRIPTION
I use size-limit with `@size-limit/file` plugin.

Here is my `.size-limit.json`:

```json
[
  {
    "name": "Home Page",
    "path": [
      "dist/en.html",
      "dist/_astro/*.js",
      "!dist/_astro/BlogShare.*.js",
      "!dist/_astro/TimelineData.*.js",
      "!dist/_astro/BlogShare.*.js"
    ],
    "limit": "40 kB",
    "brotli": true
  },
  {
    "name": "All Scripts",
    "path": ["dist/**/*.js"],
    "limit": "35 kB",
    "brotli": true
  }
]
```

At this moment there is an error about size-limit usage:

```
Unused devDependencies
@size-limit/file  package.json:62:6
```

In this PR I added a `resolve` function that automatically detects and marks all dependencies starting with `@size-limit/` as used.
