### PR TITLE
Add missing catalog property to rules in JSON schema

### DIFF
--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -138,6 +138,9 @@
         "binaries": {
           "$ref": "#/definitions/ruleValue"
         },
+        "catalog": {
+          "$ref": "#/definitions/ruleValue"
+        },
         "classMembers": {
           "$ref": "#/definitions/ruleValue"
         },


### PR DESCRIPTION
The `catalog` issue type is listed in the `issueTypes` enum (used by `include`/`exclude`) but is missing from the `rules` properties in the JSON schema.

This adds it so that `rules.catalog` is recognized by schema validation.

Fixes #1514