### PR TITLE
Identify that `@babel/runtime` is needed when `@babel/plugin-transform-runtime` is used

### DIFF
--- a/packages/knip/src/plugins/babel/index.ts
+++ b/packages/knip/src/plugins/babel/index.ts
@@ -19,17 +19,31 @@ const config = ['babel.config.{json,js,cjs,mjs,cts,ts}', '.babelrc.{json,js,cjs,
 const getName = (value: string | [string, unknown]) =>
   [Array.isArray(value) ? value[0] : value].filter(name => typeof name === 'string');
 
+// presence of dependency (key) implies that dependencies (value) are needed
+const impliedDependencies = {
+  '@babel/plugin-transform-runtime': ['@babel/runtime'],
+};
+
 export const getDependenciesFromConfig = (config: BabelConfigObj): Input[] => {
   const presets = config.presets?.flatMap(getName).map(name => resolveName(name, 'preset')) ?? [];
   const plugins = config.plugins?.flatMap(getName).map(name => resolveName(name, 'plugin')) ?? [];
   const nested = config.env ? Object.values(config.env).flatMap(getDependenciesFromConfig) : [];
   const overrides = config.overrides ? [config.overrides].flat().flatMap(getDependenciesFromConfig) : [];
-  return compact([
+
+  const dependencies = [
     ...presets.map(id => toDeferResolve(id)),
     ...plugins.map(id => toDeferResolve(id)),
     ...nested,
     ...overrides,
-  ]);
+  ];
+
+  for (const [dependency, extraDependencies] of Object.entries(impliedDependencies)) {
+    if (dependencies.find(dep => dep.specifier === dependency)) {
+      dependencies.push(...extraDependencies.map(dep => toDeferResolve(dep)));
+    }
+  }
+
+  return compact(dependencies);
 };
 
 const resolveConfig: ResolveConfig<BabelConfig> = async config => {

--- a/packages/knip/test/plugins/babel.test.ts
+++ b/packages/knip/test/plugins/babel.test.ts
@@ -19,6 +19,7 @@ test('Find dependencies with the Babel plugin (1)', async () => {
   assert(issues.unresolved['.babelrc']['react-hot-loader/babel']);
 
   assert(issues.unlisted['.babelrc.js']['@babel/plugin-transform-runtime']);
+  assert(issues.unlisted['.babelrc.js']['@babel/runtime']);
   assert(issues.unresolved['.babelrc.js']['babel-plugin-preval']);
   assert(issues.unresolved['.babelrc.js']['babel-plugin-transform-imports']);
   assert(issues.unlisted['.babelrc.js']['dotenv']);
@@ -53,6 +54,7 @@ test('Find dependencies with the Babel plugin (1)', async () => {
   assert(issues.unlisted['babel.config.js']['@babel/plugin-proposal-object-rest-spread']);
   assert(issues.unlisted['babel.config.js']['@babel/plugin-proposal-optional-chaining']);
   assert(issues.unlisted['babel.config.js']['@babel/plugin-transform-runtime']);
+  assert(issues.unlisted['babel.config.js']['@babel/runtime']);
   assert(issues.unresolved['babel.config.js']['babel-plugin-lodash']);
 
   assert(issues.unresolved['babel.config.cts']['./dir/plugin.js']);
@@ -63,7 +65,7 @@ test('Find dependencies with the Babel plugin (1)', async () => {
   assert.deepEqual(counters, {
     ...baseCounters,
     devDependencies: 2,
-    unlisted: 24,
+    unlisted: 26,
     unresolved: 17,
     processed: 3,
     total: 3,


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Fixes https://github.com/webpro-nl/knip/issues/1594
