### PR TITLE
Add support for next-intl request.ts

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -21,6 +21,7 @@ const productionEntryFilePatterns = [
   'app/**/sitemap.{js,ts}',
   'app/**/{icon,apple-icon}.{js,jsx,ts,tsx}',
   'app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}',
+  'i18n/request.{js,jsx,ts,tsx}',
   'mdx-components.{js,jsx,ts,tsx}',
 ];
 


### PR DESCRIPTION
Next-intl requires you to define a request configuration. By default this is loaded from intl/request.ts.

See https://next-intl.dev/docs/getting-started/app-router