### PR TITLE
Detect Yarn plugins that are listed by their path alone

### DIFF
--- a/packages/knip/fixtures/plugins/yarn-berry/.yarn/plugins/@yarnpkg/plugin-bar.cjs
+++ b/packages/knip/fixtures/plugins/yarn-berry/.yarn/plugins/@yarnpkg/plugin-bar.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/knip/fixtures/plugins/yarn-berry/.yarnrc.yml
+++ b/packages/knip/fixtures/plugins/yarn-berry/.yarnrc.yml
@@ -1,8 +1,11 @@
 nodeLinker: node-modules
 
 plugins:
+  # A plugin can be represented by a dict containing the path
   - checksum: 1234567890abcdef
     path: .yarn/plugins/@yarnpkg/plugin-foo.cjs
     spec: "https://example.com/@yarnpkg/plugin-foo.js"
+  # A plugin can also be represented by the path alone
+  - .yarn/plugins/@yarnpkg/plugin-bar.cjs
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs

--- a/packages/knip/src/plugins/yarn/index.ts
+++ b/packages/knip/src/plugins/yarn/index.ts
@@ -18,9 +18,7 @@ const config = ['.yarnrc.yml'];
 const entry = ['yarn.config.cjs'];
 
 type YarnConfig = {
-  plugins?: Array<{
-    path?: string;
-  }>;
+  plugins?: Array<string | { path?: string }>;
   yarnPath?: string;
 };
 
@@ -29,9 +27,8 @@ const resolveConfig: ResolveConfig<YarnConfig> = config => {
 
   if (Array.isArray(config.plugins)) {
     for (const plugin of config.plugins) {
-      if (plugin.path) {
-        inputs.push(toEntry(plugin.path));
-      }
+      if (typeof plugin === 'string') inputs.push(toEntry(plugin));
+      else if (typeof plugin.path === 'string') inputs.push(toEntry(plugin.path));
     }
   }
 

--- a/packages/knip/test/plugins/yarn-berry.test.ts
+++ b/packages/knip/test/plugins/yarn-berry.test.ts
@@ -13,7 +13,7 @@ test('Find dependencies with the yarn plugin (Berry)', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 3,
-    total: 3,
+    processed: 4,
+    total: 4,
   });
 });


### PR DESCRIPTION
In a .yarnrc.yml file, plugins can be listed either as a dict or simply as a string. In the latter case, Yarn interprets the string as the plugin's path. https://github.com/webpro-nl/knip/pull/1523 did not yet account for these kinds of plugin entries, causing the plugin files to still be flagged as unused.

([Here's](https://github.com/element-hq/element-call/actions/runs/22407328480/job/64870758723?pr=3712) where I ran into this issue in the real world)