### PR TITLE
Add Hardhat plugin

### DIFF
--- a/packages/knip/fixtures/plugins/hardhat/hardhat.config.ts
+++ b/packages/knip/fixtures/plugins/hardhat/hardhat.config.ts
@@ -1,0 +1,3 @@
+const config = {};
+
+export default config;

--- a/packages/knip/fixtures/plugins/hardhat/package.json
+++ b/packages/knip/fixtures/plugins/hardhat/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/hardhat",
+  "dependencies": {
+    "hardhat": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/hardhat/package.json
+++ b/packages/knip/fixtures/plugins/hardhat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixtures/hardhat",
-  "dependencies": {
+  "devDependencies": {
     "hardhat": "*"
   }
 }

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -399,6 +399,10 @@
           "title": "graphql-codegen plugin configuration (https://knip.dev/reference/plugins/graphql-codegen)",
           "$ref": "#/definitions/plugin"
         },
+        "hardhat": {
+          "title": "hardhat plugin configuration (https://knip.dev/reference/plugins/hardhat)",
+          "$ref": "#/definitions/plugin"
+        },
         "husky": {
           "title": "husky plugin configuration (https://knip.dev/reference/plugins/husky)",
           "$ref": "#/definitions/plugin"

--- a/packages/knip/src/plugins/hardhat/index.ts
+++ b/packages/knip/src/plugins/hardhat/index.ts
@@ -1,5 +1,5 @@
-import { toDependency } from '../../util/input.js';
 import type { IsPluginEnabled, Plugin, Resolve } from '../../types/config.js';
+import { toDependency } from '../../util/input.js';
 import { hasDependency } from '../../util/plugin.js';
 
 // https://hardhat.org/docs

--- a/packages/knip/src/plugins/hardhat/index.ts
+++ b/packages/knip/src/plugins/hardhat/index.ts
@@ -14,7 +14,7 @@ const entry: string[] = ['hardhat.config.{js,cjs,mjs,ts}'];
 
 const resolve: Resolve = async () => {
   return [toDependency('hardhat')];
-}
+};
 
 export default {
   title,

--- a/packages/knip/src/plugins/hardhat/index.ts
+++ b/packages/knip/src/plugins/hardhat/index.ts
@@ -1,0 +1,25 @@
+import { toDependency } from 'src/util/input.js';
+import type { IsPluginEnabled, Plugin, Resolve } from '../../types/config.js';
+import { hasDependency } from '../../util/plugin.js';
+
+// https://hardhat.org/docs
+
+const title = 'Hardhat';
+
+const enablers = ['hardhat'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+
+const entry: string[] = ['hardhat.config.{js,cjs,mjs,ts}'];
+
+const resolve: Resolve = async () => {
+  return [toDependency('hardhat')];
+}
+
+export default {
+  title,
+  enablers,
+  isEnabled,
+  entry,
+  resolve,
+} satisfies Plugin;

--- a/packages/knip/src/plugins/hardhat/index.ts
+++ b/packages/knip/src/plugins/hardhat/index.ts
@@ -1,4 +1,4 @@
-import { toDependency } from 'src/util/input.js';
+import { toDependency } from '../../util/input.js';
 import type { IsPluginEnabled, Plugin, Resolve } from '../../types/config.js';
 import { hasDependency } from '../../util/plugin.js';
 

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -25,6 +25,7 @@ import { default as githubAction } from './github-action/index.js';
 import { default as githubActions } from './github-actions/index.js';
 import { default as glob } from './glob/index.js';
 import { default as graphqlCodegen } from './graphql-codegen/index.js';
+import { default as hardhat } from './hardhat/index.js';
 import { default as husky } from './husky/index.js';
 import { default as i18nextParser } from './i18next-parser/index.js';
 import { default as jest } from './jest/index.js';
@@ -130,6 +131,7 @@ export const Plugins = {
   'github-actions': githubActions,
   glob,
   'graphql-codegen': graphqlCodegen,
+  hardhat,
   husky,
   'i18next-parser': i18nextParser,
   jest,

--- a/packages/knip/src/schema/plugins.ts
+++ b/packages/knip/src/schema/plugins.ts
@@ -39,6 +39,7 @@ export const pluginsSchema = z.object({
   'github-actions': pluginSchema,
   glob: pluginSchema,
   'graphql-codegen': pluginSchema,
+  hardhat: pluginSchema,
   husky: pluginSchema,
   'i18next-parser': pluginSchema,
   jest: pluginSchema,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -26,6 +26,7 @@ export type PluginName =
   | 'github-actions'
   | 'glob'
   | 'graphql-codegen'
+  | 'hardhat'
   | 'husky'
   | 'i18next-parser'
   | 'jest'
@@ -131,6 +132,7 @@ export const pluginNames = [
   'github-actions',
   'glob',
   'graphql-codegen',
+  'hardhat',
   'husky',
   'i18next-parser',
   'jest',

--- a/packages/knip/test/plugins/hardhat.test.ts
+++ b/packages/knip/test/plugins/hardhat.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/plugins/hardhat');
+
+test('Find dependencies with the Hardhat plugin', async () => {
+  const { counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
Hardhat is a CLI tool that relies on the presence of a JS config file.  The `hardhat` package may or may not be imported.

This plugin is meant to do two things:
1. Add `hardhat.config.x` as an entry.
2. Skip warnings if `hardhat` is not imported anywhere.

Is the implementation correct?  I'm not sure about the `resolve` function.