### PR TITLE
feat(astro-mdx): add compiler for @astrojs/mdx to treat layout value from mdx frontmatter as import

### DIFF
--- a/packages/knip/fixtures/plugins/astro/src/pages/about/mdx-with-layout.mdx
+++ b/packages/knip/fixtures/plugins/astro/src/pages/about/mdx-with-layout.mdx
@@ -1,0 +1,6 @@
+---
+layout: "../../layouts/Layout.astro"
+title: "MDX with Layout"
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/packages/knip/src/compilers/astro-mdx.ts
+++ b/packages/knip/src/compilers/astro-mdx.ts
@@ -1,13 +1,13 @@
 import { fencedCodeBlockMatcher, importMatcher, importsWithinFrontmatter } from './compilers.js';
 import type { HasDependency } from './types.js';
 
-// https://mdxjs.com/packages/
-const mdxDependencies = ['@astrojs/mdx'];
+// https://docs.astro.build/en/guides/integrations-guide/mdx/
+const astroMDXDependencies = ['@astrojs/mdx'];
 
 // Fields in frontmatter that could contain imports
 const frontmatterImportFields = ['layout'];
 
-const condition = (hasDependency: HasDependency) => mdxDependencies.some(hasDependency);
+const condition = (hasDependency: HasDependency) => astroMDXDependencies.some(hasDependency);
 
 const compiler = (text: string) => {
   const imports = text.replace(fencedCodeBlockMatcher, '').matchAll(importMatcher);

--- a/packages/knip/src/compilers/astro-mdx.ts
+++ b/packages/knip/src/compilers/astro-mdx.ts
@@ -2,7 +2,7 @@ import { fencedCodeBlockMatcher, importMatcher, importsWithinFrontmatter } from 
 import type { HasDependency } from './types.js';
 
 // https://docs.astro.build/en/guides/integrations-guide/mdx/
-const astroMDXDependencies = ['@astrojs/mdx'];
+const astroMDXDependencies = ['@astrojs/mdx', '@astrojs/starlight'];
 
 // Fields in frontmatter that could contain imports
 const frontmatterImportFields = ['layout'];

--- a/packages/knip/src/compilers/astro-mdx.ts
+++ b/packages/knip/src/compilers/astro-mdx.ts
@@ -1,0 +1,20 @@
+import { fencedCodeBlockMatcher, importMatcher, importsWithinFrontmatter } from './compilers.js';
+import type { HasDependency } from './types.js';
+
+// https://mdxjs.com/packages/
+const mdxDependencies = ['@astrojs/mdx'];
+
+// Fields in frontmatter that could contain imports
+const frontmatterImportFields = ['layout'];
+
+const condition = (hasDependency: HasDependency) => mdxDependencies.some(hasDependency);
+
+const compiler = (text: string) => {
+  const imports = text.replace(fencedCodeBlockMatcher, '').matchAll(importMatcher);
+
+  const frontmatterImports = [importsWithinFrontmatter(text, frontmatterImportFields)];
+
+  return [...imports, ...frontmatterImports].join('\n');
+};
+
+export default { condition, compiler };

--- a/packages/knip/src/compilers/astro-mdx.ts
+++ b/packages/knip/src/compilers/astro-mdx.ts
@@ -12,9 +12,9 @@ const condition = (hasDependency: HasDependency) => astroMDXDependencies.some(ha
 const compiler = (text: string) => {
   const imports = text.replace(fencedCodeBlockMatcher, '').matchAll(importMatcher);
 
-  const frontmatterImports = [importsWithinFrontmatter(text, frontmatterImportFields)];
+  const frontmatterImports = importsWithinFrontmatter(text, frontmatterImportFields);
 
-  return [...imports, ...frontmatterImports].join('\n');
+  return [...imports, frontmatterImports].join('\n');
 };
 
 export default { condition, compiler };

--- a/packages/knip/src/compilers/compilers.ts
+++ b/packages/knip/src/compilers/compilers.ts
@@ -28,3 +28,16 @@ export const scriptBodies: SyncCompilerFn = (text: string) => {
   }
   return scripts.join(';\n');
 };
+
+// Extract paths as imports from frontmatter for given keys (e.g., 'layout')
+const frontmatterMatcher = /---[\s\S]*?---/g;
+export const importsWithinFrontmatter = (text: string, keys: string[] = []) => {
+  const imports = [...text.matchAll(frontmatterMatcher)].flatMap(([frontmatter]) => {
+    return keys.flatMap(key => {
+      const valueMatcher = new RegExp(`${key}:\\s*["']([^"']+)["']`, 'i');
+      const match = frontmatter.match(valueMatcher);
+      return match?.[1] ? [`import ${key} from "${match[1]}";`] : [];
+    });
+  });
+  return imports.join('\n');
+};

--- a/packages/knip/src/compilers/compilers.ts
+++ b/packages/knip/src/compilers/compilers.ts
@@ -30,14 +30,15 @@ export const scriptBodies: SyncCompilerFn = (text: string) => {
 };
 
 // Extract paths as imports from frontmatter for given keys (e.g., 'layout')
-const frontmatterMatcher = /---[\s\S]*?---/g;
+const frontmatterMatcher = /---[\s\S]*?---/;
 export const importsWithinFrontmatter = (text: string, keys: string[] = []) => {
-  const imports = [...text.matchAll(frontmatterMatcher)].flatMap(([frontmatter]) => {
-    return keys.flatMap(key => {
-      const valueMatcher = new RegExp(`${key}:\\s*["']([^"']+)["']`, 'i');
-      const match = frontmatter.match(valueMatcher);
-      return match?.[1] ? [`import ${key} from "${match[1]}";`] : [];
-    });
+  const frontmatter = text.match(frontmatterMatcher)?.[0];
+  if (!frontmatter) return '';
+
+  const imports = keys.flatMap(key => {
+    const valueMatcher = new RegExp(`${key}:\\s*["']([^"']+)["']`, 'i');
+    const match = frontmatter.match(valueMatcher);
+    return match?.[1] ? [`import ${key} from "${match[1]}";`] : [];
   });
   return imports.join('\n');
 };

--- a/packages/knip/src/compilers/index.ts
+++ b/packages/knip/src/compilers/index.ts
@@ -1,5 +1,6 @@
 import type { RawConfiguration } from '../types/config.js';
 import type { DependencySet } from '../types/workspace.js';
+import AstroMDX from './astro-mdx.js';
 import Astro from './astro.js';
 import MDX from './mdx.js';
 import Svelte from './svelte.js';
@@ -50,6 +51,12 @@ export const getIncludedCompilers = (
   const hasDependency = (packageName: string) => dependencies.has(packageName);
 
   for (const [extension, { condition, compiler }] of compilers.entries()) {
+    // For MDX, try Astro compiler first if available
+    if (extension === '.mdx' && AstroMDX.condition(hasDependency)) {
+      syncCompilers.set(extension, AstroMDX.compiler);
+      continue;
+    }
+
     if ((!syncCompilers.has(extension) && condition(hasDependency)) || syncCompilers.get(extension) === true) {
       syncCompilers.set(extension, compiler);
     }

--- a/packages/knip/src/compilers/index.ts
+++ b/packages/knip/src/compilers/index.ts
@@ -54,10 +54,7 @@ export const getIncludedCompilers = (
     // For MDX, try Astro compiler first if available
     if (extension === '.mdx' && AstroMDX.condition(hasDependency)) {
       syncCompilers.set(extension, AstroMDX.compiler);
-      continue;
-    }
-
-    if ((!syncCompilers.has(extension) && condition(hasDependency)) || syncCompilers.get(extension) === true) {
+    } else if ((!syncCompilers.has(extension) && condition(hasDependency)) || syncCompilers.get(extension) === true) {
       syncCompilers.set(extension, compiler);
     }
   }

--- a/packages/knip/src/compilers/mdx.ts
+++ b/packages/knip/src/compilers/mdx.ts
@@ -15,20 +15,17 @@ const mdxDependencies = [
   'remark-mdx',
 ];
 
+// Fields in frontmatter that could contain imports
+const frontmatterImportFields = ['layout'];
+
 const condition = (hasDependency: HasDependency) => mdxDependencies.some(hasDependency);
 
 const compiler = (text: string) => {
-  // Get imports from the MDX content ignoring imports within fenced code blocks
-  const imports = [...text.replace(fencedCodeBlockMatcher, '').matchAll(importMatcher)].map(match => match[0]);
+  const imports = text.replace(fencedCodeBlockMatcher, '').matchAll(importMatcher);
 
-  let frontmatterImports = '';
+  const frontmatterImports = [importsWithinFrontmatter(text, frontmatterImportFields)];
 
-  // If this is an Astro project, also treat the layout path in the frontmatter as an import
-  if (mdxDependencies.includes('astro')) {
-    frontmatterImports = importsWithinFrontmatter(text, ['layout']);
-  }
-
-  return [...imports, frontmatterImports].filter(Boolean).join('\n');
+  return [...imports, ...frontmatterImports].join('\n');
 };
 
 export default { condition, compiler };

--- a/packages/knip/src/compilers/mdx.ts
+++ b/packages/knip/src/compilers/mdx.ts
@@ -1,9 +1,8 @@
-import { fencedCodeBlockMatcher, importMatcher, importsWithinFrontmatter } from './compilers.js';
+import { fencedCodeBlockMatcher, importMatcher } from './compilers.js';
 import type { HasDependency } from './types.js';
 
 // https://mdxjs.com/packages/
 const mdxDependencies = [
-  'astro',
   '@mdx-js/esbuild',
   '@mdx-js/loader',
   '@mdx-js/mdx',
@@ -15,17 +14,8 @@ const mdxDependencies = [
   'remark-mdx',
 ];
 
-// Fields in frontmatter that could contain imports
-const frontmatterImportFields = ['layout'];
-
 const condition = (hasDependency: HasDependency) => mdxDependencies.some(hasDependency);
 
-const compiler = (text: string) => {
-  const imports = text.replace(fencedCodeBlockMatcher, '').matchAll(importMatcher);
-
-  const frontmatterImports = [importsWithinFrontmatter(text, frontmatterImportFields)];
-
-  return [...imports, ...frontmatterImports].join('\n');
-};
+const compiler = (text: string) => [...text.replace(fencedCodeBlockMatcher, '').matchAll(importMatcher)].join('\n');
 
 export default { condition, compiler };

--- a/packages/knip/test/plugins/astro.test.ts
+++ b/packages/knip/test/plugins/astro.test.ts
@@ -8,12 +8,10 @@ import baseCounters from '../helpers/baseCounters.js';
 const cwd = resolve('fixtures/plugins/astro');
 
 test('Find dependencies with the Astro plugin', async () => {
-  const { issues, counters } = await main({
+  const { counters } = await main({
     ...baseArguments,
     cwd,
   });
-
-  console.log('Issues:', issues);
 
   assert.deepEqual(counters, {
     ...baseCounters,

--- a/packages/knip/test/plugins/astro.test.ts
+++ b/packages/knip/test/plugins/astro.test.ts
@@ -8,14 +8,16 @@ import baseCounters from '../helpers/baseCounters.js';
 const cwd = resolve('fixtures/plugins/astro');
 
 test('Find dependencies with the Astro plugin', async () => {
-  const { counters } = await main({
+  const { issues, counters } = await main({
     ...baseArguments,
     cwd,
   });
 
+  console.log('Issues:', issues);
+
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 19,
-    total: 19,
+    processed: 21,
+    total: 21,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Treats the layout in the mdx frontmatter in an Astro project as an import.

Related Issue: #1084 
