### PR TITLE
Add `date` to `IGNORED_GLOBAL_BINARIES`

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -59,6 +59,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'cp',
   'curl',
   'cut',
+  'date',
   'deno',
   'df',
   'dir',


### PR DESCRIPTION
`date` is a standard built-in util on both macOS and Linux.

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
