### PR TITLE
Add experimental nextjs conventions support

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -17,8 +17,8 @@ const defaultPageExtensions = ['{js,jsx,ts,tsx}'];
 
 const productionEntryFilePatterns = [
   '{instrumentation,instrumentation-client,middleware,proxy}.{js,ts}',
-  'app/global-error.{js,jsx,ts,tsx}',
-  'app/**/{error,layout,loading,not-found,page,template,default}.{js,jsx,ts,tsx}',
+  'app/global-{error,not-found}.{js,jsx,ts,tsx}',
+  'app/**/{error,layout,loading,not-found,page,template,default,forbidden,unauthorized}.{js,jsx,ts,tsx}',
   'app/**/route.{js,jsx,ts,tsx}',
   'app/{manifest,robots}.{js,ts}',
   'app/**/sitemap.{js,ts}',


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

This adds support for the experimental nextjs file system conventions such as:
* [global-not-found](https://nextjs.org/docs/app/api-reference/file-conventions/not-found#global-not-foundjs-experimental)
* [unauthorized](https://nextjs.org/docs/app/api-reference/file-conventions/unauthorized)
* [forbidden](https://nextjs.org/docs/app/api-reference/file-conventions/forbidden)

Not sure how you feel about supporting experimental features, but experiments generally tend to land in NextJS after a version or two, so I thought it could be good to add them sooner rather than later.