### PR TITLE
Detect cross-package imports by nearest package boundary

### DIFF
--- a/packages/knip/test/workspaces-self-and-cross-ref.test.ts
+++ b/packages/knip/test/workspaces-self-and-cross-ref.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../src/index.ts';
+import baseCounters from './helpers/baseCounters.ts';
+import { createOptions } from './helpers/create-options.ts';
+import { resolve } from './helpers/resolve.ts';
+
+const cwd = resolve('fixtures/workspaces-self-and-cross-ref');
+const leafCwd = resolve('fixtures/workspaces-self-and-cross-ref/packages/app');
+
+test('Resolve aliased workspace dependencies (dep key differs from package name)', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    unlisted: 0,
+    processed: 5,
+    total: 5,
+  });
+});
+
+test('Resolve aliased workspace dependencies from leaf workspace', async () => {
+  const options = await createOptions({ cwd: leafCwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
Fix false positive unused dependencies for internal workspace packages when the dependency key differs from the target package name, or when Knip runs from a leaf package.

Aliased workspace dependencies were missed because usage detection relied on discovered workspace package names, which aren't available when running from a leaf workspace.

Detect cross-package imports by comparing the resolved file's nearest package boundary against the current workspace directory.