### PR TITLE
Fix package name of rslib enabler

### DIFF
--- a/packages/knip/fixtures/plugins/rslib/package.json
+++ b/packages/knip/fixtures/plugins/rslib/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "@plugins/rslib"
+  "name": "@plugins/rslib",
+  "devDependencies": {
+    "@rslib/core": "*"
+  }
 }

--- a/packages/knip/fixtures/plugins/rslib/rslib.config.ts
+++ b/packages/knip/fixtures/plugins/rslib/rslib.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({});

--- a/packages/knip/src/plugins/rslib/index.ts
+++ b/packages/knip/src/plugins/rslib/index.ts
@@ -6,7 +6,7 @@ import type { RslibConfig } from './types.js';
 
 const title = 'Rslib';
 
-const enablers = ['rslib'];
+const enablers = ['@rslib/core'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 

--- a/packages/knip/test/plugins/rslib.test.ts
+++ b/packages/knip/test/plugins/rslib.test.ts
@@ -13,8 +13,7 @@ test('Find dependencies with the rslib plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    files: 1,
-    processed: 1,
-    total: 1,
+    processed: 0,
+    total: 0,
   });
 });

--- a/packages/knip/test/plugins/rslib.test.ts
+++ b/packages/knip/test/plugins/rslib.test.ts
@@ -13,7 +13,8 @@ test('Find dependencies with the rslib plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 0,
-    total: 0,
+    files: 1,
+    processed: 1,
+    total: 1,
   });
 });


### PR DESCRIPTION
The rslib package is `@rslib/core`, not `rslib`

Fixes: #1226