### PR TITLE
Fix one character getting removed too much when fixing unused exported type

### DIFF
--- a/packages/knip/src/util/remove-export.ts
+++ b/packages/knip/src/util/remove-export.ts
@@ -64,7 +64,7 @@ export const removeExport = ({ text, start, end, flags }: FixerOptions) => {
     const openingBracketIndex = getOpeningBracketIndex(beforeStart);
     if (closingBracketOffset !== -1 && openingBracketIndex !== -1) {
       const beforeBracket = beforeStart.substring(0, openingBracketIndex).trim();
-      const exportLength = beforeBracket.endsWith('export') ? 6 : beforeBracket.endsWith('export type') ? 12 : 0;
+      const exportLength = beforeBracket.endsWith('export') ? 6 : beforeBracket.endsWith('export type') ? 11 : 0;
       const exportKeywordOffset = beforeBracket.length - exportLength;
       if (exportLength) {
         const fromBracket = afterEnd.substring(closingBracketOffset).trim();

--- a/packages/knip/test/fix/fix.test.ts
+++ b/packages/knip/test/fix/fix.test.ts
@@ -101,6 +101,7 @@ type Seven = unknown;
 const Eight = 8;
 const Nine = 9;
 type Ten = unknown[];
+
 ;
 
 export {   Nine,  };
@@ -209,6 +210,7 @@ type Seven = unknown;
 const Eight = 8;
 const Nine = 9;
 type Ten = unknown[];
+
 ;
 
 export {  Eight, Nine,  };


### PR DESCRIPTION
Closes #1323

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
