### PR TITLE
Support Vitest projects configuration for dynamic project discovery

### DIFF
--- a/packages/knip/fixtures/plugins/vitest9/package.json
+++ b/packages/knip/fixtures/plugins/vitest9/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixtures/vitest9",
+  "workspaces": ["packages/*"],
+  "devDependencies": {
+    "vitest": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/vitest9/packages/client/e2e-setup.ts
+++ b/packages/knip/fixtures/plugins/vitest9/packages/client/e2e-setup.ts
@@ -1,0 +1,3 @@
+export function setup() {
+  // E2E test setup
+}

--- a/packages/knip/fixtures/plugins/vitest9/packages/client/e2e/client.test.ts
+++ b/packages/knip/fixtures/plugins/vitest9/packages/client/e2e/client.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from 'vitest';
+
+test('client e2e test', () => {
+  expect(true).toBe(true);
+});

--- a/packages/knip/fixtures/plugins/vitest9/packages/client/package.json
+++ b/packages/knip/fixtures/plugins/vitest9/packages/client/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/vitest9-client",
+  "devDependencies": {
+    "vitest": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/vitest9/packages/client/vitest.config.e2e.ts
+++ b/packages/knip/fixtures/plugins/vitest9/packages/client/vitest.config.e2e.ts
@@ -1,0 +1,8 @@
+export default {
+  test: {
+    name: 'client-e2e',
+    include: ['e2e/**/*.test.ts'],
+    setupFiles: ['./e2e-setup.ts'],
+    environment: 'happy-dom',
+  },
+};

--- a/packages/knip/fixtures/plugins/vitest9/src/example.test.ts
+++ b/packages/knip/fixtures/plugins/vitest9/src/example.test.ts
@@ -1,0 +1,8 @@
+// Unit test file
+import { describe, it, expect } from 'vitest';
+
+describe('example unit test', () => {
+  it('should work', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/packages/knip/fixtures/plugins/vitest9/src/unit.setup.ts
+++ b/packages/knip/fixtures/plugins/vitest9/src/unit.setup.ts
@@ -1,0 +1,3 @@
+export function setup() {
+  // Unit test setup
+}

--- a/packages/knip/fixtures/plugins/vitest9/vitest.config.ts
+++ b/packages/knip/fixtures/plugins/vitest9/vitest.config.ts
@@ -1,0 +1,18 @@
+export default {
+  test: {
+    projects: [
+      {
+        name: 'unit',
+        test: {
+          include: ['src/**/*.test.ts'],
+          setupFiles: ['./src/unit.setup.ts'],
+          environment: 'jsdom',
+        },
+      },
+      'packages/*/vitest.config.e2e.ts',
+    ],
+    coverage: {
+      enabled: false,
+    },
+  },
+};

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -1,7 +1,8 @@
 import { DEFAULT_EXTENSIONS } from '../../constants.js';
 import type { IsPluginEnabled, Plugin, PluginOptions, ResolveConfig } from '../../types/config.js';
 import type { PackageJson } from '../../types/package-json.js';
-import { type Input, toAlias, toDeferResolve, toDependency, toEntry } from '../../util/input.js';
+import { _glob } from '../../util/glob.js';
+import { type Input, toAlias, toConfig, toDeferResolve, toDependency, toEntry } from '../../util/input.js';
 import { join, toPosix } from '../../util/path.js';
 import { hasDependency } from '../../util/plugin.js';
 import { getEnvPackageName, getExternalReporters } from './helpers.js';
@@ -50,11 +51,21 @@ const findConfigDependencies = (localConfig: ViteConfig, options: PluginOptions)
     }
   }
 
+  const projectsDependencies: Input[] = [];
+  if (testConfig.projects !== undefined) {
+    for (const projectConfig of testConfig.projects) {
+      if (typeof projectConfig !== 'string') {
+        projectsDependencies.push(...findConfigDependencies(projectConfig, options));
+      }
+    }
+  }
+
   return [
     ...[...environments, ...reporters, ...coverage].map(id => toDependency(id)),
     ...setupFiles,
     ...globalSetup,
     ...workspaceDependencies,
+    ...projectsDependencies,
   ];
 };
 
@@ -67,10 +78,24 @@ const getConfigs = async (localConfig: ViteConfigOrFn | VitestWorkspaceConfig) =
           for (const mode of ['development', 'production'] as MODE[]) {
             const cfg = await config({ command, mode, ssrBuild: undefined });
             configs.push(cfg);
+            if (cfg.test?.projects) {
+              for (const project of cfg.test.projects) {
+                if (typeof project !== 'string') {
+                  configs.push(project);
+                }
+              }
+            }
           }
         }
       } else {
         configs.push(config);
+        if (config.test?.projects) {
+          for (const project of config.test.projects) {
+            if (typeof project !== 'string') {
+              configs.push(project);
+            }
+          }
+        }
       }
     }
   }
