### PR TITLE
Fix wrangler plugin not enabled by jsonc config

### DIFF
--- a/packages/knip/src/plugins/wrangler/index.ts
+++ b/packages/knip/src/plugins/wrangler/index.ts
@@ -11,7 +11,7 @@ const enablers = ['wrangler'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['wrangler.{json,toml}'];
+const config = ['wrangler.{json,jsonc,toml}'];
 
 const resolveConfig: ResolveConfig<WranglerConfig> = async config => {
   return (config.main ? [config.main] : []).map(id => toProductionEntry(id));


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Hi :wave:,

Last time when I added the wrangler plugin, json support wasn't stable yet, and only supported .json. Shortly after that, they released official json support, including .jsonc files, which is also the recommended format for new projects. Docs: https://developers.cloudflare.com/workers/wrangler/configuration/

This PR just adds jsonc into the supported file formats, so it's picked up as a config file. I tested it by converting the fixture's wrangler.toml into wrangler.jsonc, and it was picked up and main file was detected fine (biome made some changes in other plugins but I don't want to edit those in this PR)