### PR TITLE
Support tilde-prefixed scoped package names (e.g. @~private/pkg)

### DIFF
--- a/packages/knip/src/util/modules.ts
+++ b/packages/knip/src/util/modules.ts
@@ -31,7 +31,7 @@ export const getPackageNameFromSpecifier = (specifier: string) =>
 const matchPackageNameStart = /^(@[a-z0-9._~]|[a-z0-9])/i;
 export const isStartsLikePackageName = (specifier: string) => {
   const ch = specifier.charCodeAt(0);
-  if (ch === 46 || ch === 47 || ch === 35 || ch === 36) return false; // . / # $
+  if (ch === 46 || ch === 47 || ch === 35 || ch === 126 || ch === 36) return false; // . / # ~ $
   return matchPackageNameStart.test(specifier);
 };
 

--- a/packages/knip/test/util/modules.test.ts
+++ b/packages/knip/test/util/modules.test.ts
@@ -23,19 +23,27 @@ test('Should detect specifiers that look like package names', () => {
   assert.equal(isStartsLikePackageName('react'), true);
   assert.equal(isStartsLikePackageName('@scope/pkg'), true);
   assert.equal(isStartsLikePackageName('@~private/pkg'), true);
+  assert.equal(isStartsLikePackageName('@.internal/pkg'), true);
+  assert.equal(isStartsLikePackageName('@_private/pkg'), true);
   assert.equal(isStartsLikePackageName('./relative'), false);
   assert.equal(isStartsLikePackageName('../parent'), false);
+  assert.equal(isStartsLikePackageName('/absolute'), false);
   assert.equal(isStartsLikePackageName('#subpath'), false);
   assert.equal(isStartsLikePackageName('$dollar'), false);
   assert.equal(isStartsLikePackageName('~/alias'), false);
+  assert.equal(isStartsLikePackageName('~bare'), false);
 });
 
 test('Should extract package name from module specifier', () => {
+  assert.equal(getPackageNameFromModuleSpecifier('@scope/pkg'), '@scope/pkg');
+  assert.equal(getPackageNameFromModuleSpecifier('@scope/pkg/deep'), '@scope/pkg');
   assert.equal(getPackageNameFromModuleSpecifier('@~private/pkg'), '@~private/pkg');
   assert.equal(getPackageNameFromModuleSpecifier('@~private/pkg/deep'), '@~private/pkg');
   assert.equal(getPackageNameFromModuleSpecifier('react'), 'react');
   assert.equal(getPackageNameFromModuleSpecifier('react/jsx-runtime'), 'react');
   assert.equal(getPackageNameFromModuleSpecifier('~/something'), undefined);
+  assert.equal(getPackageNameFromModuleSpecifier('./relative'), undefined);
+  assert.equal(getPackageNameFromModuleSpecifier('#subpath'), undefined);
 });
 
 test('Should sanitize import specifier', () => {


### PR DESCRIPTION
Tiny change: adding support for tilde characters in package names.

The tilde character can be used for package names according to: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#name (i.e. package names must use URL-safe chars; which includes the tilde char)