### PR TITLE
Correct mdxlint setup in package.json

### DIFF
--- a/packages/docs/.mdxlintrc.mjs
+++ b/packages/docs/.mdxlintrc.mjs
@@ -1,1 +1,0 @@
-export { default } from 'mdxlint-preset-webpro'

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -53,7 +53,7 @@
   },
   "mdxlint": {
     "plugins": [
-      "preset-webpro"
+      "mdxlint-preset-webpro"
     ]
   }
 }


### PR DESCRIPTION
mdxlint uses the `remark` prefix to resolve plugins and presets by string. So the `preset-webpro` name resolved to the `remark-preset-webpro` package, not `mdxlint-preset-webpro`. This was solved by using the full package name.

Refs https://github.com/webpro/remark-preset-webpro/issues/1