### PR TITLE
add LS version to serverInfo

### DIFF
--- a/packages/language-server/src/server.js
+++ b/packages/language-server/src/server.js
@@ -1,8 +1,11 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createOptions, createSession, KNIP_CONFIG_LOCATIONS } from 'knip/session';
-import pkg from '../package.json' with { type: 'json' };
 import { FileChangeType, ProposedFeatures, TextDocuments } from 'vscode-languageserver';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
 import { CodeActionKind, createConnection } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {


### PR DESCRIPTION
This makes it easier to implement backward-compatible behavior in Language Server Clients 