### PR TITLE
read options after help or version

### DIFF
--- a/packages/knip/src/cli.ts
+++ b/packages/knip/src/cli.ts
@@ -24,8 +24,6 @@ try {
 
 const run = async () => {
   try {
-    const options = await createOptions({ args });
-
     if (args.help) {
       console.log(helpText);
       process.exit(0);
@@ -35,6 +33,8 @@ const run = async () => {
       console.log(version);
       process.exit(0);
     }
+
+    const options = await createOptions({ args });
 
     const { issues, counters, tagHints, configurationHints, includedWorkspaceDirs, enabledPlugins } =
       await main(options);


### PR DESCRIPTION
Don't throw `ERROR: Unable to find package.json` if the command is `knip --help` or `knip --version` when no `package.json` exists (for example if `knip` is installed globally or without installation outside of a project)
