### PR TITLE
Support new biome config extends definition 

### DIFF
--- a/packages/knip/biome.json
+++ b/packages/knip/biome.json
@@ -2,7 +2,12 @@
   "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
   "extends": ["../../biome.json"],
   "files": {
-    "ignore": ["**/dist", "package.json", "vendor/bash-parser/index.js"]
+    "ignore": [
+      "**/dist",
+      "package.json",
+      "vendor/bash-parser/index.js",
+      "fixtures/plugins/biome-workspace/packages/stub"
+    ]
   },
   "formatter": {
     "ignore": ["ignore-exports-used-in-file-alias-exclude/more.ts"]

--- a/packages/knip/fixtures/plugins/biome-workspace/biome.jsonc
+++ b/packages/knip/fixtures/plugins/biome-workspace/biome.jsonc
@@ -1,7 +1,4 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
-  "extends": ["@org/shared-configs/biome"],
-  "files": {
-    "includes": ["**", "!**/node_modules/**"]
-  }
+  "extends": ["@org/shared-configs/biome"]
 }

--- a/packages/knip/fixtures/plugins/biome-workspace/biome.jsonc
+++ b/packages/knip/fixtures/plugins/biome-workspace/biome.jsonc
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
+  "extends": ["@org/shared-configs/biome"],
+  "files": {
+    "includes": ["**", "!**/node_modules/**"]
+  }
+}

--- a/packages/knip/fixtures/plugins/biome-workspace/node_modules/@biomejs/biome/package.json
+++ b/packages/knip/fixtures/plugins/biome-workspace/node_modules/@biomejs/biome/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@biomejs/biome",
+    "bin": {
+      "biome": "bin/biome"
+    }
+  }

--- a/packages/knip/fixtures/plugins/biome-workspace/node_modules/@org/shared-configs/biome.json
+++ b/packages/knip/fixtures/plugins/biome-workspace/node_modules/@org/shared-configs/biome.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json"
+}

--- a/packages/knip/fixtures/plugins/biome-workspace/node_modules/@org/shared-configs/package.json
+++ b/packages/knip/fixtures/plugins/biome-workspace/node_modules/@org/shared-configs/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@org/shared-configs",
+    "type": "module",
+    "exports": {
+      "./biome": "./biome.json"
+    }
+  }

--- a/packages/knip/fixtures/plugins/biome-workspace/package.json
+++ b/packages/knip/fixtures/plugins/biome-workspace/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@plugins/biome-workspace",
+  "module": "index.ts",
+  "type": "module",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "lint": "biome lint ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "*",
+    "@org/shared-configs": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/biome-workspace/packages/stub/biome.json
+++ b/packages/knip/fixtures/plugins/biome-workspace/packages/stub/biome.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
+  "extends": "//"
+}

--- a/packages/knip/fixtures/plugins/biome-workspace/packages/stub/package.json
+++ b/packages/knip/fixtures/plugins/biome-workspace/packages/stub/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "stub-package"
+}

--- a/packages/knip/src/plugins/biome/index.ts
+++ b/packages/knip/src/plugins/biome/index.ts
@@ -1,9 +1,8 @@
 import type { IsPluginEnabled, Plugin, PluginOptions, ResolveConfig } from '../../types/config.js';
 import { arrayify } from '../../util/array.js';
 import { type Input, toConfig } from '../../util/input.js';
-import { extname, join } from '../../util/path.js';
+import { join } from '../../util/path.js';
 import { hasDependency } from '../../util/plugin.js';
-import { _createSyncResolver } from '../../util/resolve.js';
 import type { BiomeConfig } from './types.js';
 
 const title = 'Biome';
@@ -13,23 +12,15 @@ const enablers = ['@biomejs/biome'];
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
 const config: string[] = ['biome.json', 'biome.jsonc'];
-const configExtensions = config.map(configFileName => extname(configFileName));
-
-const resolveRootConfigReference = (specifier: string, baseDir: string) => {
-  const resolver = _createSyncResolver(configExtensions);
-  const resolvedPath = resolver(specifier, baseDir);
-
-  return resolvedPath;
-};
 
 const isRootConfigReference = (specifier: string) => specifier === '//';
 
 const resolveExtends = (extendsArray: string[], options: PluginOptions): Input[] => {
   return extendsArray.map(specifier => {
     if (isRootConfigReference(specifier)) {
-      const resolvedSpecifier = resolveRootConfigReference(join(options.rootCwd, 'biome'), options.rootCwd);
-      return toConfig('biome', resolvedSpecifier ?? specifier, { containingFilePath: options.configFilePath });
+      return toConfig('biome', join(options.rootCwd, 'biome'), { containingFilePath: options.configFilePath });
     }
+
     return toConfig('biome', specifier, { containingFilePath: options.configFilePath });
   });
 };

