### PR TITLE
Use createRequire for package manifest resolution

### DIFF
--- a/packages/knip/src/manifest/helpers.ts
+++ b/packages/knip/src/manifest/helpers.ts
@@ -1,6 +1,6 @@
+import { createRequire } from 'node:module';
 import type { Scripts } from '../types/package-json.ts';
 import { join } from '../util/path.ts';
-import { _require } from '../util/require.ts';
 
 type LoadPackageManifestOptions = { dir: string; packageName: string; cwd: string };
 
@@ -8,11 +8,11 @@ export const loadPackageManifest = ({ dir, packageName, cwd }: LoadPackageManife
   // TODO Not sure what's the most efficient way to get a package.json, but this seems to do the job across package
   // managers (npm, Yarn, pnpm)
   try {
-    return _require(join(dir, 'node_modules', packageName, 'package.json'));
+    return createRequire(join(dir, 'package.json'))(join(packageName, 'package.json'));
   } catch (_error) {
     if (dir !== cwd) {
       try {
-        return _require(join(cwd, 'node_modules', packageName, 'package.json'));
+        return createRequire(join(cwd, 'package.json'))(join(packageName, 'package.json'));
       } catch (_error) {
         // Explicitly suppressing errors here
       }

--- a/packages/knip/test/plugins/remark.test.ts
+++ b/packages/knip/test/plugins/remark.test.ts
@@ -11,14 +11,10 @@ test('Find dependencies with the Remark plugin', async () => {
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 
-  assert(issues.devDependencies['package.json']['remark-cli']);
   assert(issues.unresolved['package.json']['remark-preset-webpro']);
-  assert(issues.binaries['package.json']['remark']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    binaries: 1,
-    devDependencies: 1,
     unresolved: 1,
     processed: 0,
     total: 0,

--- a/packages/knip/test/plugins/typescript.test.ts
+++ b/packages/knip/test/plugins/typescript.test.ts
@@ -21,7 +21,6 @@ test('Find dependencies with the TypeScript plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    binaries: 1,
     unlisted: 2,
     unresolved: 5,
     processed: 0,

--- a/packages/knip/test/workspace-selectors-root.test.ts
+++ b/packages/knip/test/workspace-selectors-root.test.ts
@@ -34,7 +34,6 @@ test('Select only root workspace with . selector', async () => {
     ...baseCounters,
     dependencies: 1,
     unlisted: 1,
-    binaries: 1,
     processed: 1,
     total: 1,
   });


### PR DESCRIPTION
## Summary

- Replace hardcoded `node_modules` path lookups in `loadPackageManifest` with `createRequire` from `node:module`
- This uses Node.js standard module resolution, which works across all package managers including Yarn PnP
- Previously, peer dependency detection relied on `join(dir, 'node_modules', packageName, 'package.json')` which fails in Yarn PnP environments (no `node_modules` directory), causing false positives for unused dependencies

## Test plan

- [x] All 578 smoke tests pass (`pnpm run test:bun:smoke`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- Updated 3 test expectations where binaries are now correctly resolved (previously false positives due to manifests not being found)