### PR TITLE
fix(plugins/astro): srcDir config detection creating wrong entry patterns

### DIFF
--- a/packages/knip/src/plugins/astro/index.ts
+++ b/packages/knip/src/plugins/astro/index.ts
@@ -26,7 +26,7 @@ const production = [
 
 const resolveFromAST: ResolveFromAST = sourceFile => {
   const srcDir = getSrcDir(sourceFile);
-  const setSrcDir = (entry: string) => entry.replace(/^`src\//, `${srcDir}/`);
+  const setSrcDir = (entry: string) => entry.replace(/^src\//, `${srcDir}/`);
 
   return [
     ...entry.map(setSrcDir).map(path => toEntry(path)),


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

My astro project was not detecting the entry files automatically via the plugin so i found it weird. Looking into the plugin seems like the regex had an errant backtick. Just removed that and the local build of the plugin now worked.
