### PR TITLE
Fix Node test runner detection

### DIFF
--- a/packages/knip/src/plugins/node/index.ts
+++ b/packages/knip/src/plugins/node/index.ts
@@ -15,8 +15,14 @@ const resolveConfig: ResolveConfig<PackageJson> = localConfig => {
 
   const entries = [toProductionEntry('server.js')];
 
-  if (scripts && Object.keys(scripts).some(script => /(?<=^|\s)node\s(.*)--test/.test(scripts[script]))) {
-    const patterns = ['**/*{.,-,_}test.?(c|m)js', '**/test-*.?(c|m)js', '**/test.?(c|m)js', '**/test/**/*.?(c|m)js'];
+  if (scripts && Object.values(scripts).some(script => /(?<=^|\s)node\s(.*)--test/.test(scripts[script]))) {
+    // From https://nodejs.org/api/test.html#running-tests-from-the-command-line
+    const patterns = [
+      '**/*{.,-,_}test.{cjs,mjs,js,cts,mts,ts}',
+      '**/test-*.{cjs,mjs,js,cts,mts,ts}',
+      '**/test.{cjs,mjs,js,cts,mts,ts}',
+      '**/test/**/*.{cjs,mjs,js,cts,mts,ts}',
+    ];
     entries.push(...patterns.map(id => toEntry(id)));
   }
 


### PR DESCRIPTION
- Fixes a bug where previously the `"script"` keys were checked for `node --test` instead of the values
- Update glob patterns to match TypeScript files

Fixes #1120