### PR TITLE
feat(next): add proxy to entry file pattern

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -16,7 +16,7 @@ const config = ['next.config.{js,ts,cjs,mjs}'];
 const defaultPageExtensions = ['{js,jsx,ts,tsx}'];
 
 const productionEntryFilePatterns = [
-  '{instrumentation,instrumentation-client,middleware}.{js,ts}',
+  '{instrumentation,instrumentation-client,middleware,proxy}.{js,ts}',
   'app/global-error.{js,jsx,ts,tsx}',
   'app/**/{error,layout,loading,not-found,page,template,default}.{js,jsx,ts,tsx}',
   'app/**/route.{js,jsx,ts,tsx}',


### PR DESCRIPTION
With Next.js 16 middleware is renamed to proxy https://nextjs.org/blog/next-16#proxyts-formerly-middlewarets, this change updates the default configuration for next to include proxy as an entry file
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
