### PR TITLE
Fix PostCSS detection for @tailwindcss/postcss

### DIFF
--- a/packages/knip/fixtures/plugins/postcss-tailwindcss3/node_modules/@tailwindcss/postcss/index.js
+++ b/packages/knip/fixtures/plugins/postcss-tailwindcss3/node_modules/@tailwindcss/postcss/index.js
@@ -1,0 +1,1 @@
+export default function tailwindcss() {}

--- a/packages/knip/fixtures/plugins/postcss-tailwindcss3/node_modules/@tailwindcss/postcss/package.json
+++ b/packages/knip/fixtures/plugins/postcss-tailwindcss3/node_modules/@tailwindcss/postcss/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@tailwindcss/postcss",
+  "type": "module",
+  "exports": "./index.js",
+  "dependencies": {
+    "postcss": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/postcss-tailwindcss3/package.json
+++ b/packages/knip/fixtures/plugins/postcss-tailwindcss3/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@plugins/postcss-tailwindcss3",
+  "devDependencies": {
+    "@tailwindcss/postcss": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/postcss-tailwindcss3/postcss.config.ts
+++ b/packages/knip/fixtures/plugins/postcss-tailwindcss3/postcss.config.ts
@@ -1,0 +1,5 @@
+import tailwindcss from '@tailwindcss/postcss';
+
+export default {
+  plugins: [tailwindcss],
+};

--- a/packages/knip/src/plugins/postcss/index.ts
+++ b/packages/knip/src/plugins/postcss/index.ts
@@ -9,7 +9,7 @@ import type { PostCSSConfig } from './types.ts';
 
 const title = 'PostCSS';
 
-const enablers = ['postcss', 'postcss-cli', 'next'];
+const enablers = ['postcss', 'postcss-cli', 'next', '@tailwindcss/postcss'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
@@ -30,10 +30,12 @@ const resolveConfig: ResolveConfig<PostCSSConfig> = config => {
 
   const inputs = plugins.map(id => toDeferResolve(id));
 
-  // Because postcss is not included in peerDependencies of tailwindcss
-  return ['tailwindcss', '@tailwindcss/postcss'].some(tailwindPlugin => plugins.includes(tailwindPlugin))
-    ? [...inputs, toDependency('postcss')]
-    : inputs;
+  if (plugins.includes('tailwindcss')) {
+    // Because postcss is not included in peerDependencies of tailwindcss
+    return [...inputs, toDependency('postcss')];
+  }
+
+  return plugins.includes('@tailwindcss/postcss') ? [...inputs, toDependency('postcss', { optional: true })] : inputs;
 };
 
 const plugin: Plugin = {

--- a/packages/knip/test/plugins/postcss-tailwindcss3.test.ts
+++ b/packages/knip/test/plugins/postcss-tailwindcss3.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/postcss-tailwindcss3');
+
+test('Find dependencies with the PostCSS plugin (with @tailwindcss/postcss enabler)', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(!issues.files['postcss.config.ts']);
+  assert(!issues.devDependencies['package.json']?.['@tailwindcss/postcss']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
Fixes #1718.

## Summary

- enable the PostCSS plugin when `@tailwindcss/postcss` is listed as a dependency
- keep direct `postcss` optional for the Tailwind v4 PostCSS plugin path, since `@tailwindcss/postcss` depends on `postcss` itself
- add a fixture covering `postcss.config.ts` with `@tailwindcss/postcss` and no direct `postcss` dependency

## Validation

- `pnpm exec oxfmt --check packages/knip/src/plugins/postcss/index.ts packages/knip/test/plugins/postcss-tailwindcss3.test.ts packages/knip/fixtures/plugins/postcss-tailwindcss3/postcss.config.ts`
- `pnpm --dir packages/knip lint`
- `pnpm --dir packages/knip build`
- `node --test packages/knip/test/plugins/postcss*.test.ts`
- `node packages/knip/src/cli.ts --directory ../postcss-config-ts-unused-repro-tailwind-v4`

`pnpm --dir packages/knip test` was also attempted. It reached the e2e/session portion and failed with an unrelated `knip --fix` timeout/empty-removal assertion plus Bun `node:test` nested-test errors after that.
