### PR TITLE
Fixes for Mocha plugin

### DIFF
--- a/packages/knip/fixtures/plugins/mocha/.mocharc.json
+++ b/packages/knip/fixtures/plugins/mocha/.mocharc.json
@@ -1,4 +1,4 @@
 {
-  "extension": ["ts"],
-  "require": "ts-node/register"
+  "spec": ["**/*.test.ts"],
+  "require": ["ts-node/register", "hooks.ts"]
 }

--- a/packages/knip/fixtures/plugins/mocha/.mocharc.yml
+++ b/packages/knip/fixtures/plugins/mocha/.mocharc.yml
@@ -1,3 +1,5 @@
-extension:
-  - ts
-require: ts-node/register
+spec:
+  - "**/*.test.ts"
+require:
+  - ts-node/register
+  - hooks.ts

--- a/packages/knip/fixtures/plugins/mocha/example.test.ts
+++ b/packages/knip/fixtures/plugins/mocha/example.test.ts
@@ -1,0 +1,1 @@
+describe('Tests', () => {});

--- a/packages/knip/fixtures/plugins/mocha/hooks.ts
+++ b/packages/knip/fixtures/plugins/mocha/hooks.ts
@@ -1,0 +1,3 @@
+export const mochaHooks = {
+  beforeAll: () => {},
+};

--- a/packages/knip/fixtures/plugins/mocha/package.json
+++ b/packages/knip/fixtures/plugins/mocha/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@fixtures/mocha",
   "mocha": {
-    "extension": ["ts"],
-    "require": "ts-node/register"
+    "spec": ["**/*.test.ts"],
+    "require": ["ts-node/register", "hooks.ts"]
+  },
+  "devDependencies": {
+    "@types/mocha": "*",
+    "mocha": "*",
+    "ts-node": "*"
   }
 }

--- a/packages/knip/test/plugins/mocha.test.ts
+++ b/packages/knip/test/plugins/mocha.test.ts
@@ -15,7 +15,7 @@ test('Find dependencies with the Mocha plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 0,
-    total: 0,
+    processed: 2,
+    total: 2,
   });
 });


### PR DESCRIPTION
The `mocha` plugin has the following issues:

* Relies on presence of an explicit *require* or *import* of `mocha` in source code, but Mocha does not.
* Does not recognize dependencies (e.g. `ts-node/register` or `dotenv/config`) in the `requires` configuration field.

The `mocha` test has the following issues:

* `isEnabled` returns *false* since the fixture *package.json* dependencies do not include `mocha`; so it does not actually test the plugin
* fixture config has `extension` , which plugin does not support, and does not have `spec` which the plugin does support

This PR addresses:

* `isEnabled` will return true if default Mocha config file is present.
* `resolveConfig` adds `mocha` dependency
* `resolveConfig` supports both entries and dependencies from the `require` field
* test fixture is updated to:
  * use `spec` instead of `extension`
  * include the `mocha`, `@types/mocha`, and `ts-node` dependencies in _package.json_ 
  * include both file and dependency values for `require`