### PR TITLE
Remove `baseUrl` property from tsconfig

### DIFF
--- a/packages/knip/tsconfig.json
+++ b/packages/knip/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
The `baseUrl` tsconfig property caused my editor to autocomplete non-relative imports in #1087 and #1090.  This property is "not recommended": https://www.typescriptlang.org/tsconfig/#baseUrl.  I am not aware of any side effects that might result from removing it, and build seems to be successful.