### PR TITLE
fix: symlink failures on windows

### DIFF
--- a/packages/knip/fixtures/include-entry-reexports/tsconfig.json
+++ b/packages/knip/fixtures/include-entry-reexports/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@fixtures/include-entry-reexports__app": ["packages/app/index.mjs"],
+      "@fixtures/include-entry-reexports__shared": ["packages/shared/index.mjs"]
+    }
+  }
+}

--- a/packages/knip/fixtures/workspaces-cross-reference/packages/lib-a/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-cross-reference/packages/lib-a/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "paths": {
+      "@fixtures/workspaces-cross-reference__lib-b/*": ["../../packages/lib-b/*"]
+    }
   }
 }

--- a/packages/knip/fixtures/workspaces-cross-reference/packages/lib-b/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-cross-reference/packages/lib-b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "paths": {
+      "@fixtures/workspaces-cross-reference__lib-a/*": ["../../packages/lib-a/*"]
+    }
   }
 }

--- a/packages/knip/fixtures/workspaces-dts/packages/client/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-dts/packages/client/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@fixtures/workspaces-dts__shared": ["../../packages/shared/src/index.js"]
+    }
+  },
   "include": ["**/*.js"],
   "exclude": []
 }

--- a/packages/knip/fixtures/workspaces-dts/packages/server/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-dts/packages/server/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@fixtures/workspaces-dts__shared": ["../../packages/shared/src/index.js"]
+    }
+  },
   "include": ["**/*.js"],
   "exclude": []
 }

--- a/packages/knip/fixtures/workspaces-plugin-config/packages/backend/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-plugin-config/packages/backend/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@fixtures/workspaces-plugin-config__shared/*": ["../shared/*"]
+    }
+  }
+}

--- a/packages/knip/fixtures/workspaces-plugin-config/packages/frontend/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-plugin-config/packages/frontend/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@fixtures/workspaces-plugin-config__tailwind/*": ["../tailwind/*"]
+    }
+  }
+}

--- a/packages/knip/src/util/create-input-handler.ts
+++ b/packages/knip/src/util/create-input-handler.ts
@@ -115,7 +115,9 @@ export const createInputHandler =
           }
 
           // Return resolved path for refs to internal workspaces
-          const internalPath = _resolveSync(specifier, dirname(containingFilePath));
+          const internalPath =
+            _resolveSync(specifier, dirname(containingFilePath)) ??
+            _resolveModuleSync(specifier, containingFilePath);
           if (internalPath && isInternal(internalPath) && !isGitIgnored(internalPath)) return internalPath;
         }
 


### PR DESCRIPTION
Fixes #1614.

This is my attempt at fixing 1614. Note that a potentially cleaner approach might be to remove the symlinks altogether. But not sure how you feel about that.

Here's what Claude has to say about this PR:

  ---
#  Fix smoke tests on Windows (git core.symlinks=false)

##  Problem

  On Windows without Developer Mode enabled, git checks out symlinks (mode 120000) as plain text files containing the relative target path — because core.symlinks defaults to false. Several test fixtures use
  node_modules symlinks to simulate workspace cross-references (e.g. packages/backend/node_modules/@fixtures/pkg__shared → ../../../shared). When these are text files rather than real symlinks, the resolver
  can't traverse them, causing 4 smoke tests to fail locally on Windows even though CI passes.

  Affected tests:
  - workspaces-cross-reference
  - workspaces-dts
  - include-entry-reexports
  - workspaces-plugin-config

##  Root cause

  Knip uses two resolvers from oxc-resolver:

  - _resolveModuleSync — uses resolver.resolveFileSync(filePath, specifier), which supports tsconfig: 'auto' (finds the nearest tsconfig.json and applies its paths aliases).
  - _resolveSync — uses resolver.sync(directory, specifier), which does not apply tsconfig paths (a limitation of the sync API vs resolveFileSync).

  In create-input-handler.ts, when knip encounters a reference to a workspace-internal package (e.g. @fixtures/pkg__shared/jest-setup.ts in jest.config.js), it calls _resolveSync to resolve it to a concrete
  file path. On Linux/Mac with real symlinks this succeeds via the node_modules directory. On Windows with text-file symlinks it returns undefined, so the concrete file (jest-setup.ts) is never added to the
  reference graph and is incorrectly reported as an unused file.

##  Solution

  Two complementary changes, both purely additive:

  1. Fallback resolver in create-input-handler.ts

  When _resolveSync returns undefined for a workspace-internal reference, fall back to _resolveModuleSync (which already has tsconfig: 'auto'):

  // Before
  const internalPath = _resolveSync(specifier, dirname(containingFilePath));

  // After
  const internalPath =
    _resolveSync(specifier, dirname(containingFilePath)) ??
    _resolveModuleSync(specifier, containingFilePath);

  On Linux/Mac, _resolveSync succeeds via node_modules symlinks and the fallback is never invoked. On Windows, _resolveSync returns undefined and _resolveModuleSync picks up tsconfig.json paths instead.

  2. tsconfig.json path aliases in affected fixtures

  Added compilerOptions.paths entries to each affected fixture package that mirror the corresponding symlinks. These give the TypeScript resolver a concrete relative path to fall back to when node_modules
  resolution fails.

  ┌────────────────────────────┬───────────────────────────────────────┬────────────────────────────────────────────────────────────────────────┐
  │          Fixture           │                 File                  │                               Path added                               │
  ├────────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ workspaces-cross-reference │ packages/lib-a/tsconfig.json          │ @fixtures/workspaces-cross-reference__lib-b/* → ../../packages/lib-b/* │
  ├────────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ workspaces-cross-reference │ packages/lib-b/tsconfig.json          │ @fixtures/workspaces-cross-reference__lib-a/* → ../../packages/lib-a/* │
  ├────────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ workspaces-dts             │ packages/client/tsconfig.json         │ @fixtures/workspaces-dts__shared → ../../packages/shared/src/index.js  │
  ├────────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ workspaces-dts             │ packages/server/tsconfig.json         │ @fixtures/workspaces-dts__shared → ../../packages/shared/src/index.js  │
  ├────────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ include-entry-reexports    │ tsconfig.json (new)                   │ @fixtures/include-entry-reexports__app and __shared                    │
  ├────────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ workspaces-plugin-config   │ packages/backend/tsconfig.json (new)  │ @fixtures/workspaces-plugin-config__shared/* → ../shared/*             │
  ├────────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ workspaces-plugin-config   │ packages/frontend/tsconfig.json (new) │ @fixtures/workspaces-plugin-config__tailwind/* → ../tailwind/*         │
  └────────────────────────────┴───────────────────────────────────────┴────────────────────────────────────────────────────────────────────────┘

##  What was NOT changed

  - No fixture node_modules symlinks were removed — they still work on Linux/Mac and are the primary resolution path there.
  - No fixture source files or knip.json configs were modified.
  - The _resolveSync function itself is unchanged — only a fallback is added for the specific workspace-internal-file-reference code path.

##  Testing

  All 248 smoke tests pass locally on Windows (node --test 'test/*.test.ts'). The previously-failing 4 test files now pass. CI (Linux) is unaffected since _resolveSync continues to succeed via real symlinks
  and the fallback is never triggered.
