### PR TITLE
Fix openapi-ts dependency resolution

### DIFF
--- a/packages/knip/fixtures/plugins/openapi-ts/openapi-ts.config.ts
+++ b/packages/knip/fixtures/plugins/openapi-ts/openapi-ts.config.ts
@@ -2,9 +2,10 @@ export default {
   input: 'https://api.example.com/openapi.json',
   output: 'src/client',
   plugins: [
-    '@tanstack/react-query',
+    '@hey-api/typescript',
+    '@hey-api/client-fetch',
     {
-      name: 'zod',
+      name: '@hey-api/sdk',
     },
   ],
 };

--- a/packages/knip/fixtures/plugins/openapi-ts/package.json
+++ b/packages/knip/fixtures/plugins/openapi-ts/package.json
@@ -3,10 +3,6 @@
   "devDependencies": {
     "@hey-api/openapi-ts": "*"
   },
-  "dependencies": {
-    "@tanstack/react-query": "*",
-    "zod": "*"
-  },
   "scripts": {
     "generate": "openapi-ts"
   }

--- a/packages/knip/src/plugins/openapi-ts/index.ts
+++ b/packages/knip/src/plugins/openapi-ts/index.ts
@@ -1,8 +1,6 @@
-import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
-import { toDependency } from '../../util/input.ts';
+import type { IsPluginEnabled, Plugin } from '../../types/config.ts';
 import { hasDependency } from '../../util/plugin.ts';
 import { toC12config } from '../../util/plugin-config.ts';
-import type { OpenApiTsConfig } from './types.ts';
 
 // https://heyapi.dev/openapi-ts/configuration
 
@@ -14,22 +12,11 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 
 const config = ['package.json', ...toC12config('openapi-ts')];
 
-const resolveConfig: ResolveConfig<OpenApiTsConfig> = config => {
-  const configs = Array.isArray(config) ? config : [config];
-  return configs.flatMap(config =>
-    (config.plugins ?? [])
-      .map(plugin => (typeof plugin === 'string' ? plugin : plugin.name))
-      .filter((name): name is string => typeof name === 'string')
-      .map(id => toDependency(id))
-  );
-};
-
 const plugin: Plugin = {
   title,
   enablers,
   isEnabled,
   config,
-  resolveConfig,
 };
 
 export default plugin;

--- a/packages/knip/src/plugins/openapi-ts/types.ts
+++ b/packages/knip/src/plugins/openapi-ts/types.ts
@@ -1,7 +1,0 @@
-type PluginRef = string | { name: string };
-
-type Config = {
-  plugins?: PluginRef[];
-};
-
-export type OpenApiTsConfig = Config | Config[];


### PR DESCRIPTION
#1579 was a PR I made a little bit ago which made it so openapi-ts plugins would be resolved as dependencies. This is totally wrong, I misunderstood how openapi-ts works. Sorry about that!

This PR updates the openapi-ts plugin to remove the broken logic for plugins, which would incorrectly report that you were missing dependencies in package.json when you referenced a plugin.