### PR TITLE
feat: add configurable foreignFileExtensions option

### DIFF
--- a/packages/knip/fixtures/foreign-file-extensions-default/data.yaml
+++ b/packages/knip/fixtures/foreign-file-extensions-default/data.yaml
@@ -1,0 +1,1 @@
+yaml: content

--- a/packages/knip/fixtures/foreign-file-extensions-default/image.png
+++ b/packages/knip/fixtures/foreign-file-extensions-default/image.png
@@ -1,0 +1,1 @@
+PNG placeholder

--- a/packages/knip/fixtures/foreign-file-extensions-default/index.ts
+++ b/packages/knip/fixtures/foreign-file-extensions-default/index.ts
@@ -1,0 +1,6 @@
+// Test imports with default foreign file extensions
+import './style.css';           // Should NOT be unresolved (in default foreignFileExtensions)
+import './image.png';           // Should NOT be unresolved (in default foreignFileExtensions)
+import './data.yaml';           // Should NOT be unresolved (in default foreignFileExtensions)
+import './custom.xyz';          // Should be unresolved (NOT in default foreignFileExtensions, file doesn't exist)
+import './missing-file';        // Should be unresolved (no extension)

--- a/packages/knip/fixtures/foreign-file-extensions-default/package.json
+++ b/packages/knip/fixtures/foreign-file-extensions-default/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixtures/foreign-file-extensions-default",
+  "type": "module"
+}

--- a/packages/knip/fixtures/foreign-file-extensions-default/style.css
+++ b/packages/knip/fixtures/foreign-file-extensions-default/style.css
@@ -1,0 +1,1 @@
+/* CSS content */

--- a/packages/knip/fixtures/foreign-file-extensions/data.custom
+++ b/packages/knip/fixtures/foreign-file-extensions/data.custom
@@ -1,0 +1,1 @@
+// Custom file content

--- a/packages/knip/fixtures/foreign-file-extensions/icon.xyz
+++ b/packages/knip/fixtures/foreign-file-extensions/icon.xyz
@@ -1,0 +1,1 @@
+// XYZ content

--- a/packages/knip/fixtures/foreign-file-extensions/index.ts
+++ b/packages/knip/fixtures/foreign-file-extensions/index.ts
@@ -1,0 +1,6 @@
+// Test imports with custom foreign file extensions
+import './style.css';           // Should NOT be unresolved (in foreignFileExtensions)
+import './icon.xyz';            // Should NOT be unresolved (in foreignFileExtensions)
+import './data.custom';         // Should NOT be unresolved (in foreignFileExtensions)
+import './unknown.unknown';     // Should be unresolved (NOT in foreignFileExtensions)
+import './missing-file';        // Should be unresolved (no extension)

--- a/packages/knip/fixtures/foreign-file-extensions/knip.ts
+++ b/packages/knip/fixtures/foreign-file-extensions/knip.ts
@@ -1,0 +1,3 @@
+export default {
+  foreignFileExtensions: ['.xyz', '.custom', '.css']
+};

--- a/packages/knip/fixtures/foreign-file-extensions/package.json
+++ b/packages/knip/fixtures/foreign-file-extensions/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixtures/foreign-file-extensions",
+  "type": "module"
+}

--- a/packages/knip/fixtures/foreign-file-extensions/style.css
+++ b/packages/knip/fixtures/foreign-file-extensions/style.css
@@ -1,0 +1,1 @@
+/* CSS content */

--- a/packages/knip/src/ConfigurationChief.ts
+++ b/packages/knip/src/ConfigurationChief.ts
@@ -1,6 +1,6 @@
 import picomatch from 'picomatch';
 import type { SyncCompilers } from './compilers/types.ts';
