### PR TITLE
(PostCSS plugin): Add postcss to used dependencies when using `@tailwindcss/postcss` plugin

### DIFF
--- a/packages/knip/fixtures/plugins/postcss-tailwindcss2/node_modules/postcss/package.json
+++ b/packages/knip/fixtures/plugins/postcss-tailwindcss2/node_modules/postcss/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "postcss",
+  "bin": "cli.js"
+}

--- a/packages/knip/fixtures/plugins/postcss-tailwindcss2/node_modules/tailwindcss/package.json
+++ b/packages/knip/fixtures/plugins/postcss-tailwindcss2/node_modules/tailwindcss/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "tailwindcss"
+}

--- a/packages/knip/fixtures/plugins/postcss-tailwindcss2/package.json
+++ b/packages/knip/fixtures/plugins/postcss-tailwindcss2/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/postcss-tailwindcss2",
+  "devDependencies": {
+    "postcss": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/postcss-tailwindcss2/postcss.config.mjs
+++ b/packages/knip/fixtures/plugins/postcss-tailwindcss2/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+  plugins: ['@tailwindcss/postcss'],
+};
+
+export default config;

--- a/packages/knip/src/plugins/postcss/index.ts
+++ b/packages/knip/src/plugins/postcss/index.ts
@@ -31,7 +31,9 @@ const resolveConfig: ResolveConfig<PostCSSConfig> = config => {
   const inputs = plugins.map(toDeferResolve);
 
   // Because postcss is not included in peerDependencies of tailwindcss
-  return plugins.includes('tailwindcss') ? [...inputs, toDependency('postcss')] : inputs;
+  return ['tailwindcss', '@tailwindcss/postcss'].some(tailwindPlugin => plugins.includes(tailwindPlugin))
+    ? [...inputs, toDependency('postcss')]
+    : inputs;
 };
 
 export default {

--- a/packages/knip/test/plugins/postcss-tailwindcss2.test.ts
+++ b/packages/knip/test/plugins/postcss-tailwindcss2.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/plugins/postcss-tailwindcss2');
+
+test('Find dependencies with the PostCSS plugin (with @tailwindcss/postcss)', async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert(issues.unresolved['postcss.config.mjs']['@tailwindcss/postcss']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    unresolved: 1,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
Tailwind v4 [docs](https://tailwindcss.com/docs/installation/using-postcss) recommend using the `@tailwindcss/postcss` plugin, but the current code only handles the `tailwindcss` plugin. The following changes add support for both plugins.

This PR is heavily based on #764.