--- a/packages/knip/src/plugins/biome/index.ts
+++ b/packages/knip/src/plugins/biome/index.ts
@@ -26,7 +26,7 @@ const resolveExtends = (extendsArray: string[], options: PluginOptions): Input[]
 };
 
 const resolveConfig: ResolveConfig<BiomeConfig> = (config, options) => {
-  return [...resolveExtends(arrayify(config.extends || []), options)];
+  return [...resolveExtends(arrayify(config.extends), options)];
 };
 
 export default {

--- a/packages/knip/src/plugins/biome/index.ts
+++ b/packages/knip/src/plugins/biome/index.ts
@@ -1,6 +1,9 @@
 import type { IsPluginEnabled, Plugin, PluginOptions, ResolveConfig } from '../../types/config.js';
+import { arrayify } from '../../util/array.js';
 import { type Input, toConfig } from '../../util/input.js';
+import { extname, join } from '../../util/path.js';
 import { hasDependency } from '../../util/plugin.js';
+import { _createSyncResolver } from '../../util/resolve.js';
 import type { BiomeConfig } from './types.js';
 
 const title = 'Biome';
@@ -10,13 +13,29 @@ const enablers = ['@biomejs/biome'];
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
 const config: string[] = ['biome.json', 'biome.jsonc'];
+const configExtensions = config.map(configFileName => extname(configFileName));
+
+const resolveRootConfigReference = (specifier: string, baseDir: string) => {
+  const resolver = _createSyncResolver(configExtensions);
+  const resolvedPath = resolver(specifier, baseDir);
+
+  return resolvedPath;
+};
+
+const isRootConfigReference = (specifier: string) => specifier === '//';
 
 const resolveExtends = (extendsArray: string[], options: PluginOptions): Input[] => {
-  return extendsArray.map(specifier => toConfig('biome', specifier, { containingFilePath: options.configFilePath }));
+  return extendsArray.map(specifier => {
+    if (isRootConfigReference(specifier)) {
+      const resolvedSpecifier = resolveRootConfigReference(join(options.rootCwd, 'biome'), options.rootCwd);
+      return toConfig('biome', resolvedSpecifier ?? specifier, { containingFilePath: options.configFilePath });
+    }
+    return toConfig('biome', specifier, { containingFilePath: options.configFilePath });
+  });
 };
 
 const resolveConfig: ResolveConfig<BiomeConfig> = (config, options) => {
-  return [...resolveExtends(config.extends || [], options)];
+  return [...resolveExtends(arrayify(config.extends || []), options)];
 };
 
 export default {

--- a/packages/knip/src/util/resolve.ts
+++ b/packages/knip/src/util/resolve.ts
@@ -17,7 +17,7 @@ const createSyncResolver = (extensions: string[]) => {
   };
 };
 
-const resolveSync = createSyncResolver([...DEFAULT_EXTENSIONS, '.json']);
+const resolveSync = createSyncResolver([...DEFAULT_EXTENSIONS, '.json', '.jsonc']);
 
 export const _resolveSync = timerify(resolveSync);
 

--- a/packages/knip/test/plugins/biome-workspace.test.ts
+++ b/packages/knip/test/plugins/biome-workspace.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/plugins/biome-workspace');
+
+test('Find dependencies with the biome plugin within a workspace', async () => {
+  const { counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
## Add support for biome(2.x) new `config.extends` format
> Related issue https://github.com/webpro-nl/knip/issues/1154

Since biome 2.0.0, they introduce support for workspace support and a new format for extends that can now be either an array of config to extends (same behavior than previous major version) or a reference to the workspace with a new "micro-syntax" (explained here https://biomejs.dev/guides/big-projects/#monorepo) (eg: `{ "extends: "//" }` will mean extends root workspace config)

## Summary of changes
- Updated the biome plugin `resolveConfig` in order to handle new extends format (either single or array)
- Resolve `"extends": "//"` -> `"extends": "[workspaceroot]/biome.(json|jsonc}"`

I'm still exploring project, I have added a new basic fixtutre `biome-workspace` in order to test this behavior, I would love to have some guidance here in order to add (if needed) more relevant test cases.

And i'm not really sure where and how should i resolve project root reference, since it's really tight to biome, I tried to keep things inside biome plugin file
 