### PR TITLE
Add a plugin for react-email

### DIFF
--- a/packages/knip/fixtures/plugins/react-email/build-dir/newsletter.tsx
+++ b/packages/knip/fixtures/plugins/react-email/build-dir/newsletter.tsx
@@ -1,0 +1,4 @@
+import { Html } from '@react-email/components';
+
+export const Newsletter = Html;
+export default Newsletter;

--- a/packages/knip/fixtures/plugins/react-email/dev-dir/welcome.tsx
+++ b/packages/knip/fixtures/plugins/react-email/dev-dir/welcome.tsx
@@ -1,0 +1,2 @@
+export const Welcome = () => 'Welcome!';
+export default Welcome;

--- a/packages/knip/fixtures/plugins/react-email/export-dir/invoice.tsx
+++ b/packages/knip/fixtures/plugins/react-email/export-dir/invoice.tsx
@@ -1,0 +1,2 @@
+export const Invoice = () => 'Invoice';
+export default Invoice;

--- a/packages/knip/fixtures/plugins/react-email/node_modules/react-email/package.json
+++ b/packages/knip/fixtures/plugins/react-email/node_modules/react-email/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "react-email",
+  "bin": {
+    "email": "./index.js"
+  }
+}

--- a/packages/knip/fixtures/plugins/react-email/package.json
+++ b/packages/knip/fixtures/plugins/react-email/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@plugins/react-email",
+  "dependencies": {
+    "@react-email/components": "^1.0.12"
+  },
+  "devDependencies": {
+    "react-email": "^4.0.0",
+    "@react-email/preview-server": "^5.2.10"
+  },
+  "scripts": {
+    "build": "email build --dir ./build-dir",
+    "dev": "email dev --dir ./dev-dir",
+    "export": "email export --dir ./export-dir",
+    "start": "email start --dir ./start-dir"
+  }
+}

--- a/packages/knip/fixtures/plugins/react-email/start-dir/receipt.tsx
+++ b/packages/knip/fixtures/plugins/react-email/start-dir/receipt.tsx
@@ -1,0 +1,2 @@
+export const Receipt = () => 'Receipt';
+export default Receipt;

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -680,6 +680,10 @@
           "title": "react-cosmos plugin configuration (https://knip.dev/reference/plugins/react-cosmos)",
           "$ref": "#/definitions/plugin"
         },
