### PR TITLE
feat(plugins): add @typescript/native-preview (tsgo) support

### DIFF
--- a/packages/knip/fixtures/plugins/tsgo/package.json
+++ b/packages/knip/fixtures/plugins/tsgo/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tsgo",
+  "scripts": {
+    "build": "tsgo"
+  },
+  "devDependencies": {
+    "@typescript/native-preview": "*",
+    "@types/node": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/tsgo/tsconfig.json
+++ b/packages/knip/fixtures/plugins/tsgo/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/knip/src/plugins/typescript/index.ts
+++ b/packages/knip/src/plugins/typescript/index.ts
@@ -10,7 +10,7 @@ import { hasDependency } from '../../util/plugin.js';
 
 const title = 'TypeScript';
 
-const enablers = ['typescript'];
+const enablers = ['typescript', '@typescript/native-preview'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
@@ -49,7 +49,7 @@ const resolveConfig: ResolveConfig<TsConfigJson> = async (localConfig, options) 
 };
 
 const args = {
-  binaries: ['tsc'],
+  binaries: ['tsc', 'tsgo'],
   string: ['project'],
   alias: { project: ['p'] },
   config: [['project', (p: string) => (p.endsWith('.json') ? p : join(p, 'tsconfig.json'))]] satisfies ConfigArg,

--- a/packages/knip/test/plugins/tsgo.test.ts
+++ b/packages/knip/test/plugins/tsgo.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.js';
+import baseCounters from '../helpers/baseCounters.js';
+import { createOptions } from '../helpers/create-options.js';
+import { resolve } from '../helpers/resolve.js';
+
+const cwd = resolve('fixtures/plugins/tsgo');
+
+test('Find dependencies with the TypeScript plugin when using @typescript/native-preview', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.binaries['package.json']['tsgo']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    binaries: 1,
+    devDependencies: 1,
+    processed: 0,
+    total: 0,
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/webpro-nl/knip/issues/761#issuecomment-3859859563

## Summary                                                                           
                                                                                       
  - Add `@typescript/native-preview` as an enabler for the TypeScript plugin, so
  projects using tsgo activate the plugin without needing `typescript` in their
  dependencies
  - Recognize `tsgo` binary in package.json scripts
  - Add test fixture and test for tsgo-only projects