### PR TITLE
fix: unlisted binaries bug with execa

### DIFF
--- a/packages/knip/fixtures/script-visitors-execa-variable-cmd/package.json
+++ b/packages/knip/fixtures/script-visitors-execa-variable-cmd/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixtures/script-visitors-execa-variable-cmd",
+  "scripts": {
+    "start": "node ./script.mjs"
+  },
+  "devDependencies": {
+    "execa": "*"
+  }
+}

--- a/packages/knip/fixtures/script-visitors-execa-variable-cmd/script.mjs
+++ b/packages/knip/fixtures/script-visitors-execa-variable-cmd/script.mjs
@@ -1,0 +1,4 @@
+import { $ } from 'execa';
+
+const command = 'npm';
+await $`${command} publish --access=public --ignore-scripts`;

--- a/packages/knip/src/plugins/execa/visitors/execa.ts
+++ b/packages/knip/src/plugins/execa/visitors/execa.ts
@@ -15,8 +15,12 @@ export function createExecaVisitor(ctx: PluginVisitorContext): PluginVisitorObje
             ? tag.callee.name
             : undefined;
       if (tagName && tags.has(tagName)) {
-        for (const q of node.quasi.quasis) {
-          if (q.value.raw) ctx.addScript(q.value.raw);
+        const firstQuasiIsEmpty = !node.quasi.quasis[0]?.value.raw;
+        for (const [index, q] of node.quasi.quasis.entries()) {
+          const script = q.value.raw;
+          if (!script) continue;
+          if (index > 0 && firstQuasiIsEmpty && !/^\s*[;&|]/.test(script)) continue;
+          ctx.addScript(script);
         }
       }
     },

--- a/packages/knip/src/plugins/zx/visitors/zx.ts
+++ b/packages/knip/src/plugins/zx/visitors/zx.ts
@@ -5,8 +5,12 @@ export function createZxVisitor(ctx: PluginVisitorContext): PluginVisitorObject 
     TaggedTemplateExpression(node) {
       if (!ctx.sourceText.startsWith('#!/usr/bin/env zx')) return;
       if (node.tag.type === 'Identifier' && node.tag.name === '$') {
-        for (const q of node.quasi.quasis) {
-          if (q.value.raw) ctx.addScript(q.value.raw);
+        const firstQuasiIsEmpty = !node.quasi.quasis[0]?.value.raw;
+        for (const [index, q] of node.quasi.quasis.entries()) {
+          const script = q.value.raw;
+          if (!script) continue;
+          if (index > 0 && firstQuasiIsEmpty && !/^\s*[;&|]/.test(script)) continue;
+          ctx.addScript(script);
         }
       }
     },

--- a/packages/knip/src/typescript/visitors/script-visitors.ts
+++ b/packages/knip/src/typescript/visitors/script-visitors.ts
@@ -5,8 +5,12 @@ export function createBunShellVisitor(ctx: PluginVisitorContext): PluginVisitorO
     TaggedTemplateExpression(node) {
       const tag = node.tag;
       if (tag.type === 'Identifier' && tag.name === '$') {
-        for (const q of node.quasi.quasis) {
-          if (q.value.raw) ctx.addScript(q.value.raw);
+        const firstQuasiIsEmpty = !node.quasi.quasis[0]?.value.raw;
+        for (const [index, q] of node.quasi.quasis.entries()) {
+          const script = q.value.raw;
+          if (!script) continue;
+          if (index > 0 && firstQuasiIsEmpty && !/^\s*[;&|]/.test(script)) continue;
+          ctx.addScript(script);
         }
       }
     },

--- a/packages/knip/test/script-visitors-execa-variable-cmd.test.ts
+++ b/packages/knip/test/script-visitors-execa-variable-cmd.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../src/index.ts';
+import baseCounters from './helpers/baseCounters.ts';
+import { createOptions } from './helpers/create-options.ts';
+import { resolve } from './helpers/resolve.ts';
+
+const cwd = resolve('fixtures/script-visitors-execa-variable-cmd');
+
+test('Template literal starting with variable expression should not report false positive binary', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
Knip has a false positive with the following pattern:

```ts
const command = 'npm';
await $`${command} publish --access=public --ignore-scripts`;
```

With this code, Knip thinks that the "publish" binary is not listed.

This PR fixes the bug. (I didn't bother opening an issue in favor of just fixing it.)