### PR TITLE
docs: add config docs for compilers and treatConfigHintsAsErrors, move Plugins and Workspace to group level

### DIFF
--- a/packages/docs/src/content/docs/reference/configuration.md
+++ b/packages/docs/src/content/docs/reference/configuration.md
@@ -63,21 +63,6 @@ Array of glob patterns to find project files. Example:
 
 Also see [configuration][2] and [entry files][3].
 
-### `workspaces`
-
-Individual workspace configurations may contain all other options listed on this
-page, except for the following root-only options:
-
-- `exclude` / `include`
-- `ignoreExportsUsedInFile`
-- `ignoreWorkspaces`
-- `workspaces`
-
-Workspaces can't be nested in a Knip configuration, but they can be nested in a
-monorepo folder structure.
-
-Also see [Monorepos and workspaces][4].
-
 ### `paths`
 
 Tools like TypeScript, webpack and Babel support import aliases in various ways.
@@ -100,7 +85,41 @@ TypeScript semantics:
 - Path values are an array of relative paths.
 - Paths without an `*` are exact matches.
 
-### Plugins
+## Workspaces
+
+Individual workspace configurations may contain all other options listed on this
+page, except for the following root-only options:
+
+- `exclude` / `include`
+- `ignoreExportsUsedInFile`
+- `ignoreWorkspaces`
+- `workspaces`
+
+Workspaces can't be nested in a Knip configuration, but they can be nested in a
+monorepo folder structure.
+
+```json title="knip.json"
+{
+  "workspaces": {
+    "packages/frontend": {
+      "entry": ["src/index.tsx"],
+      "project": ["src/**/*.{ts,tsx}"],
+      "ignoreDependencies": ["@types/*"]
+    },
+    "packages/backend": {
+      "entry": ["src/server.ts"],
+      "project": ["src/**/*.ts"],
+      "jest": {
+        "entry": ["**/*.test.ts"]
+      }
+    }
+  }
+}
+```
+
+Also see [Monorepos and workspaces][4].
+
+## Plugins
 
 There are a few options to modify the behavior of a plugin:
 
@@ -181,6 +200,16 @@ notation below is valid and will report only exports tagged `@lintignore` or
 ```
 
 Also see [JSDoc & TSDoc Tags][8].
+
+### `treatConfigHintsAsErrors`
+
+Exit with non-zero code (1) if there are any configuration hints.
+
+```json title="knip.json"
+{
+  "treatConfigHintsAsErrors": true
+}
+```
 
 ## Ignore Issues
 
@@ -332,6 +361,45 @@ This will also enable reporting unused members of exported classes and enums.
 Set this option at root level to enable this globally, or within workspace
 configurations individually.
 
+## Compilers
+
+Knip supports custom compilers to transform files before analysis. Knip has
+built-in compilers for `.astro`, `.mdx`, `.svelte`, and `.vue` files that are
+automatically enabled when the relevant dependencies are found.
+
+:::note
+
+Since compilers are functions, they can only be used in dynamic configuration
+files (`.js` or `.ts`), not in JSON configuration files.
+
+:::
+
+Also see [Compilers][10].
+
+### `compilers`
+
+Override built-in compilers or add custom compilers for additional file types.
+Each compiler is a function with the signature
+`(source: string, filename: string) => string` or async equivalent.
+
+```ts title="knip.ts"
+export default {
+  compilers: {
+    // Enable a built-in compiler manually
+    mdx: true,
+
+    // Custom compiler for CSS files
+    css: (text: string) => [...text.matchAll(/(?<=@)import[^;]+/g)].join('\n'),
+
+    // Override built-in Vue compiler
+    vue: async (text: string, filename: string) => {
+      // Custom Vue compilation logic
+      return await transformVue(text);
+    },
+  },
+};
+```
+
 [1]: ../reference/dynamic-configuration.mdx
 [2]: ../overview/configuration.md
 [3]: ../explanations/entry-files.md
@@ -341,3 +409,4 @@ configurations individually.
 [7]: ../features/rules-and-filters.md#filters
 [8]: ./jsdoc-tsdoc-tags.md
 [9]: ../guides/configuring-project-files.md
+[10]: ../features/compilers.md


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

This adds documentation for the `compilers` and `treatConfigHintsAsErrors` config which were not previously documented on the reference/configuration.md page. It also moves Workspaces and Plugins to documented at the group level. These changes are being proposed ahead of #1144 so they can get independent feedback and to reduce the total number of changes in that PR.

