### PR TITLE
chore: add `k` script for easy testing

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -92,6 +92,9 @@ Run Knip without compilation:
 
 ```shell
 node path/to/knip/packages/knip/src/cli.ts
+
+// or using the alias script
+pnpm k
 ```
 
 #### Alias

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "docs": "pnpm run --dir packages/docs dev",
     "test": "pnpm run --dir packages/knip test",
     "format": "biome check --write",
+    "k": "node packages/knip/src/cli.ts",
     "lint": "biome lint .",
     "ci": "biome ci . && installed-check --ignore-dev",
     "release": "./release.sh"


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Adding this to make it easier to run fixture test:

```shell
pnpm k --directory packages/knip/fixture/tailwind-4

// or with @antfu/ni
nr k --directory packages/knip/fixture/tailwind-4
```
