### PR TITLE
Reverted change in the react-router plugin on windows

### DIFF
--- a/packages/knip/src/plugins/react-router/index.ts
+++ b/packages/knip/src/plugins/react-router/index.ts
@@ -1,12 +1,13 @@
 import { existsSync } from 'node:fs';
+import os from 'node:os';
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
 import { toEntry } from '../../util/input.js';
 import { join } from '../../util/path.js';
 import { hasDependency, load } from '../../util/plugin.js';
 import vite from '../vite/index.js';
 import type { PluginConfig, RouteConfigEntry } from './types.js';
-import os from 'node:os';
 
+const isWindows = os.platform() === 'win32';
 // https://reactrouter.com/start/framework/routing
 
 const title = 'React Router';
@@ -48,7 +49,7 @@ const resolveConfig: ResolveConfig<PluginConfig> = async (localConfig, options) 
     // See:
     //  - https://reactrouter.com/how-to/file-route-conventions#optional-segments
     //  - https://www.npmjs.com/package/fast-glob#advanced-syntax
-    .map(route => os.platform() === "win32" ? route : route.replace(/[$^*+?()\[\]]/g, '\\$&'));
+    .map(route => (isWindows ? route : route.replace(/[$^*+?()\[\]]/g, '\\$&')));
 
   return [
     join(appDir, 'routes.{js,ts}'),

--- a/packages/knip/src/plugins/react-router/index.ts
+++ b/packages/knip/src/plugins/react-router/index.ts
@@ -5,6 +5,7 @@ import { join } from '../../util/path.js';
 import { hasDependency, load } from '../../util/plugin.js';
 import vite from '../vite/index.js';
 import type { PluginConfig, RouteConfigEntry } from './types.js';
+import os from 'node:os';
 
 // https://reactrouter.com/start/framework/routing
 
@@ -47,7 +48,7 @@ const resolveConfig: ResolveConfig<PluginConfig> = async (localConfig, options) 
     // See:
     //  - https://reactrouter.com/how-to/file-route-conventions#optional-segments
     //  - https://www.npmjs.com/package/fast-glob#advanced-syntax
-    .map(route => route.replace(/[$^*+?()\[\]]/g, '\\$&'));
+    .map(route => os.platform() === "win32" ? route : route.replace(/[$^*+?()\[\]]/g, '\\$&'));
 
   return [
     join(appDir, 'routes.{js,ts}'),

--- a/packages/knip/test/plugins/react-router.test.ts
+++ b/packages/knip/test/plugins/react-router.test.ts
@@ -22,6 +22,6 @@ test('Find dependencies with the react-router plugin', async () => {
     total: 9,
     // There is a bug with routes that include () on Windows so they will not be found there, revert when
     // the bug is fixed
-    files: isWindows ? 0 : 1,
+    files: isWindows ? 1 : 0,
   });
 });

--- a/packages/knip/test/plugins/react-router.test.ts
+++ b/packages/knip/test/plugins/react-router.test.ts
@@ -1,9 +1,12 @@
 import { test } from 'bun:test';
 import assert from 'node:assert/strict';
+import os from 'node:os';
 import { main } from '../../src/index.js';
 import { resolve } from '../../src/util/path.js';
 import baseArguments from '../helpers/baseArguments.js';
 import baseCounters from '../helpers/baseCounters.js';
+
+const isWindows = os.platform() === 'win32';
 
 const cwd = resolve('fixtures/plugins/react-router');
 
@@ -17,5 +20,8 @@ test('Find dependencies with the react-router plugin', async () => {
     ...baseCounters,
     processed: 9,
     total: 9,
+    // There is a bug with routes that include () on Windows so they will not be found there, revert when
+    // the bug is fixed
+    files: isWindows ? 0 : 1,
   });
 });

--- a/packages/knip/test/plugins/react-router.test.ts
+++ b/packages/knip/test/plugins/react-router.test.ts
@@ -1,6 +1,5 @@
 import { test } from 'bun:test';
 import assert from 'node:assert/strict';
-import os from 'node:os';
 import { main } from '../../src/index.js';
 import { resolve } from '../../src/util/path.js';
 import baseArguments from '../helpers/baseArguments.js';
@@ -8,9 +7,7 @@ import baseCounters from '../helpers/baseCounters.js';
 
 const cwd = resolve('fixtures/plugins/react-router');
 
-const skipIfWindows = os.platform() === 'win32' ? test.skip : test;
-
-skipIfWindows('Find dependencies with the react-router plugin', async () => {
+test('Find dependencies with the react-router plugin', async () => {
   const { counters } = await main({
     ...baseArguments,
     cwd,


### PR DESCRIPTION
Due to this bug fix: https://github.com/webpro-nl/knip/pull/988 the entries on Windows are completely broken due to a transform happening midway between the plugin and the final resolver which turns the escaped \ \ into /.

I couldn't pinpoint the exact cause, and this fix mostly covers the issues on Windows, the only thing that won't work is the ( ) escape.