### PR TITLE
Add bun.lock support in @knip/create-config

### DIFF
--- a/packages/create-config/index.js
+++ b/packages/create-config/index.js
@@ -26,6 +26,7 @@ const getPackageManager = () => {
       .trim();
   } catch {}
 
+  if (fileExists(path.join(repositoryRoot, 'bun.lock'))) return 'bun';
   if (fileExists(path.join(repositoryRoot, 'bun.lockb'))) return 'bun';
   if (fileExists(path.join(repositoryRoot, 'yarn.lock'))) {
     const yarnLock = readFirstBytes(path.join(repositoryRoot, 'yarn.lock'), 128);


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

`@knip/create-config` was only checking for the old `bun.lockb` file, so running it in new bun projects with `bun.lock` it will use `npm` instead of `bun`