### PR TITLE
Fix false positives for arrow-wrapped dynamic imports assigned to variables

### DIFF
--- a/packages/knip/fixtures/imports-opaque/direct.ts
+++ b/packages/knip/fixtures/imports-opaque/direct.ts
@@ -1,0 +1,1 @@
+export default 1;

--- a/packages/knip/fixtures/imports-opaque/index.ts
+++ b/packages/knip/fixtures/imports-opaque/index.ts
@@ -19,3 +19,12 @@ const obj = {
   key2: await import('./awaited-assignment.js'),
   ...(await import('./obj-spread.js')),
 };
+
+const loader = () => import('./variable.js');
+function fnRun(load: () => Promise<unknown>) {
+  return load();
+}
+fnRun(loader);
+
+const direct = import('./direct.js');
+fn(direct, 0);

--- a/packages/knip/fixtures/imports-opaque/variable.ts
+++ b/packages/knip/fixtures/imports-opaque/variable.ts
@@ -1,0 +1,2 @@
+export default 1;
+export const named = 1;

--- a/packages/knip/src/typescript/visitors/dynamic-imports/importCall.ts
+++ b/packages/knip/src/typescript/visitors/dynamic-imports/importCall.ts
@@ -129,6 +129,21 @@ export default visit(
                   namespace: undefined,
                 }));
               }
+              const hasFunctionBoundary = findAncestor(node, _node => {
+                if (_node === variableDeclaration) return 'STOP';
+                return ts.isArrowFunction(_node);
+              });
+              if (hasFunctionBoundary) {
+                return {
+                  identifier: undefined,
+                  specifier,
+                  pos: node.arguments[0].pos,
+                  modifiers: IMPORT_FLAGS.OPAQUE,
+                  alias: undefined,
+                  namespace: undefined,
+                  symbol: undefined,
+                };
+              }
               return {
                 identifier: 'default',
                 alias,

--- a/packages/knip/test/imports-opaque.test.ts
+++ b/packages/knip/test/imports-opaque.test.ts
@@ -13,7 +13,7 @@ test('Ignore exports of opaque import calls', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 10,
-    total: 10,
+    processed: 12,
+    total: 12,
   });
 });


### PR DESCRIPTION
fixes #1543

the variable declaration branch in `importCall.ts` was matching `const loader = () => import('./module.js')` because `node.parent.parent` skips over the arrow function and lands on the `VariableDeclaration`

The fix  is to checking for a function boundary and if one exists the import is marked as opaque instead of resolving to `default`

Test: 
added the `const loader = () => import('./variable.js')` case to the opaque imports fixture, plus a `const direct = import('./direct.js')` negative case to verify direct imports still resolve normally
