### PR TITLE
Support custom srcDir in Astro plugin

### DIFF
--- a/packages/knip/src/plugins/astro/index.ts
+++ b/packages/knip/src/plugins/astro/index.ts
@@ -1,6 +1,6 @@
 import type { IsPluginEnabled, Plugin, Resolve, ResolveConfig, ResolveEntryPaths } from '../../types/config.js';
 import { toDependency, toEntry, toProductionEntry } from '../../util/input.js';
-import { hasDependency, load } from '../../util/plugin.js';
+import { hasDependency } from '../../util/plugin.js';
 
 // https://docs.astro.build/en/reference/configuration-reference/
 
@@ -12,18 +12,14 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 
 export const config = ['astro.config.{js,cjs,mjs,ts,mts}'];
 
-const resolveEntryPaths: ResolveEntryPaths = async (_, options) => {
-  const { configFilePath } = options;
-  const astroConfig = await load(configFilePath);
-  const srcDir = astroConfig?.srcDir ?? 'src';
+const resolveEntryPaths: ResolveEntryPaths = async config => {
+  const srcDir = config?.srcDir ?? 'src';
 
   return [`${srcDir}/content/config.ts`, `${srcDir}/content.config.ts`].map(path => toEntry(path));
 };
 
-const resolveConfig: ResolveConfig = async (_, options) => {
-  const { configFilePath } = options;
-  const astroConfig = await load(configFilePath);
-  const srcDir = astroConfig?.srcDir ?? 'src';
+const resolveConfig: ResolveConfig = async config => {
+  const srcDir = config?.srcDir ?? 'src';
 
   return [
     `${srcDir}/pages/**/*.{astro,mdx,js,ts}`,

--- a/packages/knip/src/plugins/astro/index.ts
+++ b/packages/knip/src/plugins/astro/index.ts
@@ -13,6 +13,15 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 
 export const config = ['astro.config.{js,cjs,mjs,ts,mts}'];
 
+const entry = ['src/content/config.ts', 'src/content.config.ts'];
+
+const production = [
+  'src/pages/**/*.{astro,mdx,js,ts}',
+  'src/content/**/*.mdx',
+  'src/middleware.{js,ts}',
+  'src/actions/index.{js,ts}',
+];
+
 const resolveFromAST: ResolveFromAST = sourceFile => {
   const srcDir = getSrcDir(sourceFile);
 
@@ -48,6 +57,8 @@ export default {
   enablers,
   isEnabled,
   config,
+  entry,
+  production,
   resolveFromAST,
   resolve,
 } satisfies Plugin;

--- a/packages/knip/src/plugins/astro/index.ts
+++ b/packages/knip/src/plugins/astro/index.ts
@@ -1,5 +1,5 @@
-import type { IsPluginEnabled, Plugin, Resolve, ResolveConfig, ResolveEntryPaths } from '../../types/config.js';
-import { toDependency, toEntry, toProductionEntry } from '../../util/input.js';
+import type { IsPluginEnabled, Plugin, Resolve, ResolveEntryPaths } from '../../types/config.js';
+import { toDependency, toEntry } from '../../util/input.js';
 import { hasDependency } from '../../util/plugin.js';
 
 // https://docs.astro.build/en/reference/configuration-reference/
@@ -13,20 +13,16 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 export const config = ['astro.config.{js,cjs,mjs,ts,mts}'];
 
 const resolveEntryPaths: ResolveEntryPaths = async config => {
-  const srcDir = config?.srcDir ?? 'src';
-
-  return [`${srcDir}/content/config.ts`, `${srcDir}/content.config.ts`].map(path => toEntry(path));
-};
-
-const resolveConfig: ResolveConfig = async config => {
-  const srcDir = config?.srcDir ?? 'src';
+  const srcDir = config?.srcDir ?? './src';
 
   return [
-    `${srcDir}/pages/**/*.{astro,mdx,js,ts}`,
+    `${srcDir}/content/config.ts`,
+    `${srcDir}/content.config.ts`,
     `${srcDir}/content/**/*.mdx`,
+    `${srcDir}/pages/**/*.{astro,mdx,js,ts}`,
     `${srcDir}/middleware.{js,ts}`,
     `${srcDir}/actions/index.{js,ts}`,
-  ].map(path => toProductionEntry(path));
+  ].map(path => toEntry(path));
 };
 
 const resolve: Resolve = options => {
@@ -50,6 +46,5 @@ export default {
   isEnabled,
   config,
   resolveEntryPaths,
-  resolveConfig,
   resolve,
 } satisfies Plugin;

--- a/packages/knip/src/plugins/astro/resolveFromAST.ts
+++ b/packages/knip/src/plugins/astro/resolveFromAST.ts
@@ -2,20 +2,29 @@ import ts from 'typescript';
 import { getPropertyValues } from '../../typescript/ast-helpers.js';
 
 export const getSrcDir = (sourceFile: ts.SourceFile): string => {
-  let srcDir = 'src';
+  const srcDir = 'src';
 
   function visit(node: ts.Node) {
     if (ts.isObjectLiteralExpression(node)) {
       const values = getPropertyValues(node, 'srcDir');
       if (values.size > 0) {
-        srcDir = Array.from(values)[0];
+        return Array.from(values)[0];
       }
     }
 
-    ts.forEachChild(node, visit);
+    let result: string | undefined;
+    ts.forEachChild(node, innerNode => {
+      const innerValue = visit(innerNode);
+      if (innerValue) {
+        result = innerValue;
+        return true; // Break the iteration
+      }
+      return false;
+    });
+
+    return result;
   }
 
-  visit(sourceFile);
-
-  return srcDir;
+  const foundValue = visit(sourceFile);
+  return foundValue ?? srcDir;
 };

--- a/packages/knip/src/plugins/astro/resolveFromAST.ts
+++ b/packages/knip/src/plugins/astro/resolveFromAST.ts
@@ -1,0 +1,21 @@
+import ts from 'typescript';
+import { getPropertyValues } from '../../typescript/ast-helpers.js';
+
+export const getSrcDir = (sourceFile: ts.SourceFile): string => {
+  let srcDir = 'src';
+
+  function visit(node: ts.Node) {
+    if (ts.isObjectLiteralExpression(node)) {
+      const values = getPropertyValues(node, 'srcDir');
+      if (values.size > 0) {
+        srcDir = Array.from(values)[0];
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return srcDir;
+};


### PR DESCRIPTION
The Astro plugin currently uses hardcoded paths that start with `src/`, but Astro's configuration allows changing the `srcDir` setting (default is `'src'`). This causes incorrect path resolution and "Unresolved imports" errors when users configure a custom source directory in their `astro.config.js/ts`.

Example:
https://github.com/azat-io/azat-io/blob/main/astro.config.ts#L130

This PR enhances the Astro plugin to dynamically read the Astro configuration and respect the `srcDir` setting.