### PR TITLE
fix: skip empty string entries in package.json exports

### DIFF
--- a/packages/knip/src/util/package-json.ts
+++ b/packages/knip/src/util/package-json.ts
@@ -71,7 +71,7 @@ export const getEntrySpecifiersFromManifest = (manifest: PackageJson) => {
 
   if (exports) {
     for (const item of getEntriesFromExports(exports)) {
-      if (item === './*') continue;
+      if (item === './*' || item.trim() === '') continue;
       const expanded = item
         .replace(/\/\*$/, '/**') // /* → /**
         .replace(/\/\*\./, '/**/*.') // /*. → /**/*.


### PR DESCRIPTION
## Summary

This PR adds a check to skip empty string entries when processing the `exports` field in `package.json` files.

Empty strings in exports is often used to enforce explicit subpath imports rather than barrel file imports.

## Problem

Some `package.json` files contain empty string values in their `exports` field. When knip processes these exports, the empty strings cause issues because they are treated as valid entry paths, leading to unexpected behavior or errors.

Example of a problematic `package.json`:
```json
{
  "exports": {
    ".": "./dist/index.js",
    "./utils": ""
  }
}
```

## Solution

Added a check to skip entries that are empty or contain only whitespace, similar to the existing check for `./*` patterns:

```typescript
if (item === './*' || item.trim() === '') continue;
```

This ensures that empty string entries are gracefully skipped without affecting the processing of valid export entries.

## Testing

The fix is minimal and focused - it adds a simple conditional check alongside the existing `./*` pattern check in the `getEntrySpecifiersFromManifest` function.