### PR TITLE
feat: detect vitest ui mode

### DIFF
--- a/packages/knip/fixtures/plugins/vitest/package.json
+++ b/packages/knip/fixtures/plugins/vitest/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@plugins/vitest",
   "scripts": {
-    "test": "vitest --config vitest-default-coverage.config.ts"
+    "test": "vitest --config vitest-default-coverage.config.ts",
+    "test:ui": "vitest --ui"
   },
   "devDependencies": {
-    "vitest": "*"
+    "vitest": "*",
+    "@vitest/ui": "*"
   }
 }

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -1,3 +1,4 @@
+import type { ParsedArgs } from 'minimist';
 import { DEFAULT_EXTENSIONS } from '../../constants.js';
 import type { IsPluginEnabled, Plugin, PluginOptions, ResolveConfig } from '../../types/config.js';
 import type { PackageJson } from '../../types/package-json.js';
@@ -180,6 +181,11 @@ export const resolveConfig: ResolveConfig<ViteConfigOrFn | VitestWorkspaceConfig
 
 const args = {
   config: true,
+  resolveInputs: (parsed: ParsedArgs) => {
+    const inputs: Input[] = [];
+    if (parsed['ui']) inputs.push(toDependency('@vitest/ui', { optional: true }));
+    return inputs;
+  },
 };
 
 export default {


### PR DESCRIPTION
Detect vitest ui mode (`vitest --ui`) and add `@vitest/ui` as optional dependency.
Similar to how the eslint plugin does it with the config inspector.

https://vitest.dev/guide/ui