### PR TITLE
fix: type-only imports in monorepos

### DIFF
--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/knip.json
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/knip.json
@@ -1,0 +1,8 @@
+{
+  "workspaces": {
+    "packages/*": {
+      "entry": "index.ts!",
+      "project": "index.ts!"
+    }
+  }
+}

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/node_modules/@fixtures/workspaces-type-only-dev-dependencies__prod-types
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/node_modules/@fixtures/workspaces-type-only-dev-dependencies__prod-types
@@ -1,0 +1,1 @@
+../../packages/prod-types

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/node_modules/@fixtures/workspaces-type-only-dev-dependencies__runtime
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/node_modules/@fixtures/workspaces-type-only-dev-dependencies__runtime
@@ -1,0 +1,1 @@
+../../packages/runtime

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/node_modules/@fixtures/workspaces-type-only-dev-dependencies__types
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/node_modules/@fixtures/workspaces-type-only-dev-dependencies__types
@@ -1,0 +1,1 @@
+../../packages/types

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/package.json
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixtures/workspaces-type-only-dev-dependencies",
+  "private": true
+}

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/app/index.ts
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/app/index.ts
@@ -1,0 +1,6 @@
+import type { Fruit } from '@fixtures/workspaces-type-only-dev-dependencies__types';
+import { runtime } from '@fixtures/workspaces-type-only-dev-dependencies__runtime';
+
+export const fruit: Fruit = 'apple';
+
+runtime;

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/app/index.ts
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/app/index.ts
@@ -1,6 +1,8 @@
 import type { Fruit } from '@fixtures/workspaces-type-only-dev-dependencies__types';
+import type { Vegetable } from '@fixtures/workspaces-type-only-dev-dependencies__prod-types';
 import { runtime } from '@fixtures/workspaces-type-only-dev-dependencies__runtime';
 
 export const fruit: Fruit = 'apple';
+export const vegetable: Vegetable = 'carrot';
 
 runtime;

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/app/package.json
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixtures/workspaces-type-only-dev-dependencies__app",
+  "private": true,
+  "type": "module",
+  "exports": "./index.ts",
+  "devDependencies": {
+    "@fixtures/workspaces-type-only-dev-dependencies__runtime": "workspace:*",
+    "@fixtures/workspaces-type-only-dev-dependencies__types": "workspace:*"
+  }
+}

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/app/package.json
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/app/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "type": "module",
   "exports": "./index.ts",
+  "dependencies": {
+    "@fixtures/workspaces-type-only-dev-dependencies__prod-types": "workspace:*"
+  },
   "devDependencies": {
     "@fixtures/workspaces-type-only-dev-dependencies__runtime": "workspace:*",
     "@fixtures/workspaces-type-only-dev-dependencies__types": "workspace:*"

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/prod-types/index.ts
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/prod-types/index.ts
@@ -1,0 +1,1 @@
+export type Vegetable = 'carrot';

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/prod-types/package.json
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/prod-types/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/workspaces-type-only-dev-dependencies__prod-types",
+  "private": true,
+  "type": "module",
+  "exports": "./index.ts"
+}

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/runtime/index.ts
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/runtime/index.ts
@@ -1,0 +1,1 @@
+export const runtime = 1;

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/runtime/package.json
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/runtime/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/workspaces-type-only-dev-dependencies__runtime",
+  "private": true,
+  "type": "module",
+  "exports": "./index.ts"
+}

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/types/index.ts
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/types/index.ts
@@ -1,0 +1,1 @@
+export type Fruit = 'apple';

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/types/package.json
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/packages/types/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/workspaces-type-only-dev-dependencies__types",
+  "private": true,
+  "type": "module",
+  "exports": "./index.ts"
+}

