### PR TITLE
Mention `eslint-import-resolver-typescript` in docs

### DIFF
--- a/packages/knip/src/plugins/eslint/index.ts
+++ b/packages/knip/src/plugins/eslint/index.ts
@@ -59,9 +59,7 @@ consider using an extended glob pattern like this:
 
 ### \`eslint-import-resolver-typescript\`
 
-If you're using \`eslint-plugin-import\` or \`eslint-plugin-import-x\` with custom resolvers, you have to specify them in ESLint's config even if they're normally picked up automatically by those plugins:
-
-consider using an extended glob pattern like this:
+If you're using \`eslint-plugin-import\` or \`eslint-plugin-import-x\` with custom resolvers, you have to specify them in ESLint's config:
 
 \`\`\`js
 

--- a/packages/knip/src/plugins/eslint/index.ts
+++ b/packages/knip/src/plugins/eslint/index.ts
@@ -56,6 +56,27 @@ consider using an extended glob pattern like this:
   "eslint": ["**/.eslintrc.js"]
 }
 \`\`\`
+
+### \`eslint-import-resolver-typescript\`
+
+If you're using \`eslint-plugin-import\` or \`eslint-plugin-import-x\` with custom resolvers, you have to specify them in ESLint's config even if they're normally picked up automatically by those plugins:
+
+consider using an extended glob pattern like this:
+
+\`\`\`js
+
+export default [
+  {
+    settings: {
+      "import/resolver": {
+        typescript: true,
+      },
+    },
+  },
+
+  // The rest of your tsconfig
+]
+\`\`\`
 `;
 
 /** @public */


### PR DESCRIPTION
`eslint-plugin-import` and `eslint-plugin-import-x` don't need this config, they pick up the resolver automatically, hence the confusion by many in:

- https://github.com/webpro-nl/knip/issues/806

---

By the way, the "Edit page" link in https://knip.dev/reference/plugins/eslint#generated-from-source is a 404. Maybe it should be removed or pointed to the same link as [_"eslint plugin source code"_](https://github.com/webpro-nl/knip/blob/main/packages/knip/src/plugins/eslint/index.ts))