### PR TITLE
Allow TypeScript betas as a peer dependency of knip

### DIFF
--- a/packages/knip/package.json
+++ b/packages/knip/package.json
@@ -77,7 +77,7 @@
   },
   "peerDependencies": {
     "@types/node": ">=18",
-    "typescript": ">=5.0.4"
+    "typescript": ">=5.0.4 || >=5.9.0-0"
   },
   "devDependencies": {
     "@jest/types": "^29.6.3",


### PR DESCRIPTION
Fixes https://github.com/webpro-nl/knip/issues/609 according to @voxpelli. Seems like an easy enough fix, the problem is having to do this every 3 months

```diff
-    "typescript": ">=5.0.4 || >=5.9.0-0"
+    "typescript": ">=5.0.4 || >=6.0.0-0"
```
```diff
-    "typescript": ">=5.0.4 || >=6.0.0-0"
+    "typescript": ">=5.0.4 || >=6.1.0-0"
```
