### PR TITLE
Extended the NX plugins

### DIFF
--- a/packages/knip/fixtures/plugins/nx/libs/b/.eslintrc.json
+++ b/packages/knip/fixtures/plugins/nx/libs/b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/knip/fixtures/plugins/nx/libs/b/jest.config.ts
+++ b/packages/knip/fixtures/plugins/nx/libs/b/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'b',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/libs/b',
+};

--- a/packages/knip/fixtures/plugins/nx/libs/b/project.json
+++ b/packages/knip/fixtures/plugins/nx/libs/b/project.json
@@ -21,15 +21,39 @@
       }
     },
     "test": {
-      "executor": "@nrwl/jest:jest"
+      "executor": "@nrwl/jest:jest",
+      "options": {
+        "jestConfig": "libs/b/jest.config.ts"
+      }
     },
     "tsc": {
-      "executor": "./tools/executors/tsc:tsc"
+      "executor": "./tools/executors/tsc:tsc",
+      "options": {
+        "tsConfig": "libs/b/tsconfig.lib.json"
+      }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [{ "command": "biome lint ." }]
+      }
+    },
+    "eslint": {
+      "executor": "@nx/linter:eslint",
+      "options": {
+        "eslintConfig": "libs/b/.eslintrc.json"
+      }
+    },
+    "test-vitest": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "vitestConfig": "libs/b/vitest.config.ts"
+      }
+    },
+    "build-webpack": {
+      "executor": "@nx/webpack:webpack",
+      "options": {
+        "webpackConfig": "libs/b/webpack.config.js"
       }
     }
   }

--- a/packages/knip/fixtures/plugins/nx/libs/b/tsconfig.lib.json
+++ b/packages/knip/fixtures/plugins/nx/libs/b/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/knip/fixtures/plugins/nx/libs/b/vitest.config.ts
+++ b/packages/knip/fixtures/plugins/nx/libs/b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});

--- a/packages/knip/fixtures/plugins/nx/libs/b/webpack.config.js
+++ b/packages/knip/fixtures/plugins/nx/libs/b/webpack.config.js
@@ -1,0 +1,5 @@
+const { composePlugins, withNx } = require('@nx/webpack');
+
+module.exports = composePlugins(withNx(), (config) => {
+  return config;
+});

--- a/packages/knip/src/plugins/nx/index.ts
+++ b/packages/knip/src/plugins/nx/index.ts
@@ -1,7 +1,7 @@
 import type { ParsedArgs } from 'minimist';
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
 import { compact } from '../../util/array.js';
-import { toDependency } from '../../util/input.js';
+import { toConfig, toDependency } from '../../util/input.js';
 import { hasDependency } from '../../util/plugin.js';
 import type { NxConfigRoot, NxProjectConfiguration } from './types.js';
 
@@ -68,7 +68,36 @@ const resolveConfig: ResolveConfig<NxProjectConfiguration | NxConfigRoot> = asyn
 
   const inputs = options.getInputsFromScripts(scripts);
 
-  return compact([...executors, ...inputs]).map(id => (typeof id === 'string' ? toDependency(id) : id));
+  const configInputs = targets.flatMap(target => {
+    const opts = target.options;
+    if (!opts) return [];
+
+    const configs = [];
+
+    if ('eslintConfig' in opts && typeof opts.eslintConfig === 'string') {
+      configs.push(toConfig('eslint', opts.eslintConfig));
+    }
+
+    if ('jestConfig' in opts && typeof opts.jestConfig === 'string') {
+      configs.push(toConfig('jest', opts.jestConfig));
+    }
+
+    if ('tsConfig' in opts && typeof opts.tsConfig === 'string') {
+      configs.push(toConfig('typescript', opts.tsConfig));
+    }
+
+    if ('vitestConfig' in opts && typeof opts.vitestConfig === 'string') {
+      configs.push(toConfig('vitest', opts.vitestConfig));
+    }
+
+    if ('webpackConfig' in opts && typeof opts.webpackConfig === 'string') {
+      configs.push(toConfig('webpack', opts.webpackConfig));
+    }
+
+    return configs;
+  });
+
+  return compact([...executors, ...inputs, ...configInputs]).map(id => (typeof id === 'string' ? toDependency(id) : id));
 };
 
 const args = {

--- a/packages/knip/src/plugins/nx/types.ts
+++ b/packages/knip/src/plugins/nx/types.ts
@@ -6,6 +6,11 @@ export interface NxProjectConfiguration {
       options?: {
         command?: string;
         commands?: Array<string | { command: string }>;
+        eslintConfig?: string;
+        jestConfig?: string;
+        tsConfig?: string;
+        vitestConfig?: string;
+        webpackConfig?: string;
       };
     };
   };

--- a/packages/knip/test/plugins/nx.test.ts
+++ b/packages/knip/test/plugins/nx.test.ts
@@ -30,8 +30,9 @@ test('Find dependencies with the Nx plugin', async () => {
     ...baseCounters,
     binaries: 5,
     devDependencies: 6,
-    unlisted: 3,
-    processed: 0,
-    total: 0,
+    unlisted: 5,
+    files: 3,
+    processed: 3,
+    total: 3,
   });
 });


### PR DESCRIPTION
Fixes #1235 

Detects `eslintConfig`, `jestConfig`, `tsConfig`, `vitestConfig`, and `webpackConfig` options in Nx target configurations and returns them as config inputs for cross-plugin processing.

For the test fixture I consolidates all configs in one project for easier verification which I am pretty sure is valid in Nx (for migration scenarios) however would be more realistic spread across different set ups. Let me know if you would prefer this option.

