### PR TITLE
docs: fix broken anchor link in DEVELOPMENT.md

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -197,7 +197,7 @@ regular package. Every push is published to their registry. Look for the
 `pkg-pr-new` bot in your pull request.
 
 [1]: #qa
-[2]: #attach-debugger-to-bun-from-a-test
+[2]: #attach-debugger-from-inside-a-test-file
 [3]: #getting-started
 [4]: #agents
 [5]: #contributing-a-plugin


### PR DESCRIPTION
Hi there! 👋

While reading through the DEVELOPMENT.md guide (great docs btw!), I noticed that link [2] points to a section that doesn't exist. The anchor l seems to be a leftover from a previous heading.

I updated it to match the current section title: l.

As mentioned in #1665, this might be a good candidate for some automated markdown linting in the future — happy to help explore that if there's interest. 😊

Fixes #1665

---

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] This is a documentation-only change