### PR TITLE
Add SWC plugin

### DIFF
--- a/packages/knip/fixtures/plugins/swc/.swcrc
+++ b/packages/knip/fixtures/plugins/swc/.swcrc
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://swc.rs/schema.json",
+  "jsc": {
+    "experimental": {
+      "plugins": [
+        [
+          "@swc/plugin-styled-components",
+          {}
+        ]
+      ]
+    }
+  }
+}

--- a/packages/knip/fixtures/plugins/swc/node_modules/@swc/cli/package.json
+++ b/packages/knip/fixtures/plugins/swc/node_modules/@swc/cli/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@swc/cli",
+  "version": "*",
+  "bin": {
+    "swc": "index.js"
+  },
+  "peerDependencies": {
+    "@swc/core": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/swc/package.json
+++ b/packages/knip/fixtures/plugins/swc/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@plugins/swc",
+  "scripts": {
+    "build": "swc src -d dist"
+  },
+  "devDependencies": {
+    "@swc/cli": "*",
+    "@swc/core": "*",
+    "@swc/plugin-styled-components": "*"
+  }
+}

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -729,6 +729,10 @@
           "title": "svgr plugin configuration (https://knip.dev/reference/plugins/svgr)",
           "$ref": "#/definitions/plugin"
         },
+        "swc": {
+          "title": "swc plugin configuration (https://knip.dev/reference/plugins/swc)",
+          "$ref": "#/definitions/plugin"
+        },
         "syncpack": {
           "title": "syncpack plugin configuration (https://knip.dev/reference/plugins/syncpack)",
           "$ref": "#/definitions/plugin"

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -97,6 +97,7 @@ import { default as stylelint } from './stylelint/index.js';
 import { default as svelte } from './svelte/index.js';
 import { default as svgo } from './svgo/index.js';
 import { default as svgr } from './svgr/index.js';
+import { default as swc } from './swc/index.js';
 import { default as syncpack } from './syncpack/index.js';
 import { default as tailwind } from './tailwind/index.js';
 import { default as taskfile } from './taskfile/index.js';
@@ -221,6 +222,7 @@ export const Plugins = {
   svelte,
   svgo,
   svgr,
+  swc,
   syncpack,
   tailwind,
   taskfile,

--- a/packages/knip/src/plugins/swc/index.ts
+++ b/packages/knip/src/plugins/swc/index.ts
@@ -1,0 +1,30 @@
+import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
+import { toDependency } from '../../util/input.js';
+import { hasDependency } from '../../util/plugin.js';
+import type { SWCConfig } from './types.js';
+
+// https://swc.rs/
+// https://swc.rs/docs/configuration/swcrc
+
+const title = 'SWC';
+
+const enablers = ['@swc/core'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+
+const config: string[] = ['.swcrc'];
+
+const resolveConfig: ResolveConfig<SWCConfig> = async config => {
+  const inputs = config?.jsc?.experimental?.plugins ?? [];
+  return inputs.map(([id]) => toDependency(id));
+};
+
+const plugin: Plugin = {
+  title,
+  enablers,
+  isEnabled,
+  config,
+  resolveConfig,
+};
+
+export default plugin;

--- a/packages/knip/src/plugins/swc/types.ts
+++ b/packages/knip/src/plugins/swc/types.ts
@@ -1,0 +1,7 @@
+export type SWCConfig = {
+  jsc?: {
+    experimental?: {
+      plugins?: Array<[pluginName: string, pluginOptions: Record<string, unknown>]>;
+    };
+  };
+};

--- a/packages/knip/src/schema/plugins.ts
+++ b/packages/knip/src/schema/plugins.ts
@@ -111,6 +111,7 @@ export const pluginsSchema = z.object({
   svelte: pluginSchema,
   svgo: pluginSchema,
   svgr: pluginSchema,
+  swc: pluginSchema,
   syncpack: pluginSchema,
   tailwind: pluginSchema,
   taskfile: pluginSchema,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -98,6 +98,7 @@ export type PluginName =
   | 'svelte'
   | 'svgo'
   | 'svgr'
+  | 'swc'
   | 'syncpack'
   | 'tailwind'
   | 'taskfile'
@@ -222,6 +223,7 @@ export const pluginNames = [
   'svelte',
   'svgo',
   'svgr',
+  'swc',
   'syncpack',
   'tailwind',
   'taskfile',

--- a/packages/knip/test/plugins/swc.test.ts
+++ b/packages/knip/test/plugins/swc.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.js';
+import baseCounters from '../helpers/baseCounters.js';
+import { createOptions } from '../helpers/create-options.js';
+import { resolve } from '../helpers/resolve.js';
+
+const cwd = resolve('fixtures/plugins/swc');
+
+test('Find dependencies with the swc plugin', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 0,
+    total: 0,
+  });
+});


### PR DESCRIPTION
Our (Meteor) project uses SWC directly without going through rspack or webpack or some other bundler, which I think is the more common usage model. This adds a plugin to parse and extract dependencies from the `.swcrc` config file.