### PR TITLE
Fix broken links in Writing a Plugin docs

### DIFF
--- a/packages/docs/src/content/docs/writing-a-plugin/index.md
+++ b/packages/docs/src/content/docs/writing-a-plugin/index.md
@@ -366,6 +366,6 @@ plugin, this might be the right time to open a pull request!
 [2]: ../reference/plugins.md
 [3]: ../explanations/plugins.md#entry-files-from-config-files
 [4]: https://github.com/webpro-nl/knip/blob/6a6954386b33ee8a2919005230a4bc094e11bc03/knip.json#L12
-[5]: ./inputs.md
+[5]: ../writing-a-plugin/inputs.md
 [6]: ../features/script-parser.md
-[7]: ./argument-parsing.md
+[7]: ../writing-a-plugin/argument-parsing.md


### PR DESCRIPTION
Found some broken links in the docs.