### PR TITLE
Fix add aliases crashing on obj

### DIFF
--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -89,7 +89,7 @@ export const resolveConfig: ResolveConfig<ViteConfigOrFn | VitestWorkspaceConfig
   const addAliases = (aliasOptions: AliasOptions) => {
     for (const [alias, value] of Object.entries(aliasOptions)) {
       if (!value) continue;
-      const prefixes = [value].flat().map(prefix => {
+      const prefixes = [value].flat().filter((value) => typeof value === 'string').map(prefix => {
         if (toPosix(prefix).startsWith(options.cwd)) return prefix;
         return join(options.cwd, prefix);
       });


### PR DESCRIPTION
Latest version started failing with:

```bash
export const toPosix = (value) => value.split(path.sep).join(path.posix.sep);

TypeError: value.split is not a function
    at toPosix (<my-repo>/node_modules/knip/dist/util/path.js:9:41)
    at <my-repo>/node_modules/knip/dist/plugins/vitest/index.js:93:13
    at Array.map (<anonymous>)
    at addAliases (<my-repo>/node_modules/knip/dist/plugins/vitest/index.js:91:39)
    at Object.resolveConfig (<my-repo>/node_modules/knip/dist/plugins/vitest/index.js:112:29)
    at async runPlugin (<my-repo>/node_modules/knip/dist/WorkspaceWorker.js:273:40)
    at async WorkspaceWorker.runPlugins (<my-repo>/node_modules/knip/dist/WorkspaceWorker.js:314:13)
    at async build (<my-repo>/node_modules/knip/dist/graph/build.js:94:35)
    at async main (<my-repo>/node_modules/knip/dist/index.js:43:88)
    at async run (<my-repo>/node_modules/knip/dist/cli.js:26:111)
```

I assume it's related to changes in https://github.com/webpro-nl/knip/compare/5.53.0...5.54.0#diff-725483cb0aae8ce3078066bffc472cc6bfe94e7c9ab170b8f54f9d700caf55f1R111-R114

The flat map on object entries (`for (const [alias, value] of Object.entries(aliasOptions)) {`) seems to cast `prefix` as any (which is why TS wouldn't catch it, and the function only handles strings, no `Alias` objects (see `AliasOptions` in `types.ts`.

I didn't dive too deep on the repo, just wanted to provide a quick fix to the crash by filtering out strings in the `addAliases` method.