### PR TITLE
Handle Prettier config re-exports

### DIFF
--- a/packages/knip/fixtures/plugins/prettier-reexport/node_modules/@org/prettier-config/index.js
+++ b/packages/knip/fixtures/plugins/prettier-reexport/node_modules/@org/prettier-config/index.js
@@ -1,0 +1,3 @@
+export default {
+  plugins: [import.meta.resolve('prettier-plugin-test')],
+};

--- a/packages/knip/fixtures/plugins/prettier-reexport/node_modules/@org/prettier-config/node_modules/prettier-plugin-test/index.js
+++ b/packages/knip/fixtures/plugins/prettier-reexport/node_modules/@org/prettier-config/node_modules/prettier-plugin-test/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/knip/fixtures/plugins/prettier-reexport/node_modules/@org/prettier-config/node_modules/prettier-plugin-test/package.json
+++ b/packages/knip/fixtures/plugins/prettier-reexport/node_modules/@org/prettier-config/node_modules/prettier-plugin-test/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "prettier-plugin-test",
+  "main": "./index.js"
+}

--- a/packages/knip/fixtures/plugins/prettier-reexport/node_modules/@org/prettier-config/package.json
+++ b/packages/knip/fixtures/plugins/prettier-reexport/node_modules/@org/prettier-config/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@org/prettier-config",
+  "type": "module",
+  "main": "./index.js",
+  "dependencies": {
+    "prettier-plugin-test": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/prettier-reexport/node_modules/prettier-plugin-test/dist/index.js
+++ b/packages/knip/fixtures/plugins/prettier-reexport/node_modules/prettier-plugin-test/dist/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/knip/fixtures/plugins/prettier-reexport/node_modules/prettier-plugin-test/package.json
+++ b/packages/knip/fixtures/plugins/prettier-reexport/node_modules/prettier-plugin-test/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "prettier-plugin-test",
+  "main": "./dist/index.js"
+}