@@ -83,6 +108,23 @@ export const resolveConfig: ResolveConfig<ViteConfigOrFn | VitestWorkspaceConfig
   inputs.add(toEntry(join(options.cwd, 'src/vite-env.d.ts')));
 
   const configs = await getConfigs(localConfig);
+
+  for (const cfg of configs) {
+    if (cfg.test?.projects) {
+      for (const project of cfg.test.projects) {
+        if (typeof project === 'string') {
+          const projectFiles = await _glob({
+            cwd: options.cwd,
+            patterns: [project],
+            gitignore: false,
+          });
+          for (const projectFile of projectFiles) {
+            inputs.add(toConfig('vitest', projectFile, { containingFilePath: options.configFilePath }));
+          }
+        }
+      }
+    }
+  }
 
   const addStar = (value: string) => (value.endsWith('*') ? value : join(value, '*').replace(/\/\*\*$/, '/*'));
   const addAliases = (aliasOptions: AliasOptions) => {

--- a/packages/knip/src/plugins/vitest/types.ts
+++ b/packages/knip/src/plugins/vitest/types.ts
@@ -19,6 +19,7 @@ interface VitestConfig {
     reporters?: (string | [string, unknown] | unknown)[];
     setupFiles?: string | string[];
     workspace?: (ViteConfig & { test: VitestConfig['test'] & { workspace: never } })[];
+    projects?: (string | (ViteConfig & { test: VitestConfig['test'] & { projects: never } }))[];
     alias?: AliasOptions;
   };
 }

--- a/packages/knip/test/plugins/vitest9.test.ts
+++ b/packages/knip/test/plugins/vitest9.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/plugins/vitest9');
+
+test('Find dependencies in vitest configuration (projects with inline and external)', async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert(issues.unlisted['vitest.config.ts']['jsdom']);
+  assert(issues.unlisted['packages/client/vitest.config.e2e.ts']['happy-dom']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    files: 0,
+    devDependencies: 0,
+    unlisted: 2,
+    unresolved: 0,
+    processed: 6,
+    total: 6,
+  });
+});


### PR DESCRIPTION
## Summary
Adds support for Vitest's `projects` configuration that allows defining test projects through inline configurations and external file patterns. External project files are resolved from glob patterns and their dependencies are correctly assigned to their respective workspace locations.

Resolves #1114

## Changes
- Added `projects` field to VitestConfig interface supporting both inline configs and glob patterns
- Implemented dynamic glob resolution for external project files using `_glob` utility
- External project configurations loaded using `toConfig()` for proper workspace assignment
- Created test fixture with both inline and external project configurations
- Dependencies from external projects are correctly attributed to their respective config files

## Test plan
- All existing tests pass
- New vitest9 test verifies both inline and external project dependency detection
- External project configs loaded via glob patterns work correctly
- Backward compatibility maintained for workspace configuration
- No regressions introduced