### PR TITLE
chore: specifiy `packageManager` field for corepack users

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
   },
   "engines": {
     "node": ">=22.0.0"
-  }
+  },
+  "packageManager": "pnpm@10.17.1"
 }


### PR DESCRIPTION
When running `pnpm` with corepack it needs this field to download the specified version of the package manager. It also adds the field if it doesn't exist.

Version 10.17.1 is the latest stable release.

<img width="1742" height="81" alt="image" src="https://github.com/user-attachments/assets/09f14edc-7d57-4d6e-b7cf-7ae1e94b2704" />
