### PR TITLE
Add `exec-staged` plugin

### DIFF
--- a/packages/knip/fixtures/plugins/exec-staged/exec-staged.config.js
+++ b/packages/knip/fixtures/plugins/exec-staged/exec-staged.config.js
@@ -1,0 +1,5 @@
+export default [
+  "eslint --max-warnings=0 --cache --fix $FILES",
+  { task: "prettier --write $FILES" },
+  "prettier --write --ignore-unknown $FILES",
+];

--- a/packages/knip/fixtures/plugins/exec-staged/exec-staged.config.js
+++ b/packages/knip/fixtures/plugins/exec-staged/exec-staged.config.js
@@ -1,5 +1,5 @@
 export default [
-  "eslint --max-warnings=0 --cache --fix $FILES",
-  { task: "prettier --write $FILES" },
-  "prettier --write --ignore-unknown $FILES",
+  'eslint --max-warnings=0 --cache --fix $FILES',
+  { task: 'prettier --write $FILES' },
+  'prettier --write --ignore-unknown $FILES',
 ];

--- a/packages/knip/fixtures/plugins/exec-staged/package.json
+++ b/packages/knip/fixtures/plugins/exec-staged/package.json
@@ -3,10 +3,8 @@
   "devDependencies": {
     "exec-staged": "*"
   },
-  "exec-staged": {
-    "*.js": [
-      "eslint",
-      "prettier --write $FILES"
-    ]
-  }
+  "exec-staged": [
+    "eslint",
+    "prettier --write $FILES"
+  ]
 }

--- a/packages/knip/fixtures/plugins/exec-staged/package.json
+++ b/packages/knip/fixtures/plugins/exec-staged/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@plugins/exec-staged",
+  "devDependencies": {
+    "exec-staged": "*"
+  },
+  "exec-staged": {
+    "*.js": [
+      "eslint",
+      "prettier --write $FILES"
+    ]
+  }
+}

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -395,6 +395,10 @@
           "title": "ESLint plugin configuration (https://knip.dev/reference/plugins/eslint)",
           "$ref": "#/definitions/plugin"
         },
+        "exec-staged": {
+          "title": "exec-staged plugin configuration (https://knip.dev/reference/plugins/exec-staged)",
+          "$ref": "#/definitions/plugin"
+        },
         "expo": {
           "title": "Expo plugin configuration (https://knip.dev/reference/plugins/expo)",
           "$ref": "#/definitions/plugin"

--- a/packages/knip/src/plugins/exec-staged/index.ts
+++ b/packages/knip/src/plugins/exec-staged/index.ts
@@ -1,0 +1,51 @@
+import type {
+  IsPluginEnabled,
+  Plugin,
+  ResolveConfig,
+} from "../../types/config.js";
+import type { Input } from "../../util/input.js";
+import { toCosmiconfig } from "../../util/plugin-config.js";
+import { hasDependency } from "../../util/plugin.js";
+import type { ExecStagedConfig } from "./types.js";
+
+// https://github.com/ItsNickBarry/exec-staged
+
+const title = "exec-staged";
+
+const enablers = ["exec-staged"];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) =>
+  hasDependency(dependencies, enablers);
+
+const config = [
+  "package.json",
+  "package.yaml",
+  "package.yml",
+  ...toCosmiconfig("exec-staged"),
+];
+
+const resolveConfig: ResolveConfig<ExecStagedConfig> = async (
+  config,
+  options,
+) => {
+  if (options.isProduction) return [];
+
+  if (!config) return [];
+
+  const inputs = new Set<Input>();
+
+  for (const entry of config) {
+    const script = typeof entry === "string" ? entry : entry.task;
+    for (const id of options.getInputsFromScripts(script)) inputs.add(id);
+  }
+
+  return Array.from(inputs);
+};
+
+export default {
+  title,
+  enablers,
+  isEnabled,
+  config,
+  resolveConfig,
+} satisfies Plugin;

--- a/packages/knip/src/plugins/exec-staged/index.ts
+++ b/packages/knip/src/plugins/exec-staged/index.ts
@@ -1,33 +1,20 @@
-import type {
-  IsPluginEnabled,
-  Plugin,
-  ResolveConfig,
-} from "../../types/config.js";
-import type { Input } from "../../util/input.js";
-import { toCosmiconfig } from "../../util/plugin-config.js";
-import { hasDependency } from "../../util/plugin.js";
-import type { ExecStagedConfig } from "./types.js";
+import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
+import type { Input } from '../../util/input.js';
+import { toCosmiconfig } from '../../util/plugin-config.js';
+import { hasDependency } from '../../util/plugin.js';
+import type { ExecStagedConfig } from './types.js';
 
 // https://github.com/ItsNickBarry/exec-staged
 
-const title = "exec-staged";
+const title = 'exec-staged';
 
-const enablers = ["exec-staged"];
+const enablers = ['exec-staged'];
 
-const isEnabled: IsPluginEnabled = ({ dependencies }) =>
-  hasDependency(dependencies, enablers);
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = [
-  "package.json",
-  "package.yaml",
-  "package.yml",
-  ...toCosmiconfig("exec-staged"),
-];
+const config = ['package.json', 'package.yaml', 'package.yml', ...toCosmiconfig('exec-staged')];
 
