### PR TITLE
refactor: use `toC12config` for `bump` plugin

### DIFF
--- a/packages/knip/src/plugins/bumpp/index.ts
+++ b/packages/knip/src/plugins/bumpp/index.ts
@@ -1,4 +1,5 @@
 import type { IsPluginEnabled, Plugin } from '../../types/config.js';
+import { toC12config } from '../../util/plugin-config.js';
 import { hasDependency } from '../../util/plugin.js';
 
 // https://github.com/antfu-collective/bumpp#bumpp
@@ -9,7 +10,7 @@ const enablers = ['bumpp'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const entry = ['bump.config.{mjs,ts,js,cjs,mts,cts}'];
+const entry = ['package.json', ...toC12config('bump')];
 
 export default {
   title,


### PR DESCRIPTION
Follow-up to #1278 

I misunderstood you comment https://github.com/webpro-nl/knip/pull/1278#discussion_r2366693302 and thought the `toC12config` helper would need to be added - but well now the `bumpp` plugin uses it ;)
