### PR TITLE
Update avatar URLs

### DIFF
--- a/packages/docs/mock/posts.json
+++ b/packages/docs/mock/posts.json
@@ -658,7 +658,7 @@
       {
         "id": "2",
         "username": "jokull",
-        "profile_image_url": "https://pbs.twimg.com/profile_images/1758441525300613120/JzStjli1_400x400.jpg",
+        "profile_image_url": "https://pbs.twimg.com/profile_images/1943338796122083328/NsFCJwMd_400x400.jpg",
         "name": "Jökull Solberg"
       },
       {
@@ -676,7 +676,7 @@
       {
         "id": "5",
         "username": "gary__tyr",
-        "profile_image_url": "https://pbs.twimg.com/profile_images/1748013320039440384/aJvwN534_400x400.jpg",
+        "profile_image_url": "https://pbs.twimg.com/profile_images/1947080916045631488/m42HwWiy_400x400.jpg",
         "name": "Gary Tyr"
       },
       {
@@ -718,7 +718,7 @@
       {
         "id": "19268321",
         "username": "housecor",
-        "profile_image_url": "https://pbs.twimg.com/profile_images/1869130199045906432/PUA1SYIL_400x400.jpg",
+        "profile_image_url": "https://pbs.twimg.com/profile_images/1963593369306750976/7gPWqEa8_400x400.jpg",
         "name": "Cory House"
       },
       {
@@ -730,13 +730,13 @@
       {
         "id": "95668959",
         "username": "kuizinas",
-        "profile_image_url": "https://pbs.twimg.com/profile_images/1691579603817492481/Ri-UmtYp_normal.jpg",
+        "profile_image_url": "https://pbs.twimg.com/profile_images/1978959812172894209/yQXTNMuJ_400x400.jpg",
         "name": "Gajus"
       },
       {
         "id": "1632752318994153472",
         "username": "imabhiprasad",
-        "profile_image_url": "https://pbs.twimg.com/profile_images/1632752385440333826/FLTUiree_normal.jpg",
+        "profile_image_url": "https://pbs.twimg.com/profile_images/1917768224612962304/7RHnN131_400x400.jpg",
         "name": "Abhijeet Prasad"
       },
       {

--- a/packages/docs/src/content/docs/reference/plugins.md
+++ b/packages/docs/src/content/docs/reference/plugins.md
@@ -1,5 +1,5 @@
 ---
-title: Plugins (127)
+title: Plugins (130)
 tableOfContents: false
 ---
 
@@ -7,6 +7,7 @@ tableOfContents: false
 - [Angular](/reference/plugins/angular "Angular")
 - [Astro](/reference/plugins/astro "Astro")
 - [Astro DB](/reference/plugins/astro-db "Astro DB")
+- [astro-og-canvas](/reference/plugins/astro-og-canvas "astro-og-canvas")
 - [Ava](/reference/plugins/ava "Ava")
 - [Babel](/reference/plugins/babel "Babel")
 - [Biome](/reference/plugins/biome "Biome")
@@ -62,6 +63,7 @@ tableOfContents: false
 - [Next.js](/reference/plugins/next "Next.js")
 - [next-intl](/reference/plugins/next-intl "next-intl")
 - [Next.js MDX](/reference/plugins/next-mdx "Next.js MDX")
+- [Nitro](/reference/plugins/nitro "Nitro")
 - [Node.js](/reference/plugins/node "Node.js")
 - [node-modules-inspector](/reference/plugins/node-modules-inspector "node-modules-inspector")
 - [nodemon](/reference/plugins/nodemon "nodemon")
@@ -102,6 +104,7 @@ tableOfContents: false
 - [Stryker](/reference/plugins/stryker "Stryker")
 - [Stylelint](/reference/plugins/stylelint "Stylelint")
 - [Svelte](/reference/plugins/svelte "Svelte")
+- [SvelteKit](/reference/plugins/sveltekit "SvelteKit")
 - [SVGO](/reference/plugins/svgo "SVGO")
 - [SVGR](/reference/plugins/svgr "SVGR")
 - [SWC](/reference/plugins/swc "SWC")


### PR DESCRIPTION
Currently some images are returning 404.

<img width="1046" height="569" alt="image" src="https://github.com/user-attachments/assets/22736c21-ff62-4ce4-878d-2a15359c14c2" />

---

P.S. Perhaps the `GITHUB_TOKEN` has expired on Cloudflare? Contributor information isn't showing up.

<img width="1044" height="250" alt="image" src="https://github.com/user-attachments/assets/7c6595f2-6c8d-4211-9439-9f283f5d4383" />