-import { DEFAULT_EXTENSIONS, ROOT_WORKSPACE_NAME } from './constants.ts';
+import { DEFAULT_EXTENSIONS, FOREIGN_FILE_EXTENSIONS, ROOT_WORKSPACE_NAME } from './constants.ts';
 import type {
   Configuration,
   IgnorePatterns,
@@ -61,6 +61,7 @@ const defaultConfig: Configuration = {
   syncCompilers: new Map(),
   asyncCompilers: new Map(),
   rootPluginConfigs: {},
+  foreignFileExtensions: Array.from(FOREIGN_FILE_EXTENSIONS),
 };
 
 export type Workspace = {
@@ -145,6 +146,7 @@ export class ConfigurationChief {
     const ignoreIssues = rawConfig.ignoreIssues ?? {};
     const ignoreWorkspaces = rawConfig.ignoreWorkspaces ?? defaultConfig.ignoreWorkspaces;
     const isIncludeEntryExports = rawConfig.includeEntryExports ?? this.isIncludeEntryExports;
+    const foreignFileExtensions = rawConfig.foreignFileExtensions ?? defaultConfig.foreignFileExtensions;
 
     const { syncCompilers, asyncCompilers } = rawConfig;
 
@@ -170,6 +172,7 @@ export class ConfigurationChief {
       syncCompilers: new Map(Object.entries(syncCompilers ?? {})) as SyncCompilers,
       asyncCompilers: new Map(Object.entries(asyncCompilers ?? {})),
       rootPluginConfigs,
+      foreignFileExtensions,
     };
   }
 

--- a/packages/knip/src/ProjectPrincipal.ts
+++ b/packages/knip/src/ProjectPrincipal.ts
@@ -55,12 +55,13 @@ export class ProjectPrincipal {
   resolvedFiles = new Set<string>();
   deletedFiles = new Set<string>();
 
-  constructor(options: MainOptions, toSourceFilePath: ToSourceFilePath) {
+  constructor(options: MainOptions, toSourceFilePath: ToSourceFilePath, foreignFileExtensions: string[]) {
     this.cache = new CacheConsultant('root', options);
     this.toSourceFilePath = toSourceFilePath;
     this.pluginVisitorObjects.push(createBunShellVisitor(this.pluginCtx));
     this.fileManager = new SourceFileManager({
       compilers: [this.syncCompilers, this.asyncCompilers],
+      foreignFileExtensions,
     });
   }
 

--- a/packages/knip/src/graph/build.ts
+++ b/packages/knip/src/graph/build.ts
@@ -3,7 +3,7 @@ import type { CatalogCounselor } from '../CatalogCounselor.ts';
 import type { ConfigurationChief, Workspace } from '../ConfigurationChief.ts';
 import type { ConsoleStreamer } from '../ConsoleStreamer.ts';
 import { getCompilerExtensions, getIncludedCompilers, normalizeCompilerExtension } from '../compilers/index.ts';
-import { DEFAULT_EXTENSIONS, FOREIGN_FILE_EXTENSIONS, IS_DTS } from '../constants.ts';
+import { DEFAULT_EXTENSIONS, IS_DTS } from '../constants.ts';
 import type { DependencyDeputy } from '../DependencyDeputy.ts';
 import type { IssueCollector } from '../IssueCollector.ts';
 import type { ProjectPrincipal } from '../ProjectPrincipal.ts';
@@ -381,7 +381,8 @@ export async function build({
         } else {
           if (!isGitIgnored(join(dirname(filePath), sanitizedSpecifier))) {
             const ext = extname(sanitizedSpecifier);
-            if (!ext || (ext !== '.json' && !FOREIGN_FILE_EXTENSIONS.has(ext))) unresolvedImports.add(unresolvedImport);
+            const foreignFileExtensions = new Set(chief.config.foreignFileExtensions);
+            if (!ext || (ext !== '.json' && !foreignFileExtensions.has(ext))) unresolvedImports.add(unresolvedImport);
           }
         }
       }

--- a/packages/knip/src/run.ts
+++ b/packages/knip/src/run.ts
@@ -32,7 +32,7 @@ export const run = async (options: MainOptions) => {
   const isGitIgnored = await getGitIgnoredHandler(options, new Set(workspaces.map(w => w.dir)));
 
   const toSourceFilePath = getModuleSourcePathHandler(chief);
-  const principal = new ProjectPrincipal(options, toSourceFilePath);
+  const principal = new ProjectPrincipal(options, toSourceFilePath, chief.config.foreignFileExtensions);
 
   collector.setWorkspaceFilter(chief.workspaceFilePathFilter);
   collector.setIgnoreIssues(chief.config.ignoreIssues);

--- a/packages/knip/src/schema/configuration.ts
+++ b/packages/knip/src/schema/configuration.ts
@@ -374,6 +374,21 @@ const rootConfigurationSchema = z.object({
    * ```
    */
   treatConfigHintsAsErrors: z.optional(z.boolean()),
+  /**
+   * Array of file extensions that should be treated as foreign files (non-source files).
+   * Foreign files are treated as empty files during source analysis and don't trigger
+   * unresolved import warnings when they can't be parsed.
+   *
+   * @default [".avif", ".css", ".eot", ".gif", ".html", ".ico", ".jpeg", ".jpg", ".less", ".mp3", ".png", ".sass", ".scss", ".sh", ".svg", ".ttf", ".webp", ".woff", ".woff2", ".yaml", ".yml"]
+   *
+   * @example
+   * ```json title="knip.json"
+   * {
+   *   "foreignFileExtensions": [".css", ".scss", ".png", ".jpg", ".custom"]
+   * }
+   * ```
+   */
+  foreignFileExtensions: z.optional(z.array(z.string())),
 });
 
 const reportConfigSchema = z.object({

--- a/packages/knip/src/types/config.ts
+++ b/packages/knip/src/types/config.ts
@@ -74,6 +74,7 @@ export interface Configuration {
   syncCompilers: SyncCompilers;
   asyncCompilers: AsyncCompilers;
   rootPluginConfigs: Partial<PluginsConfiguration>;
+  foreignFileExtensions: string[];
 }
 
 type NormalizedGlob = string[];

--- a/packages/knip/src/typescript/SourceFileManager.ts
+++ b/packages/knip/src/typescript/SourceFileManager.ts
@@ -1,28 +1,30 @@
 import { readFileSync } from 'node:fs';
 import type { AsyncCompilers, SyncCompilers } from '../compilers/types.ts';
-import { FOREIGN_FILE_EXTENSIONS } from '../constants.ts';
 import { debugLog } from '../util/debug.ts';
 import { extname, isInternal } from '../util/path.ts';
 
 interface SourceFileManagerOptions {
   compilers: [SyncCompilers, AsyncCompilers];
+  foreignFileExtensions: string[];
 }
 
 export class SourceFileManager {
   sourceTextCache = new Map<string, string>();
   syncCompilers: SyncCompilers;
   asyncCompilers: AsyncCompilers;
+  foreignFileExtensions: Set<string>;
 
-  constructor({ compilers }: SourceFileManagerOptions) {
+  constructor({ compilers, foreignFileExtensions }: SourceFileManagerOptions) {
     this.syncCompilers = compilers[0];
     this.asyncCompilers = compilers[1];
+    this.foreignFileExtensions = new Set(foreignFileExtensions);
   }
 
   readFile(filePath: string): string {
     if (this.sourceTextCache.has(filePath)) return this.sourceTextCache.get(filePath)!;
     const ext = extname(filePath);
     const compiler = this.syncCompilers.get(ext);
-    if (FOREIGN_FILE_EXTENSIONS.has(ext) && !compiler) {
+    if (this.foreignFileExtensions.has(ext) && !compiler) {
       this.sourceTextCache.set(filePath, '');
       return '';
     }

--- a/packages/knip/test/foreign-file-extensions.test.ts
+++ b/packages/knip/test/foreign-file-extensions.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../src/index.ts';
+import baseCounters from './helpers/baseCounters.ts';
+import { createOptions } from './helpers/create-options.ts';
+import { resolve } from './helpers/resolve.ts';
+
+const cwd = resolve('fixtures/foreign-file-extensions');
+const cwdDefault = resolve('fixtures/foreign-file-extensions-default');
+
+test('Respect custom foreignFileExtensions configuration', async () => {
+  // Test fixture has custom foreignFileExtensions: ['.xyz', '.custom', '.css']
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  // Files with extensions NOT in custom foreignFileExtensions should appear as unresolved (when they don't exist)
+  assert(issues.unresolved['index.ts']['./unknown.unknown']);
+  assert(issues.unresolved['index.ts']['./missing-file']);
+
+  // These should NOT be in unresolved (they're in custom foreignFileExtensions)
+  assert(!issues.unresolved?.['index.ts']?.['./style.css']);
+  assert(!issues.unresolved?.['index.ts']?.['./icon.xyz']);
+  assert(!issues.unresolved?.['index.ts']?.['./data.custom']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    unresolved: 2,
+    processed: 2,  // knip.ts and index.ts
+    total: 2,      // Only TypeScript files are included in project files
+  });
+});
+
+test('Use default foreignFileExtensions when not configured', async () => {
+  // Test fixture has no knip configuration, so uses default foreignFileExtensions
+  const options = await createOptions({ cwd: cwdDefault });
+  const { issues, counters } = await main(options);
+
+  // Files with extensions NOT in default foreignFileExtensions should appear as unresolved (when they don't exist)
+  assert(issues.unresolved['index.ts']['./custom.xyz']);
+  assert(issues.unresolved['index.ts']['./missing-file']);
+
+  // These should NOT be in unresolved (they're in default foreignFileExtensions)
+  assert(!issues.unresolved?.['index.ts']?.['./style.css']);
+  assert(!issues.unresolved?.['index.ts']?.['./image.png']);
+  assert(!issues.unresolved?.['index.ts']?.['./data.yaml']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    unresolved: 2,
+    processed: 1,  // Only index.ts (no knip.ts in default fixture)
+    total: 1,
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a new configuration option `foreignFileExtensions` that allows users to customize which file extensions should be treated as foreign files (non-source files that don't trigger unresolved import warnings).

## Problem

Previously, the list of foreign file extensions was hardcoded in `FOREIGN_FILE_EXTENSIONS` constant. Users couldn't customize this list for their specific project needs.

## Solution

- Added `foreignFileExtensions` configuration field to the schema with proper Zod validation
- Updated TypeScript types to include the new configuration option
- Modified `ConfigurationChief` to handle the new option with sensible defaults
- Updated `graph/build.ts` and `SourceFileManager.ts` to use configurable extensions
- Maintained full backward compatibility - existing projects work unchanged

## Usage

Users can now configure foreign file extensions in their `knip.json`:

```json
{
  "foreignFileExtensions": [".css", ".scss", ".png", ".jpg", ".custom"]
}
```

## Testing

- Added comprehensive tests for both custom and default configurations
- Verified backward compatibility with existing behavior
- All existing tests continue to pass
- Manual testing confirms expected behavior

## Backward Compatibility

✅ Existing projects work without any changes
✅ Default behavior unchanged
✅ No breaking changes to existing APIs

The default includes the same extensions as before: `.avif`, `.css`, `.eot`, `.gif`, `.html`, `.ico`, `.jpeg`, `.jpg`, `.less`, `.mp3`, `.png`, `.sass`, `.scss`, `.sh`, `.svg`, `.ttf`, `.webp`, `.woff`, `.woff2`, `.yaml`, `.yml`