### PR TITLE
Add Sanity plugin

### DIFF
--- a/packages/knip/fixtures/plugins/sanity/package.json
+++ b/packages/knip/fixtures/plugins/sanity/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@plugins/sanity",
+  "dependencies": {
+    "@sanity/blueprints": "*",
+    "@sanity/vision": "*",
+    "sanity": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/sanity/sanity.blueprint.ts
+++ b/packages/knip/fixtures/plugins/sanity/sanity.blueprint.ts
@@ -1,0 +1,10 @@
+import { defineBlueprint, defineDocumentFunction } from '@sanity/blueprints';
+
+export default defineBlueprint({
+  resources: [
+    defineDocumentFunction({
+      name: 'on-publish',
+      event: { type: 'document.publish' },
+    }),
+  ],
+});

--- a/packages/knip/fixtures/plugins/sanity/sanity.cli.ts
+++ b/packages/knip/fixtures/plugins/sanity/sanity.cli.ts
@@ -1,0 +1,8 @@
+import { defineCliConfig } from 'sanity/cli';
+
+export default defineCliConfig({
+  api: {
+    projectId: 'project-id',
+    dataset: 'production',
+  },
+});

--- a/packages/knip/fixtures/plugins/sanity/sanity.config.ts
+++ b/packages/knip/fixtures/plugins/sanity/sanity.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'sanity';
+import { structureTool } from 'sanity/structure';
+import { visionTool } from '@sanity/vision';
+import { schemaTypes } from './schema';
+
+export default defineConfig({
+  name: 'default',
+  title: 'My Studio',
+  projectId: 'project-id',
+  dataset: 'production',
+  plugins: [structureTool(), visionTool()],
+  schema: { types: schemaTypes },
+});

--- a/packages/knip/fixtures/plugins/sanity/schema.ts
+++ b/packages/knip/fixtures/plugins/sanity/schema.ts
@@ -1,0 +1,1 @@
+export const schemaTypes = [];

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -724,6 +724,10 @@
           "title": "rstest plugin configuration (https://knip.dev/reference/plugins/rstest)",
           "$ref": "#/definitions/plugin"
         },
+        "sanity": {
+          "title": "sanity plugin configuration (https://knip.dev/reference/plugins/sanity)",
+          "$ref": "#/definitions/plugin"
+        },
         "semantic-release": {
           "title": "semantic-release plugin configuration (https://knip.dev/reference/plugins/semantic-release)",
           "$ref": "#/definitions/plugin"

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -97,6 +97,7 @@ import { default as rsbuild } from './rsbuild/index.ts';
 import { default as rslib } from './rslib/index.ts';
 import { default as rspack } from './rspack/index.ts';
 import { default as rstest } from './rstest/index.ts';
+import { default as sanity } from './sanity/index.ts';
 import { default as semanticRelease } from './semantic-release/index.ts';
 import { default as sentry } from './sentry/index.ts';
 import { default as simpleGitHooks } from './simple-git-hooks/index.ts';
@@ -238,6 +239,7 @@ export const Plugins = {
   rslib,
   rspack,
   rstest,
+  sanity,
   'semantic-release': semanticRelease,
   sentry,
   'simple-git-hooks': simpleGitHooks,

--- a/packages/knip/src/plugins/sanity/index.ts
+++ b/packages/knip/src/plugins/sanity/index.ts
@@ -1,0 +1,21 @@
+import type { IsPluginEnabled, Plugin } from '../../types/config.ts';
+import { hasDependency } from '../../util/plugin.ts';
+
+// https://www.sanity.io/docs/configuration
+
+const title = 'Sanity';
+
+const enablers = ['sanity'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+
+const entry = ['sanity.config.{js,jsx,ts,tsx}', 'sanity.cli.{ts,js}', 'sanity.blueprint.{ts,js,json}'];
+
+const plugin: Plugin = {
+  title,
+  enablers,
+  isEnabled,
+  entry,
+};
+
+export default plugin;

--- a/packages/knip/src/schema/plugins.ts
+++ b/packages/knip/src/schema/plugins.ts
@@ -111,6 +111,7 @@ export const pluginsSchema = z.object({
   rslib: pluginSchema,
   rspack: pluginSchema,
   rstest: pluginSchema,
+  sanity: pluginSchema,
   'semantic-release': pluginSchema,
   sentry: pluginSchema,
   'simple-git-hooks': pluginSchema,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -98,6 +98,7 @@ export type PluginName =
   | 'rslib'
   | 'rspack'
   | 'rstest'
+  | 'sanity'
   | 'semantic-release'
   | 'sentry'
   | 'simple-git-hooks'
@@ -239,6 +240,7 @@ export const pluginNames = [
   'rslib',
   'rspack',
   'rstest',
+  'sanity',
   'semantic-release',
   'sentry',
   'simple-git-hooks',

--- a/packages/knip/test/plugins/sanity.test.ts
+++ b/packages/knip/test/plugins/sanity.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/sanity');
+
+test('Find dependencies with the Sanity plugin', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 4,
+    total: 4,
+  });
+});


### PR DESCRIPTION
Adds a plugin to detect configuration files for Sanity projects:

- `sanity.config.{js,jsx,ts,tsx}` - Sanity studio config
- `sanity.cli.{ts,js}` - CLI config
- `sanity.blueprint.{ts,js,json}` - [Blueprints](https://www.sanity.io/docs/blueprints/blueprints-introduction) config

We're big Knip users internally at Sanity, only fair that we make it work well with Knip out of the box :)