### PR TITLE
Add new vitest built-in reporters

### DIFF
--- a/packages/knip/src/plugins/vitest/helpers.ts
+++ b/packages/knip/src/plugins/vitest/helpers.ts
@@ -30,20 +30,20 @@ export const getEnvPackageName = (env: string) => {
 // https://github.com/vitest-dev/vitest/blob/v3.2.4/packages/vitest/src/node/reporters/index.ts#L46-L58
 // https://github.com/vitest-dev/vitest/blob/v4.0.3/packages/vitest/src/node/reporters/index.ts#L47-L59
 const builtInReporters = [
-    'basic',
-    'blob',
-    'default',
-    'dot',
-    'github-actions',
-    'hanging-process',
-    'html',
-    'json',
-    'junit',
-    'tap',
-    'tap-flat',
-    'tree',
-    'verbose',
-  ];
+  'basic',
+  'blob',
+  'default',
+  'dot',
+  'github-actions',
+  'hanging-process',
+  'html',
+  'json',
+  'junit',
+  'tap',
+  'tap-flat',
+  'tree',
+  'verbose',
+];
 
 export const getExternalReporters = (reporters?: ViteConfig['test']['reporters']) =>
   reporters


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
1. Update the built-in reporter list for the `vitest` plugin. Add two new reporters `tree` and `blob`.
2. Update the comment in the code to point to a version tag instead of the `main` branch. The `main` branch link could become a 404 in the future.
