### PR TITLE
Exposed WorkspaceConfig

### DIFF
--- a/packages/knip/src/schema/configuration.ts
+++ b/packages/knip/src/schema/configuration.ts
@@ -406,7 +406,7 @@ const baseWorkspaceConfigurationSchema = z.object({
 
 const partialPluginsSchema = z.partial(pluginsSchema);
 
-const workspaceConfigurationSchema = z.strictObject({
+export const workspaceConfigurationSchema = z.strictObject({
   ...baseWorkspaceConfigurationSchema.shape,
   ...partialPluginsSchema.shape,
 });

--- a/packages/knip/src/types.ts
+++ b/packages/knip/src/types.ts
@@ -1,2 +1,3 @@
 export type { RawConfigurationOrFn as KnipConfig } from './types/config.js';
 export type { Preprocessor, Reporter, ReporterOptions } from './types/issues.js';
+export type { WorkspaceProjectConfig } from './types/config.js';

--- a/packages/knip/src/types/config.ts
+++ b/packages/knip/src/types/config.ts
@@ -1,7 +1,7 @@
 import type ts from 'typescript';
 import type { z } from 'zod/mini';
 import type { AsyncCompilers, SyncCompilers } from '../compilers/types.js';
-import type { knipConfigurationSchema } from '../schema/configuration.js';
+import type { knipConfigurationSchema, workspaceConfigurationSchema } from '../schema/configuration.js';
 import type { pluginSchema } from '../schema/plugins.js';
 import type { ParsedCLIArgs } from '../util/cli-arguments.js';
 import type { Input } from '../util/input.js';
@@ -41,6 +41,8 @@ export type RawConfigurationOrFn =
   | ((options: ParsedCLIArgs) => RawConfiguration | Promise<RawConfiguration>);
 
 export type RawPluginConfiguration = z.infer<typeof pluginSchema>;
+
+export type WorkspaceProjectConfig = z.infer<typeof workspaceConfigurationSchema>;
 
 export type IgnorePatterns = (string | RegExp)[];
 


### PR DESCRIPTION
Fixed #1353 

 Exposes `WorkspaceProjectConfig` type to simplify typing workspace configurations in `knip.ts` config files.
 
Please let me know if there are naming patterns I should follow that I may have missed. I noticed a few with `RAW` but did not think it was needed here.
