### PR TITLE
resolve issue with plugin overlap on config files

### DIFF
--- a/packages/knip/fixtures/plugin-overlap/node_modules/typedoc/package.json
+++ b/packages/knip/fixtures/plugin-overlap/node_modules/typedoc/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "typedoc",
+  "bin": {
+    "typedoc": ""
+  }
+}

--- a/packages/knip/fixtures/plugin-overlap/package.json
+++ b/packages/knip/fixtures/plugin-overlap/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fixtures/plugin-overlap",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "docs": "typedoc"
+  },
+  "devDependencies": {
+    "@tsconfig/node16": "*",
+    "@types/node": "*",
+    "typedoc": "*",
+    "typedoc-plugin-markdown": "*",
+    "typescript": "*"
+  }
+}

--- a/packages/knip/fixtures/plugin-overlap/tsconfig.json
+++ b/packages/knip/fixtures/plugin-overlap/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@tsconfig/node16",
+  "compilerOptions": {}
+}

--- a/packages/knip/fixtures/plugin-overlap/typedoc.json
+++ b/packages/knip/fixtures/plugin-overlap/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "plugin": ["typedoc-plugin-markdown"]
+}

--- a/packages/knip/fixtures/workspaces-plugin-overlap/node_modules/typedoc/package.json
+++ b/packages/knip/fixtures/workspaces-plugin-overlap/node_modules/typedoc/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "typedoc",
+  "bin": {
+    "typedoc": ""
+  }
+}

--- a/packages/knip/fixtures/workspaces-plugin-overlap/package.json
+++ b/packages/knip/fixtures/workspaces-plugin-overlap/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@workspaces-paths-compilers/root",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/packages/knip/fixtures/workspaces-plugin-overlap/packages/workspace-a/package.json
+++ b/packages/knip/fixtures/workspaces-plugin-overlap/packages/workspace-a/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@workspaces-plugin-overlap/workspace-a",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "docs": "typedoc"
+  },
+  "devDependencies": {
+    "@tsconfig/node16": "*",
+    "@types/node": "*",
+    "typedoc": "*",
+    "typedoc-plugin-markdown": "*",
+    "typescript": "*"
+  }
+}

--- a/packages/knip/fixtures/workspaces-plugin-overlap/packages/workspace-a/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-plugin-overlap/packages/workspace-a/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@tsconfig/node16",
+  "compilerOptions": {}
+}

--- a/packages/knip/fixtures/workspaces-plugin-overlap/packages/workspace-a/typedoc.json
+++ b/packages/knip/fixtures/workspaces-plugin-overlap/packages/workspace-a/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "plugin": ["typedoc-plugin-markdown"]
+}

--- a/packages/knip/src/WorkspaceWorker.ts
+++ b/packages/knip/src/WorkspaceWorker.ts
@@ -371,7 +371,8 @@ export class WorkspaceWorker {
 
         const cache: CacheItem = {};
 
-        if (plugin.resolveConfig && !seen.get(wsName)?.has(configFilePath)) {
+        const key = `${wsName}:${pluginName}`;
+        if (plugin.resolveConfig && !seen.get(key)?.has(configFilePath)) {
           const localConfig = await loadConfigForPlugin(configFilePath, plugin, resolveOpts, pluginName);
           if (localConfig) {
             const inputs = await plugin.resolveConfig(localConfig, resolveOpts);
@@ -398,8 +399,8 @@ export class WorkspaceWorker {
           addInput(toEntry(configFilePath));
           addInput(toConfig(pluginName, configFilePath));
 
-          if (!seen.has(wsName)) seen.set(wsName, new Set());
-          seen.get(wsName)?.add(configFilePath);
+          if (!seen.has(key)) seen.set(key, new Set());
+          seen.get(key)?.add(configFilePath);
         }
 
         if (!isManifest && fd?.changed && fd.meta) fd.meta.data = cache;

--- a/packages/knip/test/plugin-overlap.test.ts
+++ b/packages/knip/test/plugin-overlap.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../src/index.js';
+import { resolve } from '../src/util/path.js';
+import baseArguments from './helpers/baseArguments.js';
+import baseCounters from './helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/plugin-overlap');
+
+test('Handles config file shared by multiple plugins', async () => {
+  const { counters } = await main({
+    ...baseArguments,
+    cwd,
+    isIsolateWorkspaces: true,
+  });
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+  });
+});

--- a/packages/knip/test/workspaces-plugin-overlap.test.ts
+++ b/packages/knip/test/workspaces-plugin-overlap.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../src/index.js';
+import { resolve } from '../src/util/path.js';
+import baseArguments from './helpers/baseArguments.js';
+import baseCounters from './helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/workspaces-plugin-overlap');
+
+test('Handles config file shared by multiple plugins in workspaces', async () => {
+  const { counters } = await main({
+    ...baseArguments,
+    cwd,
+    isIsolateWorkspaces: true,
+  });
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+  });
+});


### PR DESCRIPTION
As suggested, adds `pluginName` to the `seen` mix.