### PR TITLE
feat(webpack): process resolveLoader.alias

### DIFF
--- a/packages/knip/fixtures/plugins/webpack/src/app.tsx
+++ b/packages/knip/fixtures/plugins/webpack/src/app.tsx
@@ -1,2 +1,3 @@
 import dep from './app-dep';
+import '!my-loader!./app-dep';
 dep;

--- a/packages/knip/fixtures/plugins/webpack/webpack.common.js
+++ b/packages/knip/fixtures/plugins/webpack/webpack.common.js
@@ -97,6 +97,11 @@ module.exports = () => {
         Vue: ['vue/dist/vue.esm.js', 'default'],
       }),
     ],
+    resolveLoader: {
+      alias: {
+        'my-loader': path.resolve(__dirname, 'src/my-loader.js'),
+      },
+    },
     optimization: {
       minimizer: [new HtmlMinimizerPlugin({ parallel: true })],
     },

--- a/packages/knip/src/plugins/webpack/index.ts
+++ b/packages/knip/src/plugins/webpack/index.ts
@@ -1,4 +1,4 @@
-import type { RuleSetRule, RuleSetUseItem } from 'webpack';
+import type { ResolveOptions, RuleSetRule, RuleSetUseItem } from 'webpack';
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
 import { compact } from '../../util/array.js';
 import {
@@ -128,9 +128,9 @@ export const findWebpackDependenciesFromConfig: ResolveConfig<WebpackConfig> = a
         }
       }
 
-      if (opts.resolve?.alias) {
+      const processAlias = (aliases: NonNullable<ResolveOptions['alias']>) => {
         const addStar = (value: string) => (value.endsWith('*') ? value : join(value, '*').replace(/\/\*\*$/, '/*'));
-        for (const [alias, value] of Object.entries(opts.resolve.alias)) {
+        for (const [alias, value] of Object.entries(aliases)) {
           if (!value) continue;
           const prefixes = Array.isArray(value) ? value : [value];
           if (alias.endsWith('$')) {
@@ -142,6 +142,13 @@ export const findWebpackDependenciesFromConfig: ResolveConfig<WebpackConfig> = a
             }
           }
         }
+      };
+
+      if (opts.resolve?.alias) {
+        processAlias(opts.resolve.alias);
+      }
+      if (opts.resolveLoader?.alias) {
+        processAlias(opts.resolveLoader.alias);
       }
     }
   }

--- a/packages/knip/test/plugins/webpack.test.ts
+++ b/packages/knip/test/plugins/webpack.test.ts
@@ -26,7 +26,7 @@ test('Find dependencies with the Webpack plugin', async () => {
     devDependencies: 2,
     unlisted: 2,
     unresolved: 1,
-    processed: 12,
-    total: 12,
+    processed: 13,
+    total: 13,
   });
 });


### PR DESCRIPTION
This PR amends the existing `webpack` plugin to also recognize loaders defined with the `resolveLoader.alias` setting.