### PR TITLE
Add 'ng' to the list of IGNORED_GLOBAL_BINARIES

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -145,6 +145,7 @@ export const IGNORED_GLOBAL_BINARIES = new Set([
   'yarn',
   'yes',
   'zip',
+  'ng'
 ]);
 
 export const IGNORED_DEPENDENCIES = new Set(['knip', 'typescript']);


### PR DESCRIPTION
I've added `ng` of Angular to the list of IGNORED_GLOBAL_BINARIES, to avoid warning for that.
