### PR TITLE
Add warning about invalid tag characters to docs

### DIFF
--- a/packages/docs/src/content/docs/reference/configuration.md
+++ b/packages/docs/src/content/docs/reference/configuration.md
@@ -180,6 +180,13 @@ notation below is valid and will report only exports tagged `@lintignore` or
 }
 ```
 
+:::caution
+
+Tags must not contain hyphens or plus symbols, so it is recommended to stick to
+letters and avoid snake-case.
+
+:::
+
 Also see [JSDoc & TSDoc Tags][8].
 
 ### `treatConfigHintsAsErrors`


### PR DESCRIPTION
This was a tiny docs change so I didn't bother opening an issue.

I ran into some confusion around `tags` not working when I had tried to use a tag like `@some-tag` (with a hyphen) and I noticed the docs don't specifically mention this footgun.

Thanks to all the contributors for this wonderful tool!