### PR TITLE
Fix ESLint config error

### DIFF
--- a/packages/knip/src/plugins/eslint/helpers.ts
+++ b/packages/knip/src/plugins/eslint/helpers.ts
@@ -16,7 +16,8 @@ export const getInputs = (
     return getInputsDeprecated(config as ESLintConfigDeprecated | OverrideConfigDeprecated, options);
   }
 
-  const dependencies = (config as ESLintConfig).flatMap(config =>
+  const configArray = Array.isArray(config) ? config : [config];
+  const dependencies = configArray.flatMap(config =>
     config.settings ? getDependenciesFromSettings(config.settings) : []
   );
 


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
This fixes the following with ESLint object configs:
```
TypeError: config.flatMap is not a function
```

To reproduce:
```
npm install -D knip@5.64.1 eslint@9.36.0 @eslint/js@9.36.0
cat > eslint.config.js << 'EOF'
import js from '@eslint/js';
export default {
  ...js.configs.recommended,
  files: ['**/*.js'],
  rules: { 'no-unused-vars': 'error' }
};
EOF
npx knip
```