### PR TITLE
Add .DS_Store _in fixtures_ to .gitignore

### DIFF
--- a/packages/knip/.gitignore
+++ b/packages/knip/.gitignore
@@ -3,4 +3,5 @@
 /tmp
 /node_modules
 !/fixtures/**
+/fixtures/**/.DS_Store
 .cache


### PR DESCRIPTION
I failed to see that `!/fixtures/**` will negate my fix from #1530.

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
