### PR TITLE
feat: add WXT plugin

### DIFF
--- a/packages/knip/fixtures/plugins/wxt/entrypoints/background.ts
+++ b/packages/knip/fixtures/plugins/wxt/entrypoints/background.ts
@@ -1,0 +1,3 @@
+export default defineBackground(() => {
+  console.log('Background script started');
+});

--- a/packages/knip/fixtures/plugins/wxt/node_modules/wxt/index.js
+++ b/packages/knip/fixtures/plugins/wxt/node_modules/wxt/index.js
@@ -1,0 +1,1 @@
+export const defineConfig = c => c;

--- a/packages/knip/fixtures/plugins/wxt/node_modules/wxt/package.json
+++ b/packages/knip/fixtures/plugins/wxt/node_modules/wxt/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "wxt",
+  "main": "index.js"
+}

--- a/packages/knip/fixtures/plugins/wxt/package.json
+++ b/packages/knip/fixtures/plugins/wxt/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@plugins/wxt",
+  "dependencies": {
+    "wxt": "*",
+    "@wxt-dev/module-react": "*",
+    "wxt-module-console-forward": "*",
+    "unused-module": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/wxt/tsconfig.json
+++ b/packages/knip/fixtures/plugins/wxt/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/packages/knip/fixtures/plugins/wxt/wxt.config.ts
+++ b/packages/knip/fixtures/plugins/wxt/wxt.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'wxt';
+
+export default defineConfig({
+  modules: ['@wxt-dev/module-react', 'wxt-module-console-forward'],
+});

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -143,6 +143,7 @@ import { default as webdriverIo } from './webdriver-io/index.ts';
 import { default as webpack } from './webpack/index.ts';
 import { default as wireit } from './wireit/index.ts';
 import { default as wrangler } from './wrangler/index.ts';
+import { default as wxt } from './wxt/index.ts';
 import { default as xo } from './xo/index.ts';
 import { default as yarn } from './yarn/index.ts';
 import { default as yorkie } from './yorkie/index.ts';
@@ -293,6 +294,7 @@ export const Plugins = {
   webpack,
   wireit,
   wrangler,
+  wxt,
   xo,
   yarn,
   yorkie,

--- a/packages/knip/src/plugins/wxt/index.ts
+++ b/packages/knip/src/plugins/wxt/index.ts
@@ -1,0 +1,53 @@
+import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
+import type { Input } from '../../util/input.ts';
+import { toDependency, toProductionEntry } from '../../util/input.ts';
+import { hasDependency } from '../../util/plugin.ts';
+import type { WxtConfig } from './types.ts';
+
+// https://wxt.dev/guide/essentials/config.html
+
+const title = 'WXT';
+
+const enablers = ['wxt'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+
+const config = ['wxt.config.{js,mjs,ts}'];
+
+const production = ['entrypoints/**/*'];
+
+const setup = async () => {
+  if (globalThis && !('defineConfig' in globalThis)) {
+    Object.defineProperty(globalThis, 'defineConfig', {
+      value: (id: unknown) => id,
+      writable: true,
+      configurable: true,
+    });
+  }
+};
+
+const resolveConfig: ResolveConfig<WxtConfig> = async localConfig => {
+  const inputs: Input[] = [];
+
+  for (const pattern of production) {
+    inputs.push(toProductionEntry(pattern));
+  }
+
+  for (const id of localConfig?.modules ?? []) {
+    if (typeof id === 'string') inputs.push(toDependency(id));
+  }
+
+  return inputs;
+};
+
+const plugin: Plugin = {
+  title,
+  enablers,
+  isEnabled,
+  config,
+  production,
+  setup,
+  resolveConfig,
+};
+
+export default plugin;

--- a/packages/knip/src/plugins/wxt/index.ts
+++ b/packages/knip/src/plugins/wxt/index.ts
@@ -4,7 +4,7 @@ import { toDependency, toProductionEntry } from '../../util/input.ts';
 import { hasDependency } from '../../util/plugin.ts';
 import type { WxtConfig } from './types.ts';
 
-// https://wxt.dev/guide/essentials/config.html
+// https://wxt.dev/guide/essentials/entrypoints.html
 
 const title = 'WXT';
 

--- a/packages/knip/src/plugins/wxt/index.ts
+++ b/packages/knip/src/plugins/wxt/index.ts
@@ -16,16 +16,6 @@ const config = ['wxt.config.{js,mjs,ts}'];
 
 const production = ['entrypoints/**/*'];
 
-const setup = async () => {
-  if (globalThis && !('defineConfig' in globalThis)) {
-    Object.defineProperty(globalThis, 'defineConfig', {
-      value: (id: unknown) => id,
-      writable: true,
-      configurable: true,
-    });
-  }
-};
-
 const resolveConfig: ResolveConfig<WxtConfig> = async localConfig => {
   const inputs: Input[] = [];
 
@@ -46,7 +36,6 @@ const plugin: Plugin = {
   isEnabled,
   config,
   production,
-  setup,
   resolveConfig,
 };
 

--- a/packages/knip/src/plugins/wxt/types.ts
+++ b/packages/knip/src/plugins/wxt/types.ts
@@ -1,0 +1,3 @@
+export interface WxtConfig {
+  modules?: string[];
+}

--- a/packages/knip/src/schema/plugins.ts
+++ b/packages/knip/src/schema/plugins.ts
@@ -157,6 +157,7 @@ export const pluginsSchema = z.object({
   webpack: pluginSchema,
   wireit: pluginSchema,
   wrangler: pluginSchema,
+  wxt: pluginSchema,
   xo: pluginSchema,
   yarn: pluginSchema,
   yorkie: pluginSchema,

--- a/packages/knip/src/types/PluginNames.ts
+++ b/packages/knip/src/types/PluginNames.ts
@@ -144,6 +144,7 @@ export type PluginName =
   | 'webpack'
   | 'wireit'
   | 'wrangler'
+  | 'wxt'
   | 'xo'
   | 'yarn'
   | 'yorkie'
@@ -294,6 +295,7 @@ export const pluginNames = [
   'webpack',
   'wireit',
   'wrangler',
+  'wxt',
   'xo',
   'yarn',
   'yorkie',

--- a/packages/knip/test/plugins/wxt.test.ts
+++ b/packages/knip/test/plugins/wxt.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/wxt');
+
+test('Find dependencies with the wxt plugin', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.dependencies['package.json']['unused-module']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    dependencies: 1,
+    processed: 2,
+    total: 2,
+  });
+});


### PR DESCRIPTION
## Summary

- Adds plugin for [WXT](https://wxt.dev/) (Web Extension Framework)
- Resolves `modules` array entries in `wxt.config.ts` as dependencies  
- Recognizes `entrypoints/**/*` as production entry files
- Prevents false positive "unused dependency" reports for WXT modules

## Context

Based on PR #1580 by @adelin-b, addressing @webpro's review feedback:
- Changed entry pattern to `entrypoints/**/*` to match all files (not just specific extensions)
- Replaced `reduce` with `for..of` for readability
- Fixed entry pattern processing by returning entries from `resolveConfig` (static `entry` array is skipped when plugin has `resolveConfig`)

## Test plan

- [x] Plugin test passes (`bun test test/plugins/wxt.test.ts`)
- [x] Correctly identifies unused dependencies not in `modules`
- [x] Does not flag modules listed in `wxt.config.ts` as unused
- [x] Entrypoint files are not flagged as unused