### PR TITLE
Correctly detect used/unused namespace exports that begin with double underscores

### DIFF
--- a/packages/knip/fixtures/exports-special-characters/exports.ts
+++ b/packages/knip/fixtures/exports-special-characters/exports.ts
@@ -1,6 +1,7 @@
 export const $dollar = '$';
 export const dollar$ = '$$';
 export const _underscore = '_';
+export const __underscores = '__';
 
 export class DollarMembers {
   $member: string;

--- a/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/imported.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/imported.ts
@@ -1,0 +1,2 @@
+export const __underscoresUnused = 'underscoresUnused';
+export const __underscoresUsed = 'underscoresUsed';

--- a/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/index.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/index.ts
@@ -1,0 +1,5 @@
+import { __underscoresUsed } from './imported';
+import * as NS from './namespace';
+
+__underscoresUsed;
+NS.__underscoresUsed;

--- a/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/knip.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/knip.json
@@ -1,0 +1,3 @@
+{
+  "ignoreExportsUsedInFile": true
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/namespace.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/namespace.ts
@@ -1,0 +1,2 @@
+export const __underscoresUnused = 'underscoresUnused';
+export const __underscoresUsed = 'underscoresUsed';

--- a/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/package.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/ignore-exports-used-in-file-id-underscores"
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/tsconfig.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file-id-underscores/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/knip/src/typescript/ast-helpers.ts
+++ b/packages/knip/src/typescript/ast-helpers.ts
@@ -181,7 +181,7 @@ const getMemberStringLiterals = (typeChecker: ts.TypeChecker, node: ts.Node) => 
   }
 
   if (ts.isPropertyAccessExpression(node)) {
-    return [node.name.escapedText as string];
+    return [node.name.getText()];
   }
 };
 

--- a/packages/knip/test/exports-special-characters.test.ts
+++ b/packages/knip/test/exports-special-characters.test.ts
@@ -16,6 +16,7 @@ test('Handle special characters in named exports and members', async () => {
   assert(issues.exports['exports.ts']['$dollar']);
   assert(issues.exports['exports.ts']['dollar$']);
   assert(issues.exports['exports.ts']['_underscore']);
+  assert(issues.exports['exports.ts']['__underscores']);
   assert(issues.exports['exports.ts']['$Dollar']);
 
   assert(issues.types['exports.ts']['$DollarType']);
@@ -28,7 +29,7 @@ test('Handle special characters in named exports and members', async () => {
   assert.deepEqual(counters, {
     ...baseCounters,
     classMembers: 4,
-    exports: 4,
+    exports: 5,
     types: 1,
     processed: 2,
     total: 2,
@@ -45,6 +46,7 @@ test('Handle special characters in named exports and members (nsTypes)', async (
   assert(issues.exports['exports.ts']['$dollar']);
   assert(issues.exports['exports.ts']['dollar$']);
   assert(issues.exports['exports.ts']['_underscore']);
+  assert(issues.exports['exports.ts']['__underscores']);
   assert(issues.exports['exports.ts']['$Dollar']);
 
   assert(issues.types['exports.ts']['$DollarType']);
@@ -79,7 +81,7 @@ test('Handle special characters in named exports and members (nsTypes)', async (
     ...baseCounters,
     classMembers: 4,
     enumMembers: 20,
-    exports: 4,
+    exports: 5,
     types: 1,
     processed: 2,
     total: 2,

--- a/packages/knip/test/ignore-exports-used-in-file-id-underscores.test.ts
+++ b/packages/knip/test/ignore-exports-used-in-file-id-underscores.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../src/index.js';
+import { resolve } from '../src/util/path.js';
+import baseArguments from './helpers/baseArguments.js';
+import baseCounters from './helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/ignore-exports-used-in-file-id-underscores');
+
+test('Find unused exports when identifiers begin with two underscores', async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert.equal(issues.exports['imported.ts']['__underscoresUnused'].symbol, '__underscoresUnused');
+  assert.equal(issues.exports['namespace.ts']['__underscoresUnused'].symbol, '__underscoresUnused');
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    exports: 2,
+    processed: 3,
+    total: 3,
+  });
+});


### PR DESCRIPTION
**Bug**
knip fails to detect that an identifier beginning with two underscores is used when accessed as a namespace property.

**Example**
```
// exports.js
export const __foo = 1;

// imports.js
import * as NS from "./exports.js";

console.log(NS.__foo);
```

**Explanation**
In the above example, the export of `__foo` is processed [here](https://github.com/webpro-nl/knip/blob/cbfb9c3b1c6fd4f77b5e5f0987e0f027ee609feb/packages/knip/src/typescript/visitors/exports/exportKeyword.ts). Importantly, the identifier name is obtained using `getText()`.

However, the namespace property access `NS.__foo` is processed [here](https://github.com/webpro-nl/knip/blob/cbfb9c3b1c6fd4f77b5e5f0987e0f027ee609feb/packages/knip/src/typescript/ast-helpers.ts#L184) using `node.name.escapedText`. For identifiers that start with two or more underscores, `escapedText` intentionally adds an _additional_ underscore (see discussion at https://github.com/microsoft/TypeScript/issues/46401). As a result, the export name is incorrectly not found in the analysis of used exports.

**Fix**
Change `ast-helpers.ts` to use `getText()` [here](https://github.com/webpro-nl/knip/compare/main...akallem:knip:fix/id-underscores?expand=1#diff-bedfe15e5c9800561eb8ac5d536ad02084cb1b5c9c1b72f2d8dc84acc6d65e2fR184).

**Tests**
Added a new test `ignore-exports-used-in-file-id-underscores.test.ts` to verify the fix. This new test fails if the proposed fix is reverted.

Also added an additional example and assertion to `exports-special-characters.test.ts`. This passes both before and after the proposed fix, nevertheless it seemed worthwhile to check.