### PR TITLE
Rspack plugin: add mts and cts file extension support

### DIFF
--- a/packages/knip/src/plugins/rspack/index.ts
+++ b/packages/knip/src/plugins/rspack/index.ts
@@ -11,7 +11,7 @@ const enablers = ['@rspack/core'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['rspack.config*.{js,ts,mjs,cjs}'];
+const config = ['rspack.config*.{js,ts,mjs,mts,cjs,cts}'];
 
 const resolveConfig: ResolveConfig<WebpackConfig> = async (localConfig, options) => {
   const inputs = await findWebpackDependenciesFromConfig(localConfig, options);


### PR DESCRIPTION
My project is using an `.mts` file extension for our Rspack config, and I noticed that it wasn't getting automatically included.