### PR TITLE
Ensure output is flushed on exit

### DIFF
--- a/packages/knip/src/cli.ts
+++ b/packages/knip/src/cli.ts
@@ -104,7 +104,8 @@ const main = async () => {
       (!args['no-exit-code'] && totalErrorCount > Number(args['max-issues'] ?? 0)) ||
       (!options.isDisableConfigHints && options.isTreatConfigHintsAsErrors && configurationHints.length > 0)
     ) {
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   } catch (error: unknown) {
     process.exitCode = 2;
@@ -119,13 +120,14 @@ const main = async () => {
           console.log('Configuration file load error? Visit https://knip.dev/reference/known-issues');
       }
       if (isConfigurationError(knownErrors[0])) console.log('\nRun `knip --help` or visit https://knip.dev for help');
-      process.exit(2);
+      process.exitCode = 2;
+      return;
     }
     // We shouldn't arrive here, but not swallow either, so re-throw
     throw error;
   }
 
-  process.exit(0);
+  process.exitCode = 0;
 };
 
 await main();


### PR DESCRIPTION
The use of `process.exit` means that the Node.js runtime may immediately exit, without waiting for asynchronous `process.stdout.write` calls to finish. I noticed that, if I ran Knip and piped its output through `grep` or `less`, the output got truncated.

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
