### PR TITLE
Bump GitHub actions to their latest versions

### DIFF
--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
   push:
     branches:
-      - '**'
+      - "**"
     tags:
-      - '!**'
+      - "!**"
 
 jobs:
   test:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.2.22

--- a/.github/workflows/ci-ts-latest.yml
+++ b/.github/workflows/ci-ts-latest.yml
@@ -5,20 +5,20 @@ on:
   pull_request:
   push:
     branches:
-      - '**'
+      - "**"
     tags:
-      - '!**'
+      - "!**"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Ubuntu/Node v22
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - name: Install dependencies
         run: pnpm install
       - name: Install latest peer dependencies

--- a/.github/workflows/ci-ts-next.yml
+++ b/.github/workflows/ci-ts-next.yml
@@ -5,20 +5,20 @@ on:
   pull_request:
   push:
     branches:
-      - '**'
+      - "**"
     tags:
-      - '!**'
+      - "!**"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Ubuntu/Node v24
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - name: Install dependencies
         run: pnpm install
       - name: Install latest peer dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
   push:
     branches:
-      - '**'
+      - "**"
     tags:
-      - '!**'
+      - "!**"
 
 jobs:
   test:
@@ -26,11 +26,11 @@ jobs:
     name: ${{ matrix.os }} (Node v${{ matrix.node }})
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - name: Install dependencies
         run: pnpm install
       - name: Build knip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
   push:
     branches:
-      - '**'
+      - "**"
     tags:
-      - '!**'
+      - "!**"
 
 permissions:
   issues: write
@@ -19,8 +19,8 @@ jobs:
     outputs:
       sha: ${{ steps.publish.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
       - run: pnpm install --frozen-lockfile
         working-directory: packages/knip
       - run: pnpm run build
@@ -30,7 +30,7 @@ jobs:
           pnpx pkg-pr-new publish --compact './packages/knip' './packages/language-server' './packages/mcp-server'
       - name: Comment on referenced issues
         if: github.event_name == 'push'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const sha = '${{ steps.publish.outputs.sha }}';
@@ -179,10 +179,10 @@ jobs:
               npm run knip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check out ${{ matrix.project.repo }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ matrix.project.repo }}
           path: ${{ matrix.project.name }}
@@ -194,13 +194,13 @@ jobs:
           PATCH_FILE="${{ github.workspace }}/.github/workflows/patches/${{ matrix.project.name }}.patch"
           [ -f "$PATCH_FILE" ] && git apply --verbose "$PATCH_FILE" || true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
       - uses: oven-sh/setup-bun@v2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - name: Run Knip in ${{ matrix.project.repo }}
         working-directory: ${{ matrix.project.name }}

--- a/packages/docs/src/content/docs/guides/using-knip-in-ci.md
+++ b/packages/docs/src/content/docs/guides/using-knip-in-ci.md
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Ubuntu/Node v24
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Install dependencies

--- a/packages/knip/fixtures/plugins/github-actions-workspaces/.github/workflows/dir.yml
+++ b/packages/knip/fixtures/plugins/github-actions-workspaces/.github/workflows/dir.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run stylelint check
         run: yarn stylelint
         working-directory: packages/app


### PR DESCRIPTION
Having a look at the latest CI runs, there are deprecations reported:

E.g.

https://github.com/webpro-nl/knip/actions/runs/23230121480

reports

```
Node.js 20 actions are deprecated.
The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
...
```

This PR fixes these deprecation warnings by bumping Bump GitHub action workflows to their latest versions.