### PR TITLE
Add Playwright CT CSS fixture and update entry patterns

### DIFF
--- a/packages/knip/fixtures/plugins/playwright-ct/playwright/common.css
+++ b/packages/knip/fixtures/plugins/playwright-ct/playwright/common.css
@@ -1,0 +1,3 @@
+body {
+    background-color: #f0f0f0;
+}

--- a/packages/knip/fixtures/plugins/playwright-ct/playwright/index.tsx
+++ b/packages/knip/fixtures/plugins/playwright-ct/playwright/index.tsx
@@ -1,2 +1,2 @@
 // Import styles, initialize component theme here.
-// import '../src/common.css';
+import './common.css';

--- a/packages/knip/src/plugins/playwright-ct/index.ts
+++ b/packages/knip/src/plugins/playwright-ct/index.ts
@@ -1,6 +1,6 @@
 import type { IsPluginEnabled, Plugin } from '../../types/config.js';
 import { hasDependency } from '../../util/plugin.js';
-import { entry, resolveConfig } from '../playwright/index.js';
+import { resolveConfig } from '../playwright/index.js';
 
 // https://playwright.dev/docs/test-components
 
@@ -10,7 +10,9 @@ const enablers = [/^@playwright\/experimental-ct-/];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['playwright-ct.config.{js,ts}', 'playwright/index.{js,ts,jsx,tsx}'];
+const config = ['playwright-ct.config.{js,ts}'];
+
+const entry = ['**/*.@(spec|test).?(c|m)[jt]s?(x)', 'playwright/index.{js,ts,jsx,tsx}']
 
 export default {
   title,

--- a/packages/knip/src/plugins/playwright/index.ts
+++ b/packages/knip/src/plugins/playwright/index.ts
@@ -15,7 +15,7 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 
 const config = ['playwright.config.{js,ts,mjs}'];
 
-export const entry = ['**/*.@(spec|test).?(c|m)[jt]s?(x)'];
+const entry = ['**/*.@(spec|test).?(c|m)[jt]s?(x)'];
 
 const toEntryPatterns = (
   testMatch: string | RegExp | Array<string | RegExp>,

--- a/packages/knip/test/plugins/playwright-ct.test.ts
+++ b/packages/knip/test/plugins/playwright-ct.test.ts
@@ -13,6 +13,7 @@ test('Find dependencies with the Playwright for components plugin', async () => 
 
   assert.deepEqual(counters, {
     ...baseCounters,
+    files: 1,
     devDependencies: 0,
     unlisted: 0,
     processed: 3,


### PR DESCRIPTION
Resolve #1213
- Move config `playwright/index.{ts,js}` into playwright-ct entry
- Add new testcase to have css