### PR TITLE
Restructure biome configurations

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,13 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "extends": ["packages/knip/biome.json"],
   "files": {
-    "ignore": [
-      "**/dist",
-      "**/tmp",
-      "packages/knip/package.json",
-      "packages/knip/vendor/bash-parser/index.js",
-      "packages/docs/.astro"
-    ]
+    "ignore": ["**/dist", "**/tmp", "packages/docs/.astro"]
   },
   "organizeImports": {
     "enabled": true
@@ -48,10 +43,7 @@
     "enabled": true,
     "lineWidth": 120,
     "indentStyle": "space",
-    "formatWithErrors": true,
-    "ignore": [
-      "packages/knip/fixtures/ignore-exports-used-in-file-alias-exclude/more.ts"
-    ]
+    "formatWithErrors": true
   },
   "javascript": {
     "formatter": {
@@ -83,50 +75,13 @@
       }
     },
     {
-      "include": [
-        "packages/docs",
-        "packages/knip/fixtures/cli-preprocessor",
-        "packages/knip/fixtures/cli-reporter",
-        "packages/knip/scripts",
-        "packages/knip/src/cli.ts",
-        "packages/knip/src/reporters",
-        "packages/knip/src/util/cli-arguments.ts",
-        "packages/knip/src/util/debug.ts"
-      ],
+      "include": ["packages/docs"],
       "linter": {
         "rules": {
           "suspicious": {
             "noConsoleLog": "off"
           }
         }
-      }
-    },
-    {
-      "include": ["packages/knip/fixtures"],
-      "organizeImports": {
-        "enabled": false
-      },
-      "linter": {
-        "rules": {
-          "correctness": {
-            "noUnusedVariables": "off",
-            "noUnusedImports": "off"
-          },
-          "style": {
-            "useImportType": "off"
-          },
-          "nursery": {
-            "noRestrictedImports": {
-              "level": "off"
-            }
-          }
-        }
-      }
-    },
-    {
-      "include": ["packages/knip/test/util/get-inputs-from-scripts.test.ts"],
-      "formatter": {
-        "lineWidth": 200
       }
     }
   ]

--- a/packages/knip/biome.json
+++ b/packages/knip/biome.json
@@ -4,6 +4,9 @@
   "files": {
     "ignore": ["**/dist", "package.json", "vendor/bash-parser/index.js"]
   },
+  "formatter": {
+    "ignore": ["ignore-exports-used-in-file-alias-exclude/more.ts"]
+  },
   "overrides": [
     {
       "include": ["test/util/get-inputs-from-scripts.test.ts"],

--- a/packages/knip/biome.json
+++ b/packages/knip/biome.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "extends": ["../../biome.json"],
+  "files": {
+    "ignore": ["**/dist", "package.json", "vendor/bash-parser/index.js"]
+  },
+  "overrides": [
+    {
+      "include": ["test/util/get-inputs-from-scripts.test.ts"],
+      "formatter": {
+        "lineWidth": 200
+      }
+    },
+    {
+      "include": [
+        "fixtures/cli-preprocessor",
+        "fixtures/cli-reporter",
+        "scripts",
+        "src/cli.ts",
+        "src/reporters",
+        "src/util/cli-arguments.ts",
+        "src/util/debug.ts"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsoleLog": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["fixtures"],
+      "organizeImports": {
+        "enabled": false
+      },
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off",
+            "noUnusedImports": "off"
+          },
+          "style": {
+            "useImportType": "off"
+          },
+          "nursery": {
+            "noRestrictedImports": {
+              "level": "off"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Currently, we allow `format` script inside `packages/knip` but the default config in `knip` package is not on par with the root `biome.json`. This can lead to unrelated diff as in https://github.com/webpro-nl/knip/pull/1113/commits/ba0c5ca23c1ebb4dffb5a531c638598bf0eb980d.

As a plugin writer, I needed to run `bun test test/plugins/biome.test.ts` inside `packages/knip`. Unfortunately, I had to run `bun run format` at the root folder to avoid the unintended diff. It mandates an extra step in the developer workflow.

This PR is to improve the ergonomic when running `bun run format` inside `packages/knip`. Moving forward, we can define `packages/knip`-specific biome config inside `package/knip/biome.json`.