### PR TITLE
Add `env-cmd` Support

### DIFF
--- a/packages/knip/src/binaries/fallback.ts
+++ b/packages/knip/src/binaries/fallback.ts
@@ -9,7 +9,7 @@ import { toBinary, toDeferResolve, toEntry } from '../util/input.js';
 const spawningBinaries = ['cross-env', 'retry-cli'];
 
 // Binaries that have a new script behind the double-dash/end-of-command
-const endOfCommandBinaries = ['dotenvx'];
+const endOfCommandBinaries = ['dotenvx', 'env-cmd'];
 
 // Binaries with entry at first positional arg
 const positionals = new Set(['babel-node', 'esbuild', 'execa', 'jiti', 'oxnode', 'vite-node', 'zx']);

--- a/packages/knip/test/util/get-inputs-from-scripts.test.ts
+++ b/packages/knip/test/util/get-inputs-from-scripts.test.ts
@@ -253,6 +253,7 @@ test('getInputsFromScripts (concurrently)', () => {
 
 test('getInputsFromScripts (double-dash)', () => {
   t('dotenvx run --convention=nextjs -- tsx watch src/index.ts', [toBinary('dotenvx'), toBinary('tsx'), toDeferResolveEntry('src/index.ts', opt)]);
+  t('env-cmd --no-overrides -- tsx watch src/index.ts', [toBinary('env-cmd'), toBinary('tsx'), toDeferResolveEntry('src/index.ts', opt)]);
 });
 
 test('getInputsFromScripts (bash expressions)', () => {


### PR DESCRIPTION
[`env-cmd`](https://github.com/toddbluhm/env-cmd) just had a v11 release that enforces `--` usage like `dotenvx` - this PR adds support for it.

If you're wondering why someone would use `env-cmd` over `dotenvx` - `env-cmd` has different behavior (doesn't do a load of logging), different defaults (overriding existing env vars), and supports more file formats (JSON etc.) - which is crucial when you don't have control over the format (for example, Google Cloud Functions require JSON dotenv files).