### PR TITLE
feat: add `time` & `unzip` to ignored binaries

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -121,6 +121,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'tac',
   'tee',
   'test', // exception (node built-in module)
+  'time',
   'timeout',
   'touch',
   'tr',
@@ -130,6 +131,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'uname',
   'unexpand',
   'uniq',
+  'unzip',
   'wc',
   'who',
   'whoami',


### PR DESCRIPTION
IMO these binaries are common enough to be ignored globally.
Both have packages of the same name on npm that are older than 6 years

[`unzip` last published 11 years ago](https://www.npmjs.com/package/unzip)
[`time` last published 9 years ago](https://www.npmjs.com/package/time)
