### PR TITLE
fix: whitelist spelling error

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -38,7 +38,7 @@ Example terminal commands on your machine to get started:
 
 ```shell
 git clone git@github.com:[username]/knip.git
-# Or using gh CLI: gh repo fork webpro-nl/knip --clone
+# Or using the GitHub CLI: gh repo fork webpro-nl/knip --clone
 cd knip
 pnpm install
 cd packages/knip

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,7 +39,8 @@
     "timerify",
     "tsup",
     "unimported",
-    "webp"
+    "webp",
+    "webpro"
   ],
   "editor.formatOnSave": true
 }


### PR DESCRIPTION
This PR should be self-explanatory.
The word "webpro" needed to be whitelisted, as the existing file was violating lint on main branch.
That brings up the question: It seems that you are using CSpell but not actually checking for it in CI. Is that intended? 
Do you want me to do a PR that adds it?

IMHO I think IDE linting and CI linting should be identical, as it leads to a lot of developer confusion otherwise.
Josh Goldberg was the one who convinced me of this in his blog: https://www.joshuakgoldberg.com/blog/if-i-wrote-a-linter-part-2-developer-experience/