### PR TITLE
Add variable to ignoreExportsUsedInFileObjectSchema

### DIFF
--- a/packages/knip/src/schema/configuration.ts
+++ b/packages/knip/src/schema/configuration.ts
@@ -33,12 +33,13 @@ const issueTypeSchema = z.union([
 const rulesSchema = z.partialRecord(issueTypeSchema, z.enum(['error', 'warn', 'off']));
 
 const ignoreExportsUsedInFileObjectSchema = z.strictObject({
-  class: z.optional(z.boolean()),
+  variable: z.optional(z.boolean()),
+  type: z.optional(z.boolean()),
+  interface: z.optional(z.boolean()),
   enum: z.optional(z.boolean()),
   function: z.optional(z.boolean()),
-  interface: z.optional(z.boolean()),
+  class: z.optional(z.boolean()),
   member: z.optional(z.boolean()),
-  type: z.optional(z.boolean()),
 });
 
 const ignoreExportsUsedInFileSchema = z.union([z.boolean(), ignoreExportsUsedInFileObjectSchema]);


### PR DESCRIPTION
I am not sure if it is a bug, but I do think so. I was working on improving our knip configuration. I found out that when you use `ignoreExportsUsedInFile: true` unused exports, like `export default ComponentName` are not flagged. But when we switch from the boolean to an object with the possible properties all with true as the value (like below), we do get the default exports flagged.
```
ignoreExportsUsedInFile: {
    class: true,
    enum: true,
    function: true,
    interface: true,
    member: true,
    type: true,
  }
```

I checked the schema for [ignoreExportsUsedInFileObjectSchema](https://github.com/webpro-nl/knip/blob/main/packages/knip/src/schema/configuration.ts#L35) and saw that it is missing `variable`, but it does exist in [IgnorableExport](https://github.com/webpro-nl/knip/blob/20690d196775e8391dd50ae23398e57e8bd74267/packages/knip/src/types/config.ts#L42) type.