### PR TITLE
Support nested _generated dirs in Convex plugin

### DIFF
--- a/packages/knip/src/plugins/convex/index.ts
+++ b/packages/knip/src/plugins/convex/index.ts
@@ -9,7 +9,7 @@ const enablers = ['convex'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const entry: string[] = ['convex/*.config.@(js|ts)', 'convex/_generated/*.@(js|ts)'];
+const entry: string[] = ['convex/*.config.@(js|ts)', 'convex/**/_generated/*.@(js|ts)'];
 
 const plugin: Plugin = {
   title,


### PR DESCRIPTION
## Summary
- Broadened the Convex plugin entry glob from `convex/_generated/*.@(js|ts)` to `convex/**/_generated/*.@(js|ts)`
- This ensures components that generate files in nested subdirectories (e.g. `convex/betterAuth/_generated/`) are recognized as entry points

## Test plan
- [x] Verify existing `convex/_generated/` files still match
- [x] Verify nested paths like `convex/betterAuth/_generated/` now match
- [x] Run Convex plugin tests