### PR TITLE
Add Panda CSS plugin

### DIFF
--- a/packages/knip/fixtures/plugins/panda-css/node_modules/@pandacss/dev/index.js
+++ b/packages/knip/fixtures/plugins/panda-css/node_modules/@pandacss/dev/index.js
@@ -1,0 +1,1 @@
+export const defineConfig = id => id;

--- a/packages/knip/fixtures/plugins/panda-css/node_modules/@pandacss/dev/package.json
+++ b/packages/knip/fixtures/plugins/panda-css/node_modules/@pandacss/dev/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@pandacss/dev"
+}

--- a/packages/knip/fixtures/plugins/panda-css/node_modules/@pandacss/preset-panda/package.json
+++ b/packages/knip/fixtures/plugins/panda-css/node_modules/@pandacss/preset-panda/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@pandacss/preset-panda"
+}

--- a/packages/knip/fixtures/plugins/panda-css/node_modules/postcss/package.json
+++ b/packages/knip/fixtures/plugins/panda-css/node_modules/postcss/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "postcss"
+}

--- a/packages/knip/fixtures/plugins/panda-css/package.json
+++ b/packages/knip/fixtures/plugins/panda-css/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@plugins/panda-css",
+  "devDependencies": {
+    "@pandacss/dev": "*",
+    "postcss": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/panda-css/panda.config.ts
+++ b/packages/knip/fixtures/plugins/panda-css/panda.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@pandacss/dev';
+
+export default defineConfig({
+  presets: ['@pandacss/preset-panda', '@park-ui/panda-preset'],
+  include: ['./src/**/*.tsx'],
+});

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -632,6 +632,10 @@
           "title": "oxlint plugin configuration (https://knip.dev/reference/plugins/oxlint)",
           "$ref": "#/definitions/plugin"
         },
+        "panda-css": {
+          "title": "panda-css plugin configuration (https://knip.dev/reference/plugins/panda-css)",
+          "$ref": "#/definitions/plugin"
+        },
         "payload": {
           "title": "payload plugin configuration (https://knip.dev/reference/plugins/payload)",
           "$ref": "#/definitions/plugin"

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -72,6 +72,7 @@ import { default as oclif } from './oclif/index.ts';
 import { default as openapiTs } from './openapi-ts/index.ts';
 import { default as oxfmt } from './oxfmt/index.ts';
 import { default as oxlint } from './oxlint/index.ts';
+import { default as pandaCss } from './panda-css/index.ts';
 import { default as parcel } from './parcel/index.ts';
 import { default as payload } from './payload/index.ts';
 import { default as playwright } from './playwright/index.ts';
@@ -217,6 +218,7 @@ export const Plugins = {
   'openapi-ts': openapiTs,
   oxfmt,
   oxlint,
+  'panda-css': pandaCss,
   parcel,
   payload,
   playwright,

--- a/packages/knip/src/plugins/panda-css/index.ts
+++ b/packages/knip/src/plugins/panda-css/index.ts
@@ -1,0 +1,29 @@
+import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
+import { toDeferResolve, toDependency } from '../../util/input.ts';
+import { hasDependency } from '../../util/plugin.ts';
+import type { PandaCSSConfig } from './types.ts';
+
+// https://panda-css.com/docs/references/config
+
+const title = 'Panda CSS';
+
+const enablers = ['@pandacss/dev'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+
+const config = ['panda.config.{ts,js,mjs,cjs,mts,cts}'];
+
+const resolveConfig: ResolveConfig<PandaCSSConfig> = config => {
+  const presets = (config.presets ?? []).filter((preset): preset is string => typeof preset === 'string');
+  return [...presets.map(id => toDeferResolve(id)), toDependency('postcss')];
+};
+
+const plugin: Plugin = {
+  title,
+  enablers,
+  isEnabled,
+  config,
+  resolveConfig,
+};
+
+export default plugin;

--- a/packages/knip/src/plugins/panda-css/types.ts
+++ b/packages/knip/src/plugins/panda-css/types.ts
@@ -1,0 +1,3 @@
+export type PandaCSSConfig = {
+  presets?: (string | Record<string, unknown>)[];
+};

--- a/packages/knip/src/schema/plugins.ts
+++ b/packages/knip/src/schema/plugins.ts
@@ -86,6 +86,7 @@ export const pluginsSchema = z.object({
   'openapi-ts': pluginSchema,
   oxfmt: pluginSchema,
   oxlint: pluginSchema,
+  'panda-css': pluginSchema,
   parcel: pluginSchema,
   payload: pluginSchema,
   playwright: pluginSchema,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -73,6 +73,7 @@ export type PluginName =
   | 'openapi-ts'
   | 'oxfmt'
   | 'oxlint'
+  | 'panda-css'
   | 'parcel'
   | 'payload'
   | 'playwright'
@@ -218,6 +219,7 @@ export const pluginNames = [
   'openapi-ts',
   'oxfmt',
   'oxlint',
+  'panda-css',
   'parcel',
   'payload',
   'playwright',

--- a/packages/knip/test/plugins/panda-css.test.ts
+++ b/packages/knip/test/plugins/panda-css.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/panda-css');
+
+test('Find dependencies with the Panda CSS plugin', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.unlisted['panda.config.ts']['@pandacss/preset-panda']);
+  assert(issues.unlisted['panda.config.ts']['@park-ui/panda-preset']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    unlisted: 2,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `panda-css` plugin that activates when `@pandacss/dev` is in dependencies
- Detects `panda.config.{ts,js,mjs,cjs,mts,cts}` as config files
- Resolves string presets from the config as dependencies (e.g. `@pandacss/preset-panda`, `@park-ui/panda-preset`)
- Marks `postcss` as used since `@pandacss/dev` brings it transitively via `@pandacss/dev/postcss`

## Test plan

- [x] Added fixture at `fixtures/plugins/panda-css/` with panda config containing two presets
- [x] Test verifies both presets are detected as unlisted dependencies
- [x] Existing plugin tests (postcss, unocss, tailwind, babel) still pass