### PR TITLE
Hardhat plugin updates

### DIFF
--- a/packages/knip/fixtures/plugins/hardhat/contracts/Test.sol
+++ b/packages/knip/fixtures/plugins/hardhat/contracts/Test.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.8.0;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol"
+
+contract Test is ERC20 {}

--- a/packages/knip/fixtures/plugins/hardhat/hardhat.config.ts
+++ b/packages/knip/fixtures/plugins/hardhat/hardhat.config.ts
@@ -1,3 +1,9 @@
-const config = {};
+import type { HardhatUserConfig } from "../../../src/plugins/hardhat/types.js";
+
+const config: HardhatUserConfig = {
+  solidity: {
+    dependenciesToCompile: ["@solidstate/contracts/interfaces/IERC20.sol"],
+  },
+};
 
 export default config;

--- a/packages/knip/fixtures/plugins/hardhat/hardhat.config.ts
+++ b/packages/knip/fixtures/plugins/hardhat/hardhat.config.ts
@@ -1,3 +1,4 @@
+import "@solidstate/hardhat-contract-sizer";
 import type { HardhatUserConfig } from "../../../src/plugins/hardhat/types.js";
 
 const config: HardhatUserConfig = {

--- a/packages/knip/fixtures/plugins/hardhat/node_modules/@solidstate/hardhat-contract-sizer/package.json
+++ b/packages/knip/fixtures/plugins/hardhat/node_modules/@solidstate/hardhat-contract-sizer/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@solidstate/hardhat-contract-sizer",
+  "main": "index.js"
+}

--- a/packages/knip/fixtures/plugins/hardhat/package.json
+++ b/packages/knip/fixtures/plugins/hardhat/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@plugins/hardhat",
   "devDependencies": {
+    "@openzeppelin/contracts": "*",
     "@solidstate/contracts": "*",
     "@solidstate/hardhat-contract-sizer": "*",
     "hardhat": "*"

--- a/packages/knip/fixtures/plugins/hardhat/package.json
+++ b/packages/knip/fixtures/plugins/hardhat/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@plugins/hardhat",
   "devDependencies": {
+    "@solidstate/contracts": "*",
     "hardhat": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/hardhat/package.json
+++ b/packages/knip/fixtures/plugins/hardhat/package.json
@@ -2,6 +2,7 @@
   "name": "@plugins/hardhat",
   "devDependencies": {
     "@solidstate/contracts": "*",
+    "@solidstate/hardhat-contract-sizer": "*",
     "hardhat": "*"
   }
 }

--- a/packages/knip/src/plugins/hardhat/index.ts
+++ b/packages/knip/src/plugins/hardhat/index.ts
@@ -17,8 +17,6 @@ const enablers = ["hardhat"];
 const isEnabled: IsPluginEnabled = ({ dependencies }) =>
   hasDependency(dependencies, enablers);
 
-const entry: string[] = ["hardhat.config.{js,cjs,mjs,ts}"];
-
 const config = ["hardhat.config.{js,cjs,mjs,ts}"];
 
 const resolve: Resolve = async () => {
@@ -42,7 +40,6 @@ export default {
   title,
   enablers,
   isEnabled,
-  entry,
   config,
   resolve,
   resolveConfig,

--- a/packages/knip/src/plugins/hardhat/index.ts
+++ b/packages/knip/src/plugins/hardhat/index.ts
@@ -1,19 +1,41 @@
-import type { IsPluginEnabled, Plugin, Resolve } from '../../types/config.js';
-import { toDependency } from '../../util/input.js';
-import { hasDependency } from '../../util/plugin.js';
+import type {
+  IsPluginEnabled,
+  Plugin,
+  Resolve,
+  ResolveConfig,
+} from "../../types/config.js";
+import { toDeferResolve, toDependency } from "../../util/input.js";
+import { hasDependency } from "../../util/plugin.js";
+import type { HardhatUserConfig } from "./types.js";
 
 // https://hardhat.org/docs
 
-const title = 'Hardhat';
+const title = "Hardhat";
 
-const enablers = ['hardhat'];
+const enablers = ["hardhat"];
 
-const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+const isEnabled: IsPluginEnabled = ({ dependencies }) =>
+  hasDependency(dependencies, enablers);
 
-const entry: string[] = ['hardhat.config.{js,cjs,mjs,ts}'];
+const entry: string[] = ["hardhat.config.{js,cjs,mjs,ts}"];
+
+const config = ["hardhat.config.{js,cjs,mjs,ts}"];
 
 const resolve: Resolve = async () => {
-  return [toDependency('hardhat')];
+  return [toDependency("hardhat")];
+};
+
+const resolveConfig: ResolveConfig<HardhatUserConfig> = (config) => {
+  return [config.solidity]
+    .flat()
+    .filter(
+      (solidityConfig) =>
+        typeof solidityConfig !== "undefined" &&
+        typeof solidityConfig !== "string",
+    )
+    .map((solidityConfig) => solidityConfig.dependenciesToCompile ?? [])
+    .flat()
+    .map(toDeferResolve);
 };
 
 export default {
@@ -21,5 +43,7 @@ export default {
   enablers,
   isEnabled,
   entry,
+  config,
   resolve,
+  resolveConfig,
 } satisfies Plugin;

--- a/packages/knip/src/plugins/hardhat/types.ts
+++ b/packages/knip/src/plugins/hardhat/types.ts
@@ -1,0 +1,11 @@
+interface CommonSolidityUserConfig {
+  dependenciesToCompile?: string[];
+  // TODO: use remappings to detect imports in *.sol files
+  remappings?: string[];
+}
+
+type SolidityUserConfig = string | string[] | CommonSolidityUserConfig;
+
+export interface HardhatUserConfig {
+  solidity?: SolidityUserConfig;
+}


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

#1087 adds basic support for Hardhat, which is suitable for developing Hardhat plugins.  However, it lacks support for most situations faced by consumers of Hardhat.

* [x] detect imports from `dependencesToCompile` in `hardhat.config.*`
* [ ] detect `*.sol` imports from `*.sol` files
* [ ] apply remappings to `*.sol` imports
* [ ] detect test files if a Hardhat test runner plugin is installed
* [ ] check formatting