### PR TITLE
Add oxlint.config.ts to oxlint plugin

### DIFF
--- a/packages/knip/fixtures/plugins/oxlint/oxlint.config.ts
+++ b/packages/knip/fixtures/plugins/oxlint/oxlint.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "oxlint";
+
+export default defineConfig({});

--- a/packages/knip/src/plugins/oxlint/index.ts
+++ b/packages/knip/src/plugins/oxlint/index.ts
@@ -9,7 +9,7 @@ const enablers = ['oxlint'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config: string[] = ['.oxlintrc.json'];
+const config: string[] = ['.oxlintrc.json', 'oxlint.config.ts'];
 
 const args = {
   config: true,

--- a/packages/knip/test/plugins/oxlint.test.ts
+++ b/packages/knip/test/plugins/oxlint.test.ts
@@ -13,7 +13,7 @@ test('Find dependencies with the oxlint plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 0,
-    total: 0,
+    processed: 1,
+    total: 1,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Hi :wave:,

Oxlint now supports `oxlint.config.ts` as a configuration file (https://oxc.rs/docs/guide/usage/linter/config.html), so I've added that to the list of config entrypoints.

In reality, it complains if both the json and the ts files are present, but since it's a stub here it should be fine for the fixture.