### PR TITLE
Handle Vitest agent and minimal reporters

### DIFF
--- a/packages/knip/fixtures/plugins/vitest3/vitest.config.ts
+++ b/packages/knip/fixtures/plugins/vitest3/vitest.config.ts
@@ -12,7 +12,9 @@ export default defineConfig(configEnv =>
         setupFiles: ['./src/setupTests.tsx'],
         reporters: [
           'basic',
+          'agent',
           'verbose',
+          'minimal',
           'dot',
           'junit',
           'json',

--- a/packages/knip/src/plugins/vitest/helpers.ts
+++ b/packages/knip/src/plugins/vitest/helpers.ts
@@ -30,8 +30,9 @@ export const getEnvSpecifier = (env: string) => {
 
 // See full list here:
 // https://github.com/vitest-dev/vitest/blob/v3.2.4/packages/vitest/src/node/reporters/index.ts#L46-L58
-// https://github.com/vitest-dev/vitest/blob/v4.0.3/packages/vitest/src/node/reporters/index.ts#L47-L59
+// https://github.com/vitest-dev/vitest/blob/v4.1.5/packages/vitest/src/node/reporters/index.ts#L50-L64
 const builtInReporters = [
+  'agent',
   'basic',
   'blob',
   'default',
@@ -41,6 +42,7 @@ const builtInReporters = [
   'html',
   'json',
   'junit',
+  'minimal',
   'tap',
   'tap-flat',
   'tree',


### PR DESCRIPTION
Adds `agent` and `minimal` to the Vitest plugin built-in reporter list so Knip does not treat those reporter names as external package dependencies.

The reporter source link is updated to Vitest v4.1.5, where both names are present in the built-in reporter map.

QA run locally from `packages/knip`:

- `bun test test/plugins/vitest3.test.ts test/plugins/vitest.test.ts`
- `pnpm test --runtime bun --smoke`
- `pnpm fmt`
- `pnpm lint`
- `pnpm build`
- `pnpm knip`
- `pnpm knip:production`
- `git diff --check`