### PR TITLE
Script discovery tests

### DIFF
--- a/packages/knip/test/util/get-inputs-from-scripts.test.ts
+++ b/packages/knip/test/util/get-inputs-from-scripts.test.ts
@@ -193,7 +193,7 @@ test('getInputsFromScripts (bun)', () => {
   t('bun ci', []);
 });
 
-test.only('getInputsFromScripts (pnpm)', () => {
+test('getInputsFromScripts (pnpm)', () => {
   t('pnpm exec program', [toBinary('program')]);
   t('pnpm run program', []);
   t('pnpm program', [toBinary('program')]);


### PR DESCRIPTION
Not 100% if `pkgScripts` is how you tell it to treat `program` as a script. These obviously fail.

https://github.com/webpro-nl/knip/issues/1399