### PR TITLE
Fix incorrect coverage provider being reported

### DIFF
--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -38,8 +38,8 @@ const findConfigDependencies = (localConfig: ViteConfig, options: PluginOptions,
       : [];
   const reporters = getExternalReporters(testConfig.reporters);
 
-  const hasCoverageEnabled = testConfig.coverage && testConfig.coverage.enabled !== false;
-  const coverage = hasCoverageEnabled ? [`@vitest/coverage-${testConfig.coverage?.provider ?? 'v8'}`] : [];
+  const hasCoverage = testConfig.coverage && (testConfig.coverage.enabled !== false || testConfig.coverage.provider);
+  const coverage = hasCoverage ? [`@vitest/coverage-${testConfig.coverage?.provider ?? 'v8'}`] : [];
 
   const setupFiles = [testConfig.setupFiles ?? []]
     .flat()
@@ -187,9 +187,8 @@ const args: Args = {
   resolveInputs: (parsed: ParsedArgs) => {
     const inputs: Input[] = [];
     if (parsed['ui']) inputs.push(toDependency('@vitest/ui', { optional: true }));
-    if (parsed['coverage']) {
-      const provider = typeof parsed['coverage'] === 'object' ? parsed['coverage'].provider : undefined;
-      inputs.push(toDependency(`@vitest/coverage-${provider ?? 'v8'}`));
+    if (typeof parsed['coverage'] === 'object' && parsed['coverage'].provider) {
+      inputs.push(toDependency(`@vitest/coverage-${parsed['coverage'].provider}`));
     }
     if (parsed['reporter']) {
       for (const reporter of getExternalReporters([parsed['reporter']].flat())) {

--- a/packages/knip/test/plugins/vitest-npm-script.test.ts
+++ b/packages/knip/test/plugins/vitest-npm-script.test.ts
@@ -12,7 +12,7 @@ test('Find dependencies with the Vitest plugin', async () => {
   const { issues, counters } = await main(options);
 
   assert(issues.devDependencies['package.json']['vitest']);
-  assert(issues.unlisted['package.json']['@vitest/coverage-v8']);
+  assert(issues.unlisted['vitest.config.ts']['@vitest/coverage-v8']);
   assert(issues.binaries['package.json']['vitest']);
 
   assert.deepEqual(counters, {


### PR DESCRIPTION
If you have a vitest config that sets a coverage provider to `istanbul`, and a script has a `--coverage` flag, knip incorrectly reports a missing `@vitest/coverage-v8` (as well as `@vitest/coverage-istanbul`).

This PR changes this behavior:
- If a vitest config has a `coverage` config and `enabled` is not set to `false`, _or_ you've defined a `provider` property, use the configured coverage provider (or v8 as fallback). This is slightly cheating as we are _assuming_ that you'll be wanting to use coverage if you've defined an explicit provider
- If passing a `--coverage.provider` flag, add that provider as a used dependency - otherwise, leave it up to config to determine