### PR TITLE
Add args to Prettier plugin to resolve --config CLI flag

### DIFF
--- a/packages/knip/fixtures/plugins/prettier-args/my-prettier-settings.js
+++ b/packages/knip/fixtures/plugins/prettier-args/my-prettier-settings.js
@@ -1,0 +1,3 @@
+export default {
+  plugins: ['my-custom-prettier-plugin'],
+};

--- a/packages/knip/fixtures/plugins/prettier-args/package.json
+++ b/packages/knip/fixtures/plugins/prettier-args/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "prettier-args-fixture",
+  "devDependencies": {
+    "prettier": "*"
+  },
+  "scripts": {
+    "format": "prettier --write --config=my-prettier-settings.js ."
+  }
+}

--- a/packages/knip/src/plugins/prettier/index.ts
+++ b/packages/knip/src/plugins/prettier/index.ts
@@ -1,3 +1,4 @@
+import type { Args } from '../../types/args.ts';
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
 import { toDeferResolve, toDependency } from '../../util/input.ts';
 import { hasDependency } from '../../util/plugin.ts';
@@ -27,6 +28,10 @@ const resolveConfig: ResolveConfig<PrettierConfig> = config => {
     : [];
 };
 
+const args: Args = {
+  config: true,
+};
+
 const isFilterTransitiveDependencies = true;
 
 const plugin: Plugin = {
@@ -34,6 +39,7 @@ const plugin: Plugin = {
   enablers,
   isEnabled,
   config,
+  args,
   resolveConfig,
   isFilterTransitiveDependencies,
 };

--- a/packages/knip/test/plugins/prettier.test.ts
+++ b/packages/knip/test/plugins/prettier.test.ts
@@ -25,6 +25,14 @@ test('Find dependencies with the Prettier plugin', async () => {
   });
 });
 
+test('Find dependencies with the Prettier plugin (--config arg)', async () => {
+  const cwd = resolve('fixtures/plugins/prettier-args');
+  const options = await createOptions({ cwd });
+  const { issues } = await main(options);
+
+  assert(issues.unlisted['my-prettier-settings.js']['my-custom-prettier-plugin']);
+});
+
 test('Find dependencies with the Prettier plugin (.json5 config)', async () => {
   const cwd = resolve('fixtures/plugins/prettier-json5');
   const options = await createOptions({ cwd });

--- a/packages/knip/test/util/get-inputs-from-scripts.test.ts
+++ b/packages/knip/test/util/get-inputs-from-scripts.test.ts
@@ -330,6 +330,7 @@ test('getInputsFromScripts (plugins → double-dash)', () => {
 test('getInputsFromScripts (plugins → config)', () => {
   t('tsc -p tsconfig.app.json', [toBinary('tsc'), toConfig('typescript', 'tsconfig.app.json')]);
   t('tsup -c tsup.server.json', [toBinary('tsup'), toConfig('tsup', 'tsup.server.json')]);
+  t('prettier --write --config=my-prettier-settings.js', [toBinary('prettier'), toConfig('prettier', 'my-prettier-settings.js')]);
 });
 
 test('getInputsFromScripts (find -exec)', () => {


### PR DESCRIPTION
> [!NOTE]
> This is pretty much straight from Claude, albeit with lots of babysitting and verification. Please let me know if this is not acceptable. -- @xaqrox 

## Summary

- Adds `args: { config: true }` to the Prettier plugin so files referenced via `prettier --config=<path>` in scripts are tracked as config inputs
- Without this, the `--config` flag fell through to `fallbackResolve` and the referenced file was never tracked
- Follows the same pattern as the ESLint plugin

## What changed

- `packages/knip/src/plugins/prettier/index.ts` — add `args: { config: true }`
- `packages/knip/test/util/get-inputs-from-scripts.test.ts` — add script-parsing unit test for `prettier --write --config=my-prettier-settings.js`
- `packages/knip/fixtures/plugins/prettier-args/` — new fixture with a script referencing a custom config
- `packages/knip/test/plugins/prettier.test.ts` — new test block asserting the plugin referenced inside the custom config is reported as unlisted

## Verification

Both tests confirmed to fail before the fix and pass after:

```
bun test test/util/get-inputs-from-scripts.test.ts test/plugins/prettier.test.ts
# 32 pass, 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)