### PR TITLE
Ignore sass builtin dependencies in Sass/SCSS files

### DIFF
--- a/packages/knip/fixtures/compilers-scss/styles.scss
+++ b/packages/knip/fixtures/compilers-scss/styles.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @use "pkg:@fortawesome/fontawesome-free";
 @use "pkg:bootstrap/scss/bootstrap";
 @use "components";

--- a/packages/knip/src/compilers/scss.ts
+++ b/packages/knip/src/compilers/scss.ts
@@ -14,7 +14,8 @@ const compiler = (text: string) => {
 
   // biome-ignore lint/suspicious/noAssignInExpressions: standard regex loop pattern
   while ((match = importMatcher.exec(text))) {
-    if (match[2]) imports.push(`import _$${index++} from '${match[1] ? match[2] : toRelative(match[2])}';`);
+    if (match[2] && !match[2].startsWith('sass:'))
+      imports.push(`import _$${index++} from '${match[1] ? match[2] : toRelative(match[2])}';`);
   }
 
   return imports.join('\n');


### PR DESCRIPTION
The Sass compiler provides a series of @use/@import-able modules under the "sass:" namespace. These should not be treated as separate dependencies, so skip over them.

Fixes #1391.