### PR TITLE
fix: Use runtime FS case-sensitivity check in cspell and taskfile tests

### DIFF
--- a/packages/knip/test/helpers/fs-case-sensitive.ts
+++ b/packages/knip/test/helpers/fs-case-sensitive.ts
@@ -1,9 +1,17 @@
 import { accessSync } from 'node:fs';
 
 /** Returns true if the filesystem at `dir` is case-sensitive. */
-export function isCaseSensitiveFS(dir: string): boolean {
+export function isCaseSensitiveFileSystem(dir: string): boolean {
+  // If a directory has all uppercase letters, then we test for case insensitivity by comparing it
+  // with the lowercase version. Otherwise, we can compare with the uppercase version.
+  const testDir = dir === dir.toUpperCase() ? dir.toLowerCase() : dir.toUpperCase();
+
+  if (testDir === dir) {
+    throw new Error(`Cannot determine case sensitivity. The directory path of "${dir}" lacks alphabetic characters.`);
+  }
+
   try {
-    accessSync(dir.toUpperCase());
+    accessSync(testDir);
     return false;
   } catch {
     return true;

--- a/packages/knip/test/plugins/cspell.test.ts
+++ b/packages/knip/test/plugins/cspell.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { main } from '../../src/index.ts';
 import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
-import { isCaseSensitiveFS } from '../helpers/fs-case-sensitive.ts';
+import { isCaseSensitiveFileSystem } from '../helpers/fs-case-sensitive.ts';
 import { resolve } from '../helpers/resolve.ts';
 
 const cwd = resolve('fixtures/plugins/cspell');
@@ -18,7 +18,7 @@ test('Find dependencies with the Cspell plugin', async () => {
     ...baseCounters,
     devDependencies: 1,
     // case-sensitivity: fast-glob returns two files (.cspell.json and .cSpell.json) while there's only one
-    unlisted: isCaseSensitiveFS(cwd) ? 1 : 2,
+    unlisted: isCaseSensitiveFileSystem(cwd) ? 1 : 2,
     processed: 0,
     total: 0,
   });

--- a/packages/knip/test/plugins/taskfile.test.ts
+++ b/packages/knip/test/plugins/taskfile.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { main } from '../../src/index.ts';
 import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
-import { isCaseSensitiveFS } from '../helpers/fs-case-sensitive.ts';
+import { isCaseSensitiveFileSystem } from '../helpers/fs-case-sensitive.ts';
 import { resolve } from '../helpers/resolve.ts';
 
 const cwd = resolve('fixtures/plugins/taskfile');
@@ -26,8 +26,8 @@ test('Find dependencies with the taskfile plugin', async () => {
   assert.deepEqual(counters, {
     ...baseCounters,
     // case-sensitivity: fast-glob returns two files (taskfile.yml and Taskfile.yml) while there's only one
-    binaries: isCaseSensitiveFS(cwd) ? 9 : 15,
-    unresolved: isCaseSensitiveFS(cwd) ? 1 : 2,
+    binaries: isCaseSensitiveFileSystem(cwd) ? 9 : 15,
+    unresolved: isCaseSensitiveFileSystem(cwd) ? 1 : 2,
     processed: 7,
     total: 7,
   });


### PR DESCRIPTION
I cloned the knip repo and ran `pnpm test` and it just immediately fails.
The reason is because knip assumes that if you are on Windows, you are on a case insensitive file system.
But this is not true - it is best practice to [set your "repositories" directory to be case sensitive](https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity).

Thus, this PR replaces `process.platform === 'win32'` checks with a helper that tests actual filesystem case-sensitivity at runtime.

Claude helped me write this.