--- a/packages/knip/fixtures/workspaces-type-only-dev-dependencies/pnpm-workspace.yaml
+++ b/packages/knip/fixtures/workspaces-type-only-dev-dependencies/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/packages/knip/src/DependencyDeputy.ts
+++ b/packages/knip/src/DependencyDeputy.ts
@@ -217,12 +217,13 @@ export class DependencyDeputy {
     if (packageName === workspace.pkgName) return true;
 
     const workspaceNames = this.isStrict ? [workspace.name] : [workspace.name, ...[...workspace.ancestors].reverse()];
-    const closestWorkspaceName = workspaceNames.find(name => this.isInDependencies(name, packageName, isDevOnly));
+    const isDevOrTypeOnly = isDevOnly || isTypeOnly;
+    const closestWorkspaceName = workspaceNames.find(name => this.isInDependencies(name, packageName, isDevOrTypeOnly));
 
     // Prevent false positives by also marking the `@types/packageName` dependency as referenced
     const typesPackageName = !isDefinitelyTyped(packageName) && getDefinitelyTypedFor(packageName);
     const closestWorkspaceNameForTypes =
-      typesPackageName && workspaceNames.find(name => this.isInDependencies(name, typesPackageName, isDevOnly));
+      typesPackageName && workspaceNames.find(name => this.isInDependencies(name, typesPackageName, isDevOrTypeOnly));
 
     if (closestWorkspaceNameForTypes && !this.hasTypesIncluded.get(closestWorkspaceNameForTypes)?.has(packageName))
       this.addReferencedDependency(closestWorkspaceNameForTypes, typesPackageName);

--- a/packages/knip/src/graph/build.ts
+++ b/packages/knip/src/graph/build.ts
@@ -432,6 +432,7 @@ export async function build({
         if (!_import.filePath) continue;
         const packageName = getPackageNameFromModuleSpecifier(_import.specifier);
         if (!packageName) continue;
+        if (analyzeOpts.skipTypeOnly && _import.isTypeOnly) continue;
         const isWorkspace = isInternalWorkspace(packageName);
         if (isWorkspace || wsDependencies.has(packageName)) {
           file.imports.external.add({ ..._import, specifier: packageName });

--- a/packages/knip/src/graph/build.ts
+++ b/packages/knip/src/graph/build.ts
@@ -432,7 +432,6 @@ export async function build({
         if (!_import.filePath) continue;
         const packageName = getPackageNameFromModuleSpecifier(_import.specifier);
         if (!packageName) continue;
-        if (analyzeOpts.skipTypeOnly && _import.isTypeOnly) continue;
         const isWorkspace = isInternalWorkspace(packageName);
         if (isWorkspace || wsDependencies.has(packageName)) {
           file.imports.external.add({ ..._import, specifier: packageName });

--- a/packages/knip/test/workspaces-type-only-dev-dependencies.test.ts
+++ b/packages/knip/test/workspaces-type-only-dev-dependencies.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../src/index.ts';
+import baseCounters from './helpers/baseCounters.ts';
+import { createOptions } from './helpers/create-options.ts';
+import { resolve } from './helpers/resolve.ts';
+
+const cwd = resolve('fixtures/workspaces-type-only-dev-dependencies');
+
+test('Type-only workspace devDependencies should not be considered unlisted in strict mode', async () => {
+  const options = await createOptions({ cwd, isStrict: true });
+  const { issues, counters } = await main(options);
+
+  assert(!issues.unlisted['packages/app/index.ts']?.['@fixtures/workspaces-type-only-dev-dependencies__types']);
+  assert(issues.unlisted['packages/app/index.ts']['@fixtures/workspaces-type-only-dev-dependencies__runtime']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    unlisted: 1,
+    processed: 3,
+    total: 3,
+  });
+});

--- a/packages/knip/test/workspaces-type-only-dev-dependencies.test.ts
+++ b/packages/knip/test/workspaces-type-only-dev-dependencies.test.ts
@@ -7,17 +7,44 @@ import { resolve } from './helpers/resolve.ts';
 
 const cwd = resolve('fixtures/workspaces-type-only-dev-dependencies');
 
+test('Type-only workspace dependencies are not flagged in default mode', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 4,
+    total: 4,
+  });
+});
+
+test('Type-only workspace dependencies are not flagged in production mode', async () => {
+  const options = await createOptions({ cwd, isProduction: true });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 4,
+    total: 4,
+  });
+});
+
 test('Type-only workspace devDependencies should not be considered unlisted in strict mode', async () => {
   const options = await createOptions({ cwd, isStrict: true });
   const { issues, counters } = await main(options);
 
   assert(!issues.unlisted['packages/app/index.ts']?.['@fixtures/workspaces-type-only-dev-dependencies__types']);
+  assert(!issues.unlisted['packages/app/index.ts']?.['@fixtures/workspaces-type-only-dev-dependencies__prod-types']);
   assert(issues.unlisted['packages/app/index.ts']['@fixtures/workspaces-type-only-dev-dependencies__runtime']);
+
+  assert(
+    !issues.dependencies['packages/app/package.json']?.['@fixtures/workspaces-type-only-dev-dependencies__prod-types']
+  );
 
   assert.deepEqual(counters, {
     ...baseCounters,
     unlisted: 1,
-    processed: 3,
-    total: 3,
+    processed: 4,
+    total: 4,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

In monorepos, Knip has begun to flag `type`-only `import`s as being unlisted. While I'm generally in favor of this change, Knip is clearly documented to have different behavior, so this patch should hopefully fix it.

Disclaimer: This patch was suggested by an LLM running in an agentic loop on the Flint repo. I typed the fix myself in hopes of convincing myself it was wrong, but from my limited reading of the code it seems reasonable. The repro was minimized from the Flint repository by an agent, and has been manually verified to be a) representive of the problem and b) fail previously & pass now.