### PR TITLE
Plugin for Parcel

### DIFF
--- a/packages/knip/fixtures/plugins/parcel/.parcelrc
+++ b/packages/knip/fixtures/plugins/parcel/.parcelrc
@@ -1,0 +1,15 @@
+{
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "*.{js,mjs,jsx,cjs,ts,tsx}": [
+      "@parcel/transformer-js",
+      "@parcel/transformer-react-refresh-wrap"
+    ],
+    "*.svg": ["@parcel/transformer-svg-react"]
+  },
+  "optimizers": {
+    "*.{js,mjs,cjs}": ["@parcel/optimizer-terser"],
+    "*.css": ["@parcel/optimizer-cssnano"]
+  },
+  "reporters": ["@parcel/reporter-cli", "@parcel/reporter-bundle-analyzer"]
+}

--- a/packages/knip/fixtures/plugins/parcel/package.json
+++ b/packages/knip/fixtures/plugins/parcel/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@plugins/parcel",
+  "scripts": {
+    "start": "parcel src/index.html",
+    "build": "parcel build src/index.html"
+  },
+  "devDependencies": {
+    "parcel": "*"
+  }
+}

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -66,6 +66,7 @@ import { default as nx } from './nx/index.js';
 import { default as nyc } from './nyc/index.js';
 import { default as oclif } from './oclif/index.js';
 import { default as oxlint } from './oxlint/index.js';
+import { default as parcel } from './parcel/index.js';
 import { default as playwright } from './playwright/index.js';
 import { default as playwrightCt } from './playwright-ct/index.js';
 import { default as playwrightTest } from './playwright-test/index.js';
@@ -194,6 +195,7 @@ export const Plugins = {
   nyc,
   oclif,
   oxlint,
+  parcel,
   playwright,
   'playwright-ct': playwrightCt,
   'playwright-test': playwrightTest,

--- a/packages/knip/src/plugins/parcel/index.ts
+++ b/packages/knip/src/plugins/parcel/index.ts
@@ -1,0 +1,57 @@
+import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
+import { toDeferResolve } from '../../util/input.js';
+import { hasDependency } from '../../util/plugin.js';
+import type { ParcelConfig } from './types.js';
+
+// https://parceljs.org/plugin-system/configuration/
+
+const title = 'Parcel';
+
+const enablers = ['parcel', '@parcel/core'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+
+const config = ['.parcelrc'];
+
+const resolveConfig: ResolveConfig<ParcelConfig> = async config => {
+  const dependencies: string[] = [];
+
+  if (typeof config.extends === 'string') {
+    dependencies.push(config.extends);
+  } else if (Array.isArray(config.extends)) {
+    dependencies.push(...config.extends);
+  }
+
+  const extractPlugins = (plugins: string | string[] | undefined) => {
+    if (!plugins) return [];
+    return typeof plugins === 'string' ? [plugins] : plugins;
+  };
+
+  const extractPluginsFromMap = (pluginMap: Record<string, string | string[]> | undefined) => {
+    if (!pluginMap) return [];
+    return Object.values(pluginMap).flatMap(extractPlugins);
+  };
+
+  if (config.resolvers) dependencies.push(...extractPlugins(config.resolvers));
+  if (config.transformers) dependencies.push(...extractPluginsFromMap(config.transformers));
+  if (config.bundler) dependencies.push(config.bundler);
+  if (config.namers) dependencies.push(...extractPlugins(config.namers));
+  if (config.runtimes) dependencies.push(...extractPluginsFromMap(config.runtimes));
+  if (config.packagers) dependencies.push(...extractPluginsFromMap(config.packagers));
+  if (config.optimizers) dependencies.push(...extractPluginsFromMap(config.optimizers));
+  if (config.compressors) dependencies.push(...extractPluginsFromMap(config.compressors));
+  if (config.reporters) dependencies.push(...extractPlugins(config.reporters));
+  if (config.validators) dependencies.push(...extractPluginsFromMap(config.validators));
+
+  return dependencies.map(id => toDeferResolve(id));
+};
+
+const plugin: Plugin = {
+  title,
+  enablers,
+  isEnabled,
+  config,
+  resolveConfig,
+};
+
+export default plugin;

--- a/packages/knip/src/plugins/parcel/types.ts
+++ b/packages/knip/src/plugins/parcel/types.ts
@@ -1,0 +1,13 @@
+export type ParcelConfig = {
+  extends?: string | string[];
+  resolvers?: string | string[];
+  transformers?: Record<string, string | string[]>;
+  bundler?: string;
+  namers?: string | string[];
+  runtimes?: Record<string, string | string[]>;
+  packagers?: Record<string, string | string[]>;
+  optimizers?: Record<string, string | string[]>;
+  compressors?: Record<string, string | string[]>;
+  reporters?: string | string[];
+  validators?: Record<string, string | string[]>;
+};

--- a/packages/knip/src/schema/plugins.ts
+++ b/packages/knip/src/schema/plugins.ts
@@ -80,6 +80,7 @@ export const pluginsSchema = z.object({
   nyc: pluginSchema,
   oclif: pluginSchema,
   oxlint: pluginSchema,
+  parcel: pluginSchema,
   playwright: pluginSchema,
   'playwright-ct': pluginSchema,
   'playwright-test': pluginSchema,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -67,6 +67,7 @@ export type PluginName =
   | 'nyc'
   | 'oclif'
   | 'oxlint'
+  | 'parcel'
   | 'playwright'
   | 'playwright-ct'
   | 'playwright-test'
@@ -195,6 +196,7 @@ export const pluginNames = [
   'nyc',
   'oclif',
   'oxlint',
+  'parcel',
   'playwright',
   'playwright-ct',
   'playwright-test',

--- a/packages/knip/test/plugins/parcel.test.ts
+++ b/packages/knip/test/plugins/parcel.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.js';
+import baseCounters from '../helpers/baseCounters.js';
+import { createOptions } from '../helpers/create-options.js';
+import { resolve } from '../helpers/resolve.js';
+
+const cwd = resolve('fixtures/plugins/parcel');
+
+test('Find dependencies with the Parcel plugin', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.devDependencies['package.json']['parcel']);
+  assert(issues.unresolved['.parcelrc']['@parcel/config-default']);
+  assert(issues.unresolved['.parcelrc']['@parcel/transformer-js']);
+  assert(issues.unresolved['.parcelrc']['@parcel/transformer-react-refresh-wrap']);
+  assert(issues.unresolved['.parcelrc']['@parcel/transformer-svg-react']);
+  assert(issues.unresolved['.parcelrc']['@parcel/optimizer-terser']);
+  assert(issues.unresolved['.parcelrc']['@parcel/optimizer-cssnano']);
+  assert(issues.unresolved['.parcelrc']['@parcel/reporter-cli']);
+  assert(issues.unresolved['.parcelrc']['@parcel/reporter-bundle-analyzer']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    devDependencies: 1,
+    binaries: 1,
+    unresolved: 8,
+    processed: 0,
+    total: 0,
+  });
+});


### PR DESCRIPTION
Adds support for detecting dependencies from Parcel `.parcelrc` configuration files. The plugin parses `.parcelrc` files and extracts all Parcel plugin dependencies from configuration fields including:

  - `extends` - Base configurations
  - `transformers` - Code transformation plugins
  - `optimizers` - Optimisation plugins
  - `reporters` - Build reporter plugins
  - `packagers`, `compressors`, `validators`, `resolvers`, `namers`, `runtimes`, `bundler`