### PR TITLE
Update reporters to have the correct name for the default reporter

### DIFF
--- a/packages/docs/src/content/docs/features/reporters.md
+++ b/packages/docs/src/content/docs/features/reporters.md
@@ -12,7 +12,7 @@ Knip provides the following built-in reporters:
 - [`json`][2]
 - [`markdown`][3]
 - [`codeclimate`][4]
-- `symbol` (default)
+- `symbols` (default)
 
 Example usage:
 


### PR DESCRIPTION
In the docs currently it says the default reporter is `symbol`. This is not true, if you do `--report symbol` you get an error. 

After looking at the code it turns out that the reporter is actually called `symbols`. I have updated the docs so if you are reading the docs you will see the correct reporter name.

Thanks for this brilliant project!