+        "react-email": {
+          "title": "react-email plugin configuration (https://knip.dev/reference/plugins/react-email)",
+          "$ref": "#/definitions/plugin"
+        },
         "react-native": {
           "title": "react-native plugin configuration (https://knip.dev/reference/plugins/react-native)",
           "$ref": "#/definitions/plugin"

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -87,6 +87,7 @@ import { default as prisma } from './prisma/index.ts';
 import { default as qwik } from './qwik/index.ts';
 import { default as raycast } from './raycast/index.ts';
 import { default as reactCosmos } from './react-cosmos/index.ts';
+import { default as reactEmail } from './react-email/index.ts';
 import { default as reactNative } from './react-native/index.ts';
 import { default as reactRouter } from './react-router/index.ts';
 import { default as relay } from './relay/index.ts';
@@ -232,6 +233,7 @@ export const Plugins = {
   qwik,
   raycast,
   'react-cosmos': reactCosmos,
+  'react-email': reactEmail,
   'react-native': reactNative,
   'react-router': reactRouter,
   relay,

--- a/packages/knip/src/plugins/react-email/index.ts
+++ b/packages/knip/src/plugins/react-email/index.ts
@@ -1,5 +1,5 @@
-import parseArgs from 'minimist';
-import type { IsPluginEnabled, Plugin, Resolve } from '../../types/config.ts';
+import type { Args } from '../../types/args.ts';
+import type { IsPluginEnabled, Plugin } from '../../types/config.ts';
 import { toDependency, toEntry } from '../../util/input.ts';
 import { hasDependency } from '../../util/plugin.ts';
 
@@ -12,49 +12,27 @@ const enablers = ['react-email'];
 const isEnabled: IsPluginEnabled = ({ dependencies }) =>
   hasDependency(dependencies, enablers);
 
-const scriptPattern = /^email (build|dev|export|start)/;
+const entry = ['emails/**/*.tsx'];
 
-const resolve: Resolve = ({ rootManifest, manifest }) => {
-  const scripts = { ...rootManifest?.scripts, ...manifest.scripts };
-  const inputs = [];
-  let hasPreviewScript = false;
-  const dirs = new Set<string>();
+const previewCommands = new Set(['build', 'dev', 'start']);
 
-  for (const key in scripts) {
-    const script = scripts[key];
-
-    const matches = scriptPattern.exec(script);
-    if (!matches) continue;
-
-    if (!hasPreviewScript && matches[1] !== 'export') {
+const args: Args = {
+  binaries: ['email'],
+  resolveInputs: parsed => {
+    const inputs = [];
+    if (previewCommands.has(parsed._[0]))
       inputs.push(toDependency('@react-email/preview-server'));
-      hasPreviewScript = true;
-    }
-
-    const parsed = parseArgs(script.split(' '), { string: ['dir'] });
-    if (typeof parsed.dir !== 'string') continue;
-
-    const dir = parsed.dir.replace(/^\.\//, '');
-    if (dirs.has(dir)) continue;
-
-    dirs.add(dir);
-    inputs.push(toEntry(`${dir}/**/*.tsx`));
-  }
-
-  if (dirs.size === 0) inputs.push(toEntry('emails/**/*.tsx'));
-
-  return inputs;
+    if (parsed.dir) inputs.push(toEntry(`${parsed.dir}/**/*.tsx`));
+    return inputs;
+  },
 };
 
 const plugin: Plugin = {
   title,
   enablers,
   isEnabled,
-  resolve,
+  entry,
+  args,
 };
 
 export default plugin;
-
-export const docs = {
-  note: 'Email templates that re-export a component as both a named and default export will trigger a `duplicates` issue. Add a [`@alias` JSDoc tag][1] to the default export to suppress it, or set `ignoreIssues` for the emails directory in your knip config.\n\n[1]: /reference/jsdoc-tsdoc-tags#alias',
-};

--- a/packages/knip/src/plugins/react-email/index.ts
+++ b/packages/knip/src/plugins/react-email/index.ts
@@ -1,0 +1,60 @@
+import parseArgs from 'minimist';
+import type { IsPluginEnabled, Plugin, Resolve } from '../../types/config.ts';
+import { toDependency, toEntry } from '../../util/input.ts';
+import { hasDependency } from '../../util/plugin.ts';
+
+// https://react.email/docs/cli
+
+const title = 'React Email';
+
+const enablers = ['react-email'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) =>
+  hasDependency(dependencies, enablers);
+
+const scriptPattern = /^email (build|dev|export|start)/;
+
+const resolve: Resolve = ({ rootManifest, manifest }) => {
+  const scripts = { ...rootManifest?.scripts, ...manifest.scripts };
+  const inputs = [];
+  let hasPreviewScript = false;
+  const dirs = new Set<string>();
+
+  for (const key in scripts) {
+    const script = scripts[key];
+
+    const matches = scriptPattern.exec(script);
+    if (!matches) continue;
+
+    if (!hasPreviewScript && matches[1] !== 'export') {
+      inputs.push(toDependency('@react-email/preview-server'));
+      hasPreviewScript = true;
+    }
+
+    const parsed = parseArgs(script.split(' '), { string: ['dir'] });
+    if (typeof parsed.dir !== 'string') continue;
+
+    const dir = parsed.dir.replace(/^\.\//, '');
+    if (dirs.has(dir)) continue;
+
+    dirs.add(dir);
+    inputs.push(toEntry(`${dir}/**/*.tsx`));
+  }
+
+  if (dirs.size === 0) inputs.push(toEntry('emails/**/*.tsx'));
+
+  return inputs;
+};
+
+const plugin: Plugin = {
+  title,
+  enablers,
+  isEnabled,
+  resolve,
+};
+
+export default plugin;
+
+export const docs = {
+  note: 'Email templates that re-export a component as both a named and default export will trigger a `duplicates` issue. Add a [`@alias` JSDoc tag][1] to the default export to suppress it, or set `ignoreIssues` for the emails directory in your knip config.\n\n[1]: /reference/jsdoc-tsdoc-tags#alias',
+};

--- a/packages/knip/src/schema/plugins.ts
+++ b/packages/knip/src/schema/plugins.ts
@@ -101,6 +101,7 @@ export const pluginsSchema = z.object({
   qwik: pluginSchema,
   raycast: pluginSchema,
   'react-cosmos': pluginSchema,
+  'react-email': pluginSchema,
   'react-native': pluginSchema,
   'react-router': pluginSchema,
   relay: pluginSchema,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -88,6 +88,7 @@ export type PluginName =
   | 'qwik'
   | 'raycast'
   | 'react-cosmos'
+  | 'react-email'
   | 'react-native'
   | 'react-router'
   | 'relay'
@@ -233,6 +234,7 @@ export const pluginNames = [
   'qwik',
   'raycast',
   'react-cosmos',
+  'react-email',
   'react-native',
   'react-router',
   'relay',

--- a/packages/knip/test/plugins/react-email.test.ts
+++ b/packages/knip/test/plugins/react-email.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/react-email');
+
+test('Find dependencies with the react-email plugin', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 4,
+    total: 4,
+  });
+});


### PR DESCRIPTION
Adding a plugin to support [`react-email`](https://react.email/docs/introduction).
