### PR TITLE
Recognize vue.config.mjs

### DIFF
--- a/packages/knip/src/plugins/vue/index.ts
+++ b/packages/knip/src/plugins/vue/index.ts
@@ -13,7 +13,7 @@ const enablers = ['vue'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['vue.config.{js,ts}'];
+const config = ['vue.config.{js,ts,mjs}'];
 
 const resolveConfig: ResolveConfig<VueConfig> = async (config, options) => {
   const { manifest } = options;


### PR DESCRIPTION
Since Vue CLI 5, vue.config.mjs is also recognized as the Vue config file