### PR TITLE
feat: add WXT plugin

### DIFF
--- a/packages/knip/fixtures/plugins/wxt/entrypoints/background.ts
+++ b/packages/knip/fixtures/plugins/wxt/entrypoints/background.ts
@@ -1,0 +1,3 @@
+export default defineBackground(() => {
+  console.log('Background script started');
+});

--- a/packages/knip/fixtures/plugins/wxt/node_modules/wxt/index.js
+++ b/packages/knip/fixtures/plugins/wxt/node_modules/wxt/index.js
@@ -1,0 +1,1 @@
+export const defineConfig = c => c;

--- a/packages/knip/fixtures/plugins/wxt/node_modules/wxt/package.json
+++ b/packages/knip/fixtures/plugins/wxt/node_modules/wxt/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "wxt",
+  "main": "index.js"
+}

--- a/packages/knip/fixtures/plugins/wxt/package.json
+++ b/packages/knip/fixtures/plugins/wxt/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@plugins/wxt",
+  "dependencies": {
+    "wxt": "*",
+    "@wxt-dev/module-react": "*",
+    "wxt-module-console-forward": "*",
+    "unused-module": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/wxt/tsconfig.json
+++ b/packages/knip/fixtures/plugins/wxt/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/packages/knip/fixtures/plugins/wxt/wxt.config.ts
+++ b/packages/knip/fixtures/plugins/wxt/wxt.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'wxt';
+
+export default defineConfig({
+  modules: ['@wxt-dev/module-react', 'wxt-module-console-forward'],
+});

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -132,6 +132,7 @@ import { default as webdriverIo } from './webdriver-io/index.ts';
 import { default as webpack } from './webpack/index.ts';
 import { default as wireit } from './wireit/index.ts';
 import { default as wrangler } from './wrangler/index.ts';
+import { default as wxt } from './wxt/index.ts';
 import { default as xo } from './xo/index.ts';
 import { default as yarn } from './yarn/index.ts';
 import { default as yorkie } from './yorkie/index.ts';
@@ -271,6 +272,7 @@ export const Plugins = {
   webpack,
   wireit,
   wrangler,
+  wxt,
   xo,
   yarn,
   yorkie,

--- a/packages/knip/src/plugins/wxt/index.ts
+++ b/packages/knip/src/plugins/wxt/index.ts
@@ -1,0 +1,52 @@
+import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
+import type { Input } from '../../util/input.ts';
+import { toDependency } from '../../util/input.ts';
+import { hasDependency } from '../../util/plugin.ts';
+import type { WxtConfig } from './types.ts';
+
+// https://wxt.dev/guide/configuration.html
+
+const title = 'WXT';
+
+const enablers = ['wxt'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+
+const config = ['wxt.config.{js,mjs,ts}'];
+
+const entry = ['entrypoints/**/*.{ts,tsx,js,jsx,html}'];
+
+const production = ['entrypoints/**/*.{ts,tsx,js,jsx,html}'];
+
+const setup = async () => {
+  if (globalThis && !('defineConfig' in globalThis)) {
+    Object.defineProperty(globalThis, 'defineConfig', {
+      value: (id: any) => id,
+      writable: true,
+      configurable: true,
+    });
+  }
+};
+
+const resolveConfig: ResolveConfig<WxtConfig> = async localConfig => {
+  const deps =
+    localConfig?.modules?.reduce<Input[]>((acc, id) => {
+      if (typeof id === 'string') acc.push(toDependency(id));
+      return acc;
+    }, []) ?? [];
+
+  return deps;
+};
+
+const plugin: Plugin = {
+  title,
+  enablers,
+  isEnabled,
+  config,
+  entry,
+  production,
+  setup,
+  resolveConfig,
+};
+
+export default plugin;

--- a/packages/knip/src/plugins/wxt/types.ts
+++ b/packages/knip/src/plugins/wxt/types.ts
@@ -1,0 +1,3 @@
+export interface WxtConfig {
+  modules?: string[];
+}

--- a/packages/knip/src/schema/plugins.ts
+++ b/packages/knip/src/schema/plugins.ts
@@ -146,6 +146,7 @@ export const pluginsSchema = z.object({
   webpack: pluginSchema,
   wireit: pluginSchema,
   wrangler: pluginSchema,
+  wxt: pluginSchema,
   xo: pluginSchema,
   yarn: pluginSchema,
   yorkie: pluginSchema,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -133,6 +133,7 @@ export type PluginName =
   | 'webpack'
   | 'wireit'
   | 'wrangler'
+  | 'wxt'
   | 'xo'
   | 'yarn'
   | 'yorkie'
@@ -272,6 +273,7 @@ export const pluginNames = [
   'webpack',
   'wireit',
   'wrangler',
+  'wxt',
   'xo',
   'yarn',
   'yorkie',

--- a/packages/knip/test/plugins/wxt.test.ts
+++ b/packages/knip/test/plugins/wxt.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/wxt');
+
+test('Find dependencies with the wxt plugin', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.dependencies['package.json']['unused-module']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    files: 1,
+    dependencies: 1,
+    processed: 2,
+    total: 2,
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new plugin for [WXT](https://wxt.dev/) (Web Extension Framework)
- Resolves `modules` array entries in `wxt.config.ts` as dependencies
- Defines `entrypoints/**/*` as entry file patterns
- Prevents false positive "unused dependency" reports for WXT modules (e.g. `@wxt-dev/module-react`, `wxt-module-console-forward`)

## Motivation

WXT uses a `modules` array in `wxt.config.ts` similar to Nuxt's module system. Without this plugin, knip reports these modules as unused devDependencies because they're only referenced in the WXT config and never directly imported in source code.

## Implementation

Follows the same pattern as the Nuxt plugin:
- `setup()` defines a global `defineConfig` helper so knip can load the config
- `resolveConfig()` extracts string entries from the `modules` array as dependencies
- Entry patterns match WXT's conventional `entrypoints/` directory

## Test plan

- [x] Plugin test passes (`node --test test/plugins/wxt.test.ts`)
- [x] Correctly identifies unused dependencies not in `modules`
- [x] Does not flag modules listed in `wxt.config.ts` as unused