### PR TITLE
fix(rslib): resolve entry points from rslib config

### DIFF
--- a/packages/knip/fixtures/plugins/rslib/rslib.config.ts
+++ b/packages/knip/fixtures/plugins/rslib/rslib.config.ts
@@ -1,3 +1,10 @@
 import { defineConfig } from '@rslib/core';
 
-export default defineConfig({});
+export default defineConfig({
+  source: {
+    entry: {
+      index: './src/index.ts',
+      browser: './src/browser.ts',
+    },
+  },
+});

--- a/packages/knip/fixtures/plugins/rslib/src/browser.ts
+++ b/packages/knip/fixtures/plugins/rslib/src/browser.ts
@@ -1,0 +1,1 @@
+export const browserValue = 1;

--- a/packages/knip/fixtures/plugins/rslib/src/index.ts
+++ b/packages/knip/fixtures/plugins/rslib/src/index.ts
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/packages/knip/fixtures/plugins/rslib2/package.json
+++ b/packages/knip/fixtures/plugins/rslib2/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@plugins/rslib2",
+  "devDependencies": {
+    "@rslib/core": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/rslib2/rslib.config.ts
+++ b/packages/knip/fixtures/plugins/rslib2/rslib.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig([
+  {
+    source: {
+      entry: { index: './src/index.ts' },
+    },
+    format: 'esm',
+  },
+  {
+    source: {
+      entry: { index: './src/index.ts' },
+    },
+    format: 'cjs',
+  },
+]);

--- a/packages/knip/fixtures/plugins/rslib2/src/index.ts
+++ b/packages/knip/fixtures/plugins/rslib2/src/index.ts
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/packages/knip/src/plugins/rslib/index.ts
+++ b/packages/knip/src/plugins/rslib/index.ts
@@ -1,6 +1,7 @@
-import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
+import type { IsPluginEnabled, Plugin, ResolveFromAST } from '../../types/config.ts';
+import { toProductionEntry } from '../../util/input.ts';
 import { hasDependency } from '../../util/plugin.ts';
-import type { RslibConfig } from './types.ts';
+import { getEntryFromAST } from './resolveFromAST.ts';
 
 // https://rslib.rs/guide/basic/configure-rslib
 
@@ -10,18 +11,19 @@ const enablers = ['@rslib/core'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const entry = ['rslib*.config.{mjs,ts,js,cjs,mts,cts}'];
+const config = ['rslib*.config.{mjs,ts,js,cjs,mts,cts}'];
 
-const resolveConfig: ResolveConfig<RslibConfig> = () => {
-  return [];
+const resolveFromAST: ResolveFromAST = program => {
+  const entries = getEntryFromAST(program);
+  return [...entries].map(id => toProductionEntry(id, { allowIncludeExports: true }));
 };
 
 const plugin: Plugin = {
   title,
   enablers,
   isEnabled,
-  entry,
-  resolveConfig,
+  config,
+  resolveFromAST,
 };
 
 export default plugin;

--- a/packages/knip/src/plugins/rslib/resolveFromAST.ts
+++ b/packages/knip/src/plugins/rslib/resolveFromAST.ts
@@ -1,0 +1,6 @@
+import type { Program } from 'oxc-parser';
+import { collectPropertyValues } from '../../typescript/ast-helpers.ts';
+
+export const getEntryFromAST = (program: Program): Set<string> => {
+  return collectPropertyValues(program, 'entry');
+};

--- a/packages/knip/src/plugins/rslib/types.ts
+++ b/packages/knip/src/plugins/rslib/types.ts
@@ -1,2 +1,0 @@
-// oxlint-disable-next-line @typescript-eslint/no-empty-object-type
-export type RslibConfig = {};

--- a/packages/knip/test/plugins/rslib.test.ts
+++ b/packages/knip/test/plugins/rslib.test.ts
@@ -8,12 +8,23 @@ import { resolve } from '../helpers/resolve.ts';
 const cwd = resolve('fixtures/plugins/rslib');
 
 test('Find dependencies with the rslib plugin', async () => {
-  const options = await createOptions({ cwd, isStrict: true });
+  const options = await createOptions({ cwd });
   const { counters } = await main(options);
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 0,
-    total: 0,
+    processed: 3,
+    total: 3,
+  });
+});
+
+test('rslib plugin handles array config form', async () => {
+  const options = await createOptions({ cwd: resolve('fixtures/plugins/rslib2') });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
   });
 });


### PR DESCRIPTION
## The problem

The rslib plugin was a stub — `resolveConfig` always returned `[]` and the config glob was listed under `entry` (treating `rslib.config.ts` as a source entry itself) instead of `config` (a file to parse for entries). This meant knip never extracted source entry points from `rslib.config.ts`, so all source files in rslib-based packages were reported as unused files.

## The fix

Mirrors the rolldown and tsdown plugins:

- Change `entry` key to `config` so knip parses the file rather than treating it as a source entry
- Add `resolveFromAST` using `collectPropertyValues(program, 'entry')`, which walks the full AST and handles both the object-map form (`source.entry: { index: './src/index.ts' }`) and the array `defineConfig([...])` form

## Testing

Two new tests and an expanded fixture:
- Single config with multiple named entries (`source.entry: { index, browser }`)
- Array config form (`defineConfig([...])`) — verifies deduplication when two lib configs share an entry

Tested against a real monorepo (12 rslib packages): reduced false-positive "unused files" reports from 72 to 25.

All 256 plugin tests pass.
