### PR TITLE
fix: use SHA256 instead of MD5 for CodeClimate fingerprints

### DIFF
--- a/packages/knip/src/reporters/codeclimate.ts
+++ b/packages/knip/src/reporters/codeclimate.ts
@@ -105,10 +105,10 @@ function createLocation(filePath: string, cwd: string, line?: number, col?: numb
 }
 
 function createFingerprint(filePath: string, cwd: string, message: string): string {
-  const md5 = createHash('md5');
+  const hash = createHash('sha256');
 
-  md5.update(toRelative(filePath, cwd));
-  md5.update(message);
+  hash.update(toRelative(filePath, cwd));
+  hash.update(message);
 
-  return md5.digest('hex');
+  return hash.digest('hex');
 }


### PR DESCRIPTION
## Summary

- Replace MD5 with SHA256 for fingerprint generation in CodeClimate reporter
- Avoids security scanner false positives for cryptographically broken hash

## Context

MD5 is flagged by security scanners even when not used for cryptographic purposes. SHA256 eliminates this friction for organizations with compliance requirements.

**Note:** Fingerprints will change, causing one-time duplicate issue reports during transition.

Resolves #1688

## Test plan

- [x] Verified output produces valid 64-char hex fingerprints
- [x] No breaking changes to CodeClimate JSON structure