### PR TITLE
Oxfmt now supports .ts config files

### DIFF
--- a/packages/knip/src/plugins/oxfmt/index.ts
+++ b/packages/knip/src/plugins/oxfmt/index.ts
@@ -9,7 +9,7 @@ const enablers = ['oxfmt'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['.oxfmtrc.json', '.oxfmtrc.jsonc'];
+const config = ['.oxfmtrc.json', '.oxfmtrc.jsonc', 'oxfmt.config.ts'];
 
 const args = {
   config: true,


### PR DESCRIPTION
Hey :wave:,

I should have known it was coming, oxfmt now supports `oxfmt.config.ts` as of yesterday's release. Docs for reference: https://oxc.rs/docs/guide/usage/formatter/config.html#create-a-config-file

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
