### PR TITLE
Update react-email plugin for react-email@6

### DIFF
--- a/packages/knip/fixtures/plugins/react-email-v6/dev-dir/welcome.tsx
+++ b/packages/knip/fixtures/plugins/react-email-v6/dev-dir/welcome.tsx
@@ -1,0 +1,2 @@
+export const Welcome = () => 'Welcome!';
+export default Welcome;

--- a/packages/knip/fixtures/plugins/react-email-v6/node_modules/react-email/package.json
+++ b/packages/knip/fixtures/plugins/react-email-v6/node_modules/react-email/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "react-email",
+  "bin": {
+    "email": "./index.js"
+  }
+}

--- a/packages/knip/fixtures/plugins/react-email-v6/package.json
+++ b/packages/knip/fixtures/plugins/react-email-v6/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@plugins/react-email-v6",
+  "dependencies": {
+    "react-email": "^6.0.0"
+  },
+  "devDependencies": {
+    "@react-email/ui": "^6.0.0"
+  },
+  "scripts": {
+    "dev": "email dev --dir ./dev-dir"
+  }
+}

--- a/packages/knip/src/plugins/react-email/index.ts
+++ b/packages/knip/src/plugins/react-email/index.ts
@@ -1,6 +1,9 @@
+import { readFileSync } from 'node:fs';
 import type { Args } from '../../types/args.ts';
 import type { IsPluginEnabled, Plugin } from '../../types/config.ts';
+import type { PackageJson } from '../../types/package-json.ts';
 import { toDependency, toEntry } from '../../util/input.ts';
+import { join } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
 
 // https://react.email/docs/cli
@@ -15,11 +18,21 @@ const entry = ['emails/**/*.tsx'];
 
 const previewCommands = new Set(['build', 'dev', 'start']);
 
+const getPreviewDependency = (cwd: string): string => {
+  try {
+    const manifest: PackageJson = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8'));
+    const range = manifest.dependencies?.['react-email'] ?? manifest.devDependencies?.['react-email'];
+    const major = range?.match(/\d+/)?.[0];
+    if (major && Number.parseInt(major, 10) >= 6) return '@react-email/ui';
+  } catch {}
+  return '@react-email/preview-server';
+};
+
 const args: Args = {
   binaries: ['email'],
-  resolveInputs: parsed => {
+  resolveInputs: (parsed, { cwd }) => {
     const inputs = [];
-    if (previewCommands.has(parsed._[0])) inputs.push(toDependency('@react-email/preview-server'));
+    if (previewCommands.has(parsed._[0])) inputs.push(toDependency(getPreviewDependency(cwd)));
     if (parsed.dir) inputs.push(toEntry(`${parsed.dir}/**/*.tsx`));
     return inputs;
   },

--- a/packages/knip/test/plugins/react-email.test.ts
+++ b/packages/knip/test/plugins/react-email.test.ts
@@ -17,3 +17,14 @@ test('Find dependencies with the react-email plugin', async () => {
     total: 4,
   });
 });
+
+test('Find dependencies with the react-email plugin (v6)', async () => {
+  const options = await createOptions({ cwd: resolve('fixtures/plugins/react-email-v6') });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
After [react-email@6 release](https://react.email/docs/changelog#april-16-2026), the `@react-email/preview-server` dependency that react-email knip plugin explicitly references has been renamed to `@react-email/ui`. 

This PR updates the react-email plugin to take into consideration the version of react-email installed and based on that return the `preview-server` or `ui` dependency.

A separate fixture for react-email-v6 has been added which contains dependencies in line with version 6.

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
