### PR TITLE
Handle SvelteKit service worker integration

### DIFF
--- a/packages/knip/src/plugins/svelte/index.ts
+++ b/packages/knip/src/plugins/svelte/index.ts
@@ -18,11 +18,13 @@ const production = [
   'src/routes/**/+{page,server,page.server,error,layout,layout.server}{,@*}.{js,ts,svelte}',
   'src/hooks.{server,client}.{js,ts}',
   'src/params/*.{js,ts}',
+  'src/service-worker{.js,.ts,/index.{js,ts}}',
 ];
 
 const resolve: Resolve = options => {
-  const alias = toAlias('$app/*', [join(options.cwd, 'node_modules/@sveltejs/kit/src/runtime/app/*')]);
-  return [alias];
+  const app = toAlias('$app/*', [join(options.cwd, 'node_modules/@sveltejs/kit/src/runtime/app/*')]);
+  const sw = toAlias('$service-worker', [join(options.cwd, 'node_modules/@sveltejs/kit/types/index.d.ts')]);
+  return [app, sw];
 };
 
 export default {


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Probably needs some more code [in case the service worker path is changed in the sveltekit config](https://svelte.dev/docs/kit/configuration#files:~:text=app%20(see%20Routing)-,serviceWorker,-?:%20string;) (to change the entry), or [automatic sw registration is disabled](https://svelte.dev/docs/kit/configuration#serviceWorker) (to remove the entry)

Relevant config pages: https://svelte.dev/docs/kit/service-workers (general info) and https://svelte.dev/docs/kit/$service-worker (for the `$service-worker` alias)
