### PR TITLE
fix(playwright): Add missing built-in `null` reporter

### DIFF
--- a/packages/knip/src/plugins/playwright/index.ts
+++ b/packages/knip/src/plugins/playwright/index.ts
@@ -30,7 +30,7 @@ const toEntryPatterns = (
   return patterns.map(pattern => toEntry(join(dir, pattern)));
 };
 
-const builtinReporters = ['dot', 'line', 'list', 'junit', 'html', 'blob', 'json', 'github'];
+const builtinReporters = ['dot', 'line', 'list', 'junit', 'html', 'blob', 'json', 'github', 'null'];
 
 export const resolveConfig: ResolveConfig<PlaywrightTestConfig> = async (localConfig, options) => {
   const { cwd, configFileDir } = options;


### PR DESCRIPTION
Playwright has a special `null` reporter that is no-op, it does nothing. The `null` reporter is useful when conditionally configuring reporters, e.g: a reporter in CI but no reporter in development.

```typescript
import { defineConfig } from '@playwright/test';

export default defineConfig({
  reporter: [!!process.env.CI ? "github" : "null"],
});
```

https://github.com/microsoft/playwright/blob/d444bbb1e950ea03e67f9b3559d38fb5e205e9ba/packages/playwright/types/test.d.ts#L36-L46

```typescript
export type ReporterDescription = Readonly<
  ['blob'] | ['blob', BlobReporterOptions] |
  ['dot'] |
  ['line'] |
  ['list'] | ['list', ListReporterOptions] |
  ['github'] |
  ['junit'] | ['junit', JUnitReporterOptions] |
  ['json'] | ['json', JsonReporterOptions] |
  ['html'] | ['html', HtmlReporterOptions] |
  ['null'] |
  [string] | [string, any]
>;
```

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
