### PR TITLE
feat: support YAML package manifests

### DIFF
--- a/packages/docs/src/content/docs/features/monorepos-and-workspaces.md
+++ b/packages/docs/src/content/docs/features/monorepos-and-workspaces.md
@@ -8,7 +8,8 @@ Workspaces are handled out-of-the-box by Knip.
 
 Workspaces are sometimes also referred to as package-based monorepos, or as
 packages in a monorepo. Knip uses the term workspace exclusively to indicate a
-directory that has a `package.json`.
+directory that has a package manifest (`package.json`, `package.yaml` or
+`package.yml`).
 
 ## Configuration
 
@@ -66,11 +67,15 @@ The `workspaces` in Knip configuration (4) not already defined in the root
 
 :::caution
 
-A workspace must have a `package.json` file.
+A workspace must have a package manifest file (`package.json`, `package.yaml`
+or `package.yml`).
+
+If multiple manifest files are present in the same workspace, Knip prefers
+`package.json`.
 
 :::
 
-For projects with only a root `package.json`, please see [integrated
+For projects with only a root package manifest, please see [integrated
 monorepos][2].
 
 ## Additional workspaces

--- a/packages/docs/src/content/docs/reference/faq.md
+++ b/packages/docs/src/content/docs/reference/faq.md
@@ -300,9 +300,10 @@ dependencies found in webpack configuration, handled by Knip's webpack plugin.
 
 ### What's the difference between workspaces, projects and programs?
 
-A workspace is a directory with a `package.json` file. They're configured in
-`package.json#workspaces` (or `pnpm-workspaces.yml`). In case a directory has a
-`package.json` file, but is not a workspace (from a package manager
+A workspace is a directory with a package manifest (`package.json`,
+`package.yaml` or `package.yml`). They're configured in
+`package.json#workspaces` (or `pnpm-workspace.yaml`). In case a directory has a
+package manifest file, but is not a workspace (from a package manager
 perspective), it can be added as a workspace to the Knip configuration.
 
 Projects - in the context of TypeScript - are directories with a `tsconfig.json`
@@ -314,7 +315,7 @@ resolver.
 ### Why doesn't Knip match my TypeScript project structure?
 
 Repositories and workspaces in a monorepo aren't necessarily structured like
-TypeScript projects. Put simply, the location of `package.json` files isn't
+TypeScript projects. Put simply, the location of package manifest files isn't
 always adjacent to `tsconfig.json` files. Knip follows the structure of
 workspaces in a monorepo.
 
@@ -327,7 +328,7 @@ and installs a single "kitchen sink" module resolver function per workspace.
 Different strategies might add more complexity and performance penalties, while
 the current strategy is simple, fast and good enough.
 
-Note that any directory with a `package.json` not listed in the root
+Note that any directory with a package manifest not listed in the root
 `package.json#workspaces` can be added to the Knip configuration manually to
 have it handled as a separate workspace.
 

--- a/packages/knip/src/PackagePeeker.ts
+++ b/packages/knip/src/PackagePeeker.ts
@@ -14,12 +14,18 @@ export class PackagePeeker {
 
     for (let i = 0; i < this.lines.length; i++) {
       const line = this.lines[i];
+      const jsonDeps = line.indexOf('"dependencies"') !== -1;
+      const jsonDevDeps = line.indexOf('"devDependencies"') !== -1;
+      const jsonOptPeerDeps = line.indexOf('"optionalPeerDependencies"') !== -1;
+      const yamlDeps = /^\s*dependencies:\s*/.test(line);
+      const yamlDevDeps = /^\s*devDependencies:\s*/.test(line);
+      const yamlOptPeerDeps = /^\s*optionalPeerDependencies:\s*/.test(line);
       const section =
-        line.indexOf('"dependencies"') !== -1
+        jsonDeps || yamlDeps
           ? 'dependencies'
-          : line.indexOf('"devDependencies"') !== -1
+          : jsonDevDeps || yamlDevDeps
             ? 'devDependencies'
-            : line.indexOf('"optionalPeerDependencies"') !== -1
+            : jsonOptPeerDeps || yamlOptPeerDeps
               ? 'optionalPeerDependencies'
               : undefined;
       if (section) this.sections[section] = { startLine: i, startPos: pos };
@@ -38,10 +44,14 @@ export class PackagePeeker {
     if (lines.length === 0 || !section) return;
 
     let pos = section.startPos + lines[section.startLine].length + 1;
+    const escapedPackageName = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const yamlMatcher = new RegExp(`^\\s*${escapedPackageName}:\\s*`);
 
     for (let i = section.startLine + 1; i < lines.length; i++) {
       const line = lines[i];
-      if (line.includes(`"${packageName}"`)) {
+      const jsonMatch = line.includes(`"${packageName}"`);
+      const yamlMatch = yamlMatcher.test(line);
+      if (jsonMatch || yamlMatch) {
         const col = line.indexOf(packageName);
         return { line: i + 1, col: col + 1, pos: pos + col };
       }

--- a/packages/knip/src/util/create-options.ts
+++ b/packages/knip/src/util/create-options.ts
@@ -8,7 +8,7 @@ import type { PackageJson } from '../types/package-json.ts';
 import { getCatalogContainer } from './catalog.ts';
 import type { ParsedCLIArgs } from './cli-arguments.ts';
 import { ConfigurationError } from './errors.ts';
-import { findFile, loadJSON } from './fs.ts';
+import { findFile, findManifestFile, loadManifest } from './fs.ts';
 import { getIncludedIssueTypes, shorthandDeps, shorthandExports, shorthandFiles } from './get-included-issue-types.ts';
 import { defaultRules } from './issue-initializers.ts';
 import { loadResolvedConfigFile } from './load-config.ts';
@@ -23,7 +23,7 @@ interface CreateOptions extends Partial<Options> {
 }
 
 /**
- * - Loads package.json/pnpm-workspace.yaml
+ * - Loads package manifest/pnpm-workspace.yaml
  * - Loads & validates knip.json
  * - Creates options
  */
@@ -32,11 +32,11 @@ export const createOptions = async (options: CreateOptions) => {
   const pcwd = process.cwd();
   const cwd = normalize(toPosix(toAbsolute(options.cwd ?? args.directory ?? pcwd, pcwd)));
 
-  const manifestPath = findFile(cwd, 'package.json');
-  const manifest: PackageJson = manifestPath && (await loadJSON(manifestPath));
+  const manifestPath = findManifestFile(cwd);
+  const manifest: PackageJson = manifestPath && (await loadManifest(manifestPath));
 
   if (!(manifestPath && manifest)) {
-    throw new ConfigurationError('Unable to find package.json');
+    throw new ConfigurationError('Unable to find package manifest (package.json, package.yaml, or package.yml)');
   }
 
   let configFilePath: string | undefined;
@@ -49,7 +49,8 @@ export const createOptions = async (options: CreateOptions) => {
   }
 
   if (args.config && !configFilePath && !manifest.knip) {
-    throw new ConfigurationError(`Unable to find ${args.config} or package.json#knip`);
+    const manifestFileName = manifestPath.split('/').pop() ?? 'package.json';
+    throw new ConfigurationError(`Unable to find ${args.config} or ${manifestFileName}#knip`);
   }
 
   const loadedConfig = Object.assign(

--- a/packages/knip/src/util/fs.ts
+++ b/packages/knip/src/util/fs.ts
@@ -27,6 +27,14 @@ export const findFile = (cwd: string, fileName: string) => {
   return isFile(filePath) ? filePath : undefined;
 };
 
+export const findManifestFile = (cwd: string): string | undefined => {
+  const candidates = ['package.json', 'package.yaml', 'package.yml'];
+  for (const candidate of candidates) {
+    const filePath = join(cwd, candidate);
+    if (isFile(filePath)) return filePath;
+  }
+};
+
 export const findFileWithExtensions = (basePath: string, extensions: string[]): string | undefined => {
   for (const ext of extensions) {
     const candidate = basePath + ext;
@@ -61,6 +69,11 @@ export const loadJSON = async (filePath: string) => {
   } catch {
     return parseJSONC(filePath, contents);
   }
+};
+
+export const loadManifest = async (filePath: string) => {
+  const ext = extname(filePath);
+  return ext === '.yaml' || ext === '.yml' ? await loadYAML(filePath) : await loadJSON(filePath);
 };
 
 export const loadJSONC = async (filePath: string) => {

--- a/packages/knip/src/util/map-workspaces.ts
+++ b/packages/knip/src/util/map-workspaces.ts
@@ -2,12 +2,20 @@ import { readFile } from 'node:fs/promises';
 import fg from 'fast-glob';
 import type { PackageJson, WorkspacePackage } from '../types/package-json.ts';
 import { partition } from './array.ts';
+import { debugLog } from './debug.ts';
 import { ConfigurationError } from './errors.ts';
+import { parseYAML } from './fs.ts';
 import { getPackageName } from './package-name.ts';
-import { join } from './path.ts';
+import { extname, join } from './path.ts';
 
 type Packages = Map<string, WorkspacePackage>;
 type WorkspacePkgNames = Set<string>;
+
+const parseManifest = (manifestStr: string, manifestPath: string): PackageJson => {
+  const ext = extname(manifestPath);
+  if (ext === '.yaml' || ext === '.yml') return parseYAML(manifestStr);
+  return JSON.parse(manifestStr);
+};
 
 export default async function mapWorkspaces(cwd: string, workspaces: string[]): Promise<[Packages, WorkspacePkgNames]> {
   const [negatedPatterns, patterns] = partition(workspaces, p => p.match(/^!/));
@@ -16,20 +24,35 @@ export default async function mapWorkspaces(cwd: string, workspaces: string[]): 
 
   if (patterns.length === 0 && negatedPatterns.length === 0) return [packages, wsPkgNames];
 
-  const manifestPatterns = patterns.map(p => join(p, 'package.json'));
+  const manifestPatterns = patterns.flatMap(p => [
+    join(p, 'package.json'),
+    join(p, 'package.yaml'),
+    join(p, 'package.yml'),
+  ]);
 
   const matches = await fg.glob(manifestPatterns, {
     cwd,
     ignore: ['**/node_modules/**', ...negatedPatterns.map(p => p.slice(1))],
   });
 
-  for (const match of matches.sort()) {
-    const name = match === 'package.json' ? '.' : match.replace(/\/package\.json$/, '');
+  const matchesByDir = new Map<string, string[]>();
+  for (const match of matches) {
+    const dirPath = match.replace(/(^|\/)package\.(json|yaml|yml)$/, '');
+    const dirMatches = matchesByDir.get(dirPath);
+    if (dirMatches) dirMatches.push(match);
+    else matchesByDir.set(dirPath, [match]);
+  }
+
+  for (const [dirPath, dirMatches] of matchesByDir) {
+    const packageJson = dirPath ? join(dirPath, 'package.json') : 'package.json';
+    const match = dirMatches.includes(packageJson) ? packageJson : dirMatches.slice().sort()[0];
+    if (!match) continue;
+    const name = dirPath === '' ? '.' : dirPath;
     const dir = join(cwd, name);
     const manifestPath = join(cwd, match);
     try {
       const manifestStr = await readFile(manifestPath, 'utf8');
-      const manifest: PackageJson = JSON.parse(manifestStr);
+      const manifest: PackageJson = parseManifest(manifestStr, manifestPath);
       const pkgName = getPackageName(manifest, dir);
       const pkg: WorkspacePackage = { dir, name, pkgName, manifestPath, manifestStr, manifest };
       packages.set(name, pkg);
@@ -37,7 +60,7 @@ export default async function mapWorkspaces(cwd: string, workspaces: string[]): 
       else throw new ConfigurationError(`Missing package name in ${manifestPath}`);
     } catch (error) {
       // @ts-expect-error
-      if (error?.code === 'ENOENT') debugLog('*', `Unable to load package.json for ${name}`);
+      if (error?.code === 'ENOENT') debugLog('*', `Unable to load package manifest for ${name}`);
       else throw error;
     }
   }

--- a/packages/knip/test/util/map-workspaces.test.ts
+++ b/packages/knip/test/util/map-workspaces.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { join } from '../../src/util/path.ts';
+import mapWorkspaces from '../../src/util/map-workspaces.ts';
+
+test('Map root workspace from package.yaml', async t => {
+  const cwd = await mkdtemp(join(tmpdir(), 'knip-map-workspaces-'));
+  t.after(async () => rm(cwd, { recursive: true, force: true }));
+
+  await writeFile(
+    join(cwd, 'package.yaml'),
+    ['name: root-workspace', 'workspaces:', '  - packages/*', 'dependencies:', '  a.b: 1.0.0'].join('\n')
+  );
+  await mkdir(join(cwd, 'packages', 'one'), { recursive: true });
+  await writeFile(join(cwd, 'packages', 'one', 'package.yaml'), ['name: workspace-one'].join('\n'));
+
+  const [packages, wsPkgNames] = await mapWorkspaces(cwd, ['.', 'packages/*']);
+  const rootPackage = packages.get('.');
+
+  assert(rootPackage);
+  assert.equal(rootPackage.manifestPath, join(cwd, 'package.yaml'));
+  assert.equal(rootPackage.pkgName, 'root-workspace');
+  assert(wsPkgNames.has('root-workspace'));
+  assert(packages.has('packages/one'));
+});
+
+test('Prefer package.json over YAML in same workspace', async t => {
+  const cwd = await mkdtemp(join(tmpdir(), 'knip-map-workspaces-'));
+  t.after(async () => rm(cwd, { recursive: true, force: true }));
+
+  await mkdir(join(cwd, 'packages', 'one'), { recursive: true });
+  await writeFile(join(cwd, 'packages', 'one', 'package.yaml'), ['name: from-yaml'].join('\n'));
+  await writeFile(join(cwd, 'packages', 'one', 'package.json'), JSON.stringify({ name: 'from-json' }, null, 2));
+
+  const [packages] = await mapWorkspaces(cwd, ['packages/*']);
+  const workspace = packages.get('packages/one');
+
+  assert(workspace);
+  assert.equal(workspace.pkgName, 'from-json');
+  assert.equal(workspace.manifestPath, join(cwd, 'packages', 'one', 'package.json'));
+});

--- a/packages/knip/test/util/package-peeker.test.ts
+++ b/packages/knip/test/util/package-peeker.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { PackagePeeker } from '../../src/PackagePeeker.ts';
+
+test('Find dependency location in YAML manifest', () => {
+  const manifestStr = [
+    'name: demo',
+    'dependencies:',
+    '  alpha: 1.0.0',
+    'devDependencies:',
+    '  beta: 1.0.0',
+    'optionalPeerDependencies:',
+    '  gamma: 1.0.0',
+  ].join('\n');
+
+  const peeker = new PackagePeeker(manifestStr);
+  const dep = peeker.getLocation('dependencies', 'alpha');
+  const dev = peeker.getLocation('devDependencies', 'beta');
+  const opt = peeker.getLocation('optionalPeerDependencies', 'gamma');
+
+  assert(dep);
+  assert.equal(dep.line, 3);
+  assert(dev);
+  assert.equal(dev.line, 5);
+  assert(opt);
+  assert.equal(opt.line, 7);
+});
+
+test('Escape regex characters in YAML package names', () => {
+  const manifestStr = ['name: demo', 'dependencies:', '  aXb: 1.0.0', '  a.b: 2.0.0'].join('\n');
+
+  const peeker = new PackagePeeker(manifestStr);
+  const location = peeker.getLocation('dependencies', 'a.b');
+
+  assert(location);
+  assert.equal(location.line, 4);
+});


### PR DESCRIPTION
## Summary

- Add support for `package.yaml` and `package.yml` manifests in addition to `package.json`.
- Load the root manifest from JSON or YAML and improve config-related errors to reference the actual manifest file.
- Extend workspace manifest discovery/parsing to include YAML, with deterministic preference for `package.json` when both formats exist.
- Update dependency location peeking to recognise YAML dependency sections and safely match package names containing regex-special characters.

## Why

Some projects use YAML manifests instead of JSON. Knip previously assumed `package.json` only, which caused manifest discovery and dependency diagnostics to fail in those setups.

> [!NOTE]
> Support for `package.yaml` seems conspicuous by its absence, but I couldn't see any discussion in Issues or PRs. Perhaps it's against the philosophy or maybe I've missed a substantial blocker in my, frankly quite superficial, analysis of this?

## What Changed

- `packages/knip/src/util/fs.ts`
  - Added `findManifestFile()` for `package.json` / `package.yaml` / `package.yml`.
  - Added `loadManifest()` to parse JSON or YAML by extension.
- `packages/knip/src/util/create-options.ts`
  - Switched root manifest loading to `findManifestFile()` + `loadManifest()`.
  - Updated error messages when manifest/config isn’t found.
- `packages/knip/src/util/map-workspaces.ts`
  - Added YAML manifest glob patterns.
  - Parse workspace manifests as JSON or YAML.
  - Group matches by workspace directory and prefer `package.json` if both formats exist.
  - Fixed root manifest directory normalisation.
- `packages/knip/src/PackagePeeker.ts`
  - Added YAML section detection for `dependencies`, `devDependencies`, and `optionalPeerDependencies`.
  - Added escaped YAML key matching for package names (avoids regex false matches).
- Tests
  - Added `packages/knip/test/util/map-workspaces.test.ts`
    - root workspace mapping with `package.yaml`
    - preference of `package.json` over YAML in same workspace
  - Added `packages/knip/test/util/package-peeker.test.ts`
    - YAML dependency location detection
    - package names with regex-special characters

## Test Plan

- [x] `pnpm install`
- [x] `pnpm -C packages/knip run build`
- [x] `pnpm -C packages/knip run test:node`
- [x] `pnpm -C packages/knip exec tsx --test test/util/map-workspaces.test.ts test/util/package-peeker.test.ts`
- [x] Manual validation in a consumer project using YAML manifest.