### PR TITLE
Add pkg as built-in pnpm command

### DIFF
--- a/packages/knip/src/binaries/package-manager/pnpm.ts
+++ b/packages/knip/src/binaries/package-manager/pnpm.ts
@@ -39,6 +39,7 @@ const commands = [
   'patch-commit',
   'patch-remove',
   'patch',
+  'pkg',
   'prepare',
   'prune',
   'publish',


### PR DESCRIPTION
Currently, I am receiving an error:

```
> knip

Unlisted binaries (1)
pkg  .github/workflows/release.yml
 ELIFECYCLE  Command failed with exit code 1.
```

However, this is an existing built-in command in pnpm:

```
pnpm pkg --help
Manages your package.json

Usage:
npm pkg set <key>=<value> [<key>=<value> ...]
npm pkg get [<key> [<key> ...]]
npm pkg delete <key> [<key> ...]
npm pkg set [<array>[<index>].<key>=<value> ...]
npm pkg set [<array>[].<key>=<value> ...]
npm pkg fix

Options:
[-f|--force] [--json]
[-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
[--workspaces]

  -f|--force
    Removes various protections against unfortunate side effects, common

  --json
    Whether or not to output JSON data, rather than the normal output.

  -w|--workspace
    Enable running a command in the context of the configured workspaces of the

  --workspaces
    Set to true to run the command in the context of **all** configured
```