### PR TITLE
Fix Angular plugin to allow for @angular/build

### DIFF
--- a/packages/knip/fixtures/plugins/angular2/angular.json
+++ b/packages/knip/fixtures/plugins/angular2/angular.json
@@ -20,7 +20,7 @@
           }
         },
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
             "outputPath": "dist/blorp",
             "index": "src/index.html",
@@ -72,7 +72,7 @@
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "blorp:build:production"
@@ -84,10 +84,10 @@
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",

--- a/packages/knip/fixtures/plugins/angular2/package.json
+++ b/packages/knip/fixtures/plugins/angular2/package.json
@@ -10,7 +10,7 @@
     "@angular/cli": "*",
     "@angular/ssr": "*",
     "@angular-builders/custom-esbuild": "*",
-    "@angular-devkit/build-angular": "*",
+    "@angular/build": "*",
     "karma": "*"
   }
 }

--- a/packages/knip/src/plugins/angular/index.ts
+++ b/packages/knip/src/plugins/angular/index.ts
@@ -33,7 +33,7 @@ const resolveConfig: ResolveConfig<AngularCLIWorkspaceConfiguration> = async (co
     for (const [targetName, target] of Object.entries(project.architect)) {
       const { options: opts, configurations: configs } = target;
       const [packageName] = typeof target.builder === 'string' ? target.builder.split(':') : [];
-      if (typeof packageName === 'string') inputs.add(toDependency(packageName));
+      if (packageName) inputs.add(toDependency(packageName));
       if (opts) {
         if ('tsConfig' in opts && typeof opts.tsConfig === 'string') {
           inputs.add(toConfig('typescript', opts.tsConfig, { containingFilePath: configFilePath }));
@@ -79,7 +79,7 @@ const resolveConfig: ResolveConfig<AngularCLIWorkspaceConfiguration> = async (co
           );
         }
       }
-      if (target.builder === '@angular-devkit/build-angular:karma' && opts) {
+      if (target.builder && isAngularBuilderRefWithName({ builderRef: target.builder, name: 'karma' }) && opts) {
         const karmaBuilderOptions = opts as KarmaTarget;
         // https://github.com/angular/angular-cli/blob/19.0.6/packages/angular_devkit/build_angular/src/builders/karma/schema.json#L143
         const testFilePatterns = karmaBuilderOptions.include ?? ['**/*.spec.ts'];
@@ -147,6 +147,11 @@ const entriesByOption = (opts: TargetOptions): EntriesByOption =>
           : [],
     })
   );
+
+const isAngularBuilderRefWithName = ({ builderRef, name }: { builderRef: string; name: string }) => {
+  const [pkg, builderName] = builderRef.split(':');
+  return (pkg === '@angular-devkit/build-angular' || pkg === '@angular/build') && builderName === name;
+};
 
 type TargetOptions = Exclude<Target['options'], undefined>;
 type Target = Architect[string];


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
Angular plugin didn't detect Karma related dependencies after migrating to `@angular/build` builder (from `@angular-devkit/build-angular`). Here we allow for detecting Karma dependencies in both scenarios.

Angular 2 tests have been updated to use `@angular/build` to take these new builders into account in general too

PD: [Angular is migrating to `@angular/build` package for builders as has less dependencies if using the new build system](https://github.com/angular/angular-cli/pull/27520)
