### PR TITLE
 Add .spec-d to vitest entry files

### DIFF
--- a/packages/docs/src/content/docs/explanations/plugins.md
+++ b/packages/docs/src/content/docs/explanations/plugins.md
@@ -100,7 +100,7 @@ dependencies.
 For example, if `next` is listed as a dependency in `package.json`, the Next.js
 plugin will automatically add multiple patterns as entry files, such as
 `pages/**/*.{js,jsx,ts,tsx}`. If `vitest` is listed, the Vitest plugin adds
-`**/*.{test,test-d,spec}.ts` as entry file patterns. Most plugins have entry
+`**/*.{test,test-d,spec,spec-d}.ts` as entry file patterns. Most plugins have entry
 files configured, so you don't have to.
 
 It's mostly plugins for meta frameworks and test runners that have `entry` files

--- a/packages/knip/fixtures/plugins/vitest/test/basic.spec-d.ts
+++ b/packages/knip/fixtures/plugins/vitest/test/basic.spec-d.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf, test } from 'vitest';
+
+test('Type A', () => {
+  expectTypeOf(Math.sqrt(4)).toEqualTypeOf<number>();
+});

--- a/packages/knip/fixtures/plugins/vitest/test/basic.test-d.ts
+++ b/packages/knip/fixtures/plugins/vitest/test/basic.test-d.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf, test } from 'vitest';
+
+test('Type B', () => {
+  expectTypeOf(Math.sqrt(4)).toEqualTypeOf<number>();
+});

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -21,7 +21,7 @@ const config = ['vitest.config.{js,mjs,ts,cjs,mts,cts}', 'vitest.{workspace,proj
 
 const mocks = ['**/__mocks__/**/*.[jt]s?(x)'];
 
-const entry = ['**/*.{bench,test,test-d,spec}.?(c|m)[jt]s?(x)', ...mocks];
+const entry = ['**/*.{bench,test,test-d,spec,spec-d}.?(c|m)[jt]s?(x)', ...mocks];
 
 const findConfigDependencies = (localConfig: ViteConfig, options: PluginOptions, vitestRoot: string) => {
   const { configFileDir: dir } = options;

--- a/packages/knip/test/plugins/vitest.test.ts
+++ b/packages/knip/test/plugins/vitest.test.ts
@@ -29,8 +29,8 @@ test('Find dependencies with the Vitest plugin', async () => {
     ...baseCounters,
     unlisted: 11,
     unresolved: 1,
-    processed: 9,
-    total: 9,
+    processed: 11,
+    total: 11,
   });
 });
 


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

add `spec-d` to the vitest plugin's entry file patterns.
https://vitest.dev/config/typecheck.html#typecheck-include