-const resolveConfig: ResolveConfig<ExecStagedConfig> = async (
-  config,
-  options,
-) => {
+const resolveConfig: ResolveConfig<ExecStagedConfig> = async (config, options) => {
   if (options.isProduction) return [];
 
   if (!config) return [];
@@ -35,7 +22,7 @@ const resolveConfig: ResolveConfig<ExecStagedConfig> = async (
   const inputs = new Set<Input>();
 
   for (const entry of config) {
-    const script = typeof entry === "string" ? entry : entry.task;
+    const script = typeof entry === 'string' ? entry : entry.task;
     for (const id of options.getInputsFromScripts(script)) inputs.add(id);
   }
 

--- a/packages/knip/src/plugins/exec-staged/types.ts
+++ b/packages/knip/src/plugins/exec-staged/types.ts
@@ -1,0 +1,5 @@
+type Task = { task: string };
+
+type Config = string | Task;
+
+export type ExecStagedConfig = Config[];

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -23,6 +23,7 @@ import { default as dotenv } from './dotenv/index.js';
 import { default as drizzle } from './drizzle/index.js';
 import { default as eleventy } from './eleventy/index.js';
 import { default as eslint } from './eslint/index.js';
+import { default as execStaged } from './exec-staged/index.js';
 import { default as expo } from './expo/index.js';
 import { default as gatsby } from './gatsby/index.js';
 import { default as githubAction } from './github-action/index.js';
@@ -134,6 +135,7 @@ export const Plugins = {
   drizzle,
   eleventy,
   eslint,
+  'exec-staged': execStaged,
   expo,
   gatsby,
   'github-action': githubAction,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -24,6 +24,7 @@ export type PluginName =
   | 'drizzle'
   | 'eleventy'
   | 'eslint'
+  | 'exec-staged'
   | 'expo'
   | 'gatsby'
   | 'github-action'

--- a/packages/knip/test/plugins/exec-staged.test.ts
+++ b/packages/knip/test/plugins/exec-staged.test.ts
@@ -1,0 +1,43 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { main } from "../../src/index.js";
+import { resolve } from "../../src/util/path.js";
+import baseArguments from "../helpers/baseArguments.js";
+import baseCounters from "../helpers/baseCounters.js";
+
+const cwd = resolve("fixtures/plugins/exec-staged");
+
+test("Find dependencies with the exec-staged plugin", async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert(issues.binaries["package.json"]["eslint"]);
+  assert(issues.binaries["package.json"]["prettier"]);
+  assert(issues.binaries["exec-staged.config.js"]["eslint"]);
+  assert(issues.binaries["exec-staged.config.js"]["prettier"]);
+  assert(issues.devDependencies["package.json"]["exec-staged"]);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    binaries: 4,
+    devDependencies: 1,
+    processed: 1,
+    total: 1,
+  });
+});
+
+test("Find dependencies with the exec-staged plugin (production)", async () => {
+  const { counters } = await main({
+    ...baseArguments,
+    cwd,
+    isProduction: true,
+  });
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 0,
+    total: 0,
+  });
+});

--- a/packages/knip/test/plugins/exec-staged.test.ts
+++ b/packages/knip/test/plugins/exec-staged.test.ts
@@ -1,23 +1,23 @@
-import { test } from "bun:test";
-import assert from "node:assert/strict";
-import { main } from "../../src/index.js";
-import { resolve } from "../../src/util/path.js";
-import baseArguments from "../helpers/baseArguments.js";
-import baseCounters from "../helpers/baseCounters.js";
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
 
-const cwd = resolve("fixtures/plugins/exec-staged");
+const cwd = resolve('fixtures/plugins/exec-staged');
 
-test("Find dependencies with the exec-staged plugin", async () => {
+test('Find dependencies with the exec-staged plugin', async () => {
   const { issues, counters } = await main({
     ...baseArguments,
     cwd,
   });
 
-  assert(issues.binaries["package.json"]["eslint"]);
-  assert(issues.binaries["package.json"]["prettier"]);
-  assert(issues.binaries["exec-staged.config.js"]["eslint"]);
-  assert(issues.binaries["exec-staged.config.js"]["prettier"]);
-  assert(issues.devDependencies["package.json"]["exec-staged"]);
+  assert(issues.binaries['package.json']['eslint']);
+  assert(issues.binaries['package.json']['prettier']);
+  assert(issues.binaries['exec-staged.config.js']['eslint']);
+  assert(issues.binaries['exec-staged.config.js']['prettier']);
+  assert(issues.devDependencies['package.json']['exec-staged']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
@@ -28,7 +28,7 @@ test("Find dependencies with the exec-staged plugin", async () => {
   });
 });
 
-test("Find dependencies with the exec-staged plugin (production)", async () => {
+test('Find dependencies with the exec-staged plugin (production)', async () => {
   const { counters } = await main({
     ...baseArguments,
     cwd,


### PR DESCRIPTION
I wrote [`exec-staged`](https://github.com/ItsNickBarry/exec-staged) because `lint-staged` doesn't support Knip.  This PR adds Knip support for `exec-staged`.