--- a/packages/knip/fixtures/plugins/prettier-reexport/package.json
+++ b/packages/knip/fixtures/plugins/prettier-reexport/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixtures/prettier-reexport",
+  "type": "module",
+  "devDependencies": {
+    "prettier": "*",
+    "@org/prettier-config": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/prettier-reexport/prettier.config.js
+++ b/packages/knip/fixtures/plugins/prettier-reexport/prettier.config.js
@@ -1,0 +1,1 @@
+export { default } from '@org/prettier-config';

--- a/packages/knip/src/plugins/prettier/index.ts
+++ b/packages/knip/src/plugins/prettier/index.ts
@@ -1,5 +1,9 @@
+import ts from 'typescript';
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.js';
+import { loadFile } from '../../util/fs.js';
 import { toDeferResolve, toDependency } from '../../util/input.js';
+import { isStartsLikePackageName } from '../../util/modules.js';
+import { extname } from '../../util/path.js';
 import { hasDependency } from '../../util/plugin.js';
 import type { PrettierConfig } from './types.js';
 
@@ -19,12 +23,93 @@ const config = [
   'package.{json,yaml}',
 ];
 
-const resolveConfig: ResolveConfig<PrettierConfig> = config => {
+const jsLikeExtensions = new Set(['.js', '.cjs', '.mjs', '.ts', '.cts', '.mts']);
+
+const getScriptKind = (ext: string) => {
+  if (ext === '.ts' || ext === '.cts' || ext === '.mts') return ts.ScriptKind.TS;
+  return ts.ScriptKind.JS;
+};
+
+const getReexportedPackageFromEsm = (statement: ts.Statement) => {
+  if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier) return;
+  if (!ts.isStringLiteralLike(statement.moduleSpecifier)) return;
+  const specifier = statement.moduleSpecifier.text;
+  if (!isStartsLikePackageName(specifier)) return;
+  if (!statement.exportClause || !ts.isNamedExports(statement.exportClause)) return;
+  if (statement.exportClause.elements.length !== 1) return;
+  const element = statement.exportClause.elements[0];
+  if (element.name.text !== 'default') return;
+  if (element.propertyName && element.propertyName.text !== 'default') return;
+  return specifier;
+};
+
+const getRequireCall = (expression: ts.Expression) => {
+  if (ts.isCallExpression(expression)) return expression;
+  if (ts.isPropertyAccessExpression(expression) && expression.name.text === 'default') {
+    if (ts.isCallExpression(expression.expression)) return expression.expression;
+  }
+};
+
+const getReexportedPackageFromCjs = (statement: ts.Statement) => {
+  if (!ts.isExpressionStatement(statement)) return;
+  const expression = statement.expression;
+  if (!ts.isBinaryExpression(expression) || expression.operatorToken.kind !== ts.SyntaxKind.EqualsToken) return;
+  const left = expression.left;
+  if (!ts.isPropertyAccessExpression(left)) return;
+  if (!ts.isIdentifier(left.expression) || left.expression.text !== 'module' || left.name.text !== 'exports') return;
+  const call = getRequireCall(expression.right);
+  if (!call || !ts.isIdentifier(call.expression) || call.expression.text !== 'require') return;
+  const [arg] = call.arguments;
+  if (!arg || !ts.isStringLiteralLike(arg)) return;
+  const specifier = arg.text;
+  if (!isStartsLikePackageName(specifier)) return;
+  return specifier;
+};
+
+const isDirective = (statement: ts.Statement) =>
+  ts.isExpressionStatement(statement) && ts.isStringLiteralLike(statement.expression);
+
+const getReexportedPackage = async (configFilePath: string) => {
+  const ext = extname(configFilePath);
+  if (!jsLikeExtensions.has(ext)) return;
+
+  const contents = await loadFile(configFilePath);
+  const sourceFile = ts.createSourceFile(
+    configFilePath,
+    contents,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(ext)
+  );
+
+  let reexportedPackage: string | undefined;
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isEmptyStatement(statement) || isDirective(statement)) continue;
+    const candidate = getReexportedPackageFromEsm(statement) ?? getReexportedPackageFromCjs(statement);
+    if (!candidate) {
+      reexportedPackage = undefined;
+      break;
+    }
+    if (reexportedPackage && reexportedPackage !== candidate) {
+      reexportedPackage = undefined;
+      break;
+    }
+    reexportedPackage = candidate;
+  }
+
+  return reexportedPackage;
+};
+
+const resolveConfig: ResolveConfig<PrettierConfig> = async (config, options) => {
   if (typeof config === 'string') return [toDeferResolve(config)];
 
-  return Array.isArray(config.plugins)
-    ? config.plugins.filter((plugin): plugin is string => typeof plugin === 'string').map(id => toDependency(id))
-    : [];
+  if (!Array.isArray(config.plugins)) return [];
+
+  const reexportedPackage = await getReexportedPackage(options.configFilePath);
+  if (reexportedPackage) return [];
+
+  return config.plugins.filter((plugin): plugin is string => typeof plugin === 'string').map(id => toDependency(id));
 };
 
 const plugin: Plugin = {

--- a/packages/knip/test/plugins/prettier.test.ts
+++ b/packages/knip/test/plugins/prettier.test.ts
@@ -41,3 +41,19 @@ test('Find dependencies with the Prettier plugin (.json5 config)', async () => {
     total: 0,
   });
 });
+
+test('Handle re-exported config', async () => {
+  const cwd = resolve('fixtures/plugins/prettier-reexport');
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert.equal(issues.unlisted['prettier.config.js']?.['prettier-plugin-test'], undefined);
+  assert.equal(issues.devDependencies['package.json']?.['@org/prettier-config'], undefined);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    devDependencies: 1,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
Fix false positive “unlisted dependencies” for Prettier plugins when config is re-exported.

If a Prettier config file is a pure re-export (ESM `export { default } from 'pkg'` or CJS `module.exports = require('pkg')`), Knip should not report plugins from that external config as dependencies of the consumer.

Implementation: detect pure re-export via AST and skip `plugins` resolution for that config.