### PR TITLE
chore: git ignore artifacts

### DIFF
--- a/packages/knip/.gitignore
+++ b/packages/knip/.gitignore
@@ -5,3 +5,5 @@
 !/fixtures/**
 /fixtures/**/.DS_Store
 .cache
+bin/knip
+bin/knip-bun


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

After build, the `bin/knip` and `bi/knip-bun` is created and detected by git. Should ignore those two files