### PR TITLE
Fix confusing test fixtures for openapi-ts plugin

### DIFF
--- a/packages/knip/fixtures/plugins/openapi-ts/openapi-ts.config.ts
+++ b/packages/knip/fixtures/plugins/openapi-ts/openapi-ts.config.ts
@@ -2,11 +2,9 @@ export default {
   input: 'https://api.example.com/openapi.json',
   output: 'src/client',
   plugins: [
-    '@hey-api/typescript',
-    '@hey-api/sdk',
-    {
-      name: '@hey-api/client-fetch',
-    },
     '@tanstack/react-query',
+    {
+      name: 'zod',
+    },
   ],
 };

--- a/packages/knip/fixtures/plugins/openapi-ts/package.json
+++ b/packages/knip/fixtures/plugins/openapi-ts/package.json
@@ -4,10 +4,8 @@
     "@hey-api/openapi-ts": "*"
   },
   "dependencies": {
-    "@hey-api/typescript": "*",
-    "@hey-api/sdk": "*",
-    "@hey-api/client-fetch": "*",
-    "@tanstack/react-query": "*"
+    "@tanstack/react-query": "*",
+    "zod": "*"
   },
   "scripts": {
     "generate": "openapi-ts"


### PR DESCRIPTION
Fixes confusing test fixtures for the openapi-ts plugin, which got called out after #1579 had been merged