### PR TITLE
Fix Vercel config detection

### DIFF
--- a/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/package.json
+++ b/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "@plugins/vercel-workspaces-web"
+  "name": "@plugins/vercel-workspaces-web",
+  "devDependencies": {
+    "@vercel/config": "*"
+  }
 }

--- a/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/package.json
+++ b/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@plugins/vercel-workspaces-web"
+}

--- a/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/src/index.ts
+++ b/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/src/index.ts
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/vercel.ts
+++ b/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/vercel.ts
@@ -1,0 +1,3 @@
+export const config = {
+  framework: 'nextjs',
+};

--- a/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/vercel.ts
+++ b/packages/knip/fixtures/plugins/vercel-workspaces/apps/web/vercel.ts
@@ -1,3 +1,5 @@
+import type { VercelConfig } from '@vercel/config/v1';
+
 export const config = {
   framework: 'nextjs',
-};
+} satisfies VercelConfig;

--- a/packages/knip/fixtures/plugins/vercel-workspaces/package.json
+++ b/packages/knip/fixtures/plugins/vercel-workspaces/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@plugins/vercel-workspaces",
+  "workspaces": ["apps/*"],
+  "knip": {
+    "workspaces": {
+      "apps/*": {
+        "entry": "src/index.ts",
+        "project": "**/*.ts"
+      }
+    }
+  }
+}

--- a/packages/knip/fixtures/plugins/vercel/package.json
+++ b/packages/knip/fixtures/plugins/vercel/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "@plugins/vercel"
+  "name": "@plugins/vercel",
+  "devDependencies": {
+    "@vercel/config": "*"
+  }
 }

--- a/packages/knip/fixtures/plugins/vercel/vercel.ts
+++ b/packages/knip/fixtures/plugins/vercel/vercel.ts
@@ -1,3 +1,5 @@
+import type { VercelConfig } from '@vercel/config/v1';
+
 export const config = {
   framework: 'nextjs',
-};
+} satisfies VercelConfig;

--- a/packages/knip/src/plugins/vercel/index.ts
+++ b/packages/knip/src/plugins/vercel/index.ts
@@ -1,17 +1,15 @@
 import type { IsPluginEnabled, Plugin } from '../../types/config.ts';
-import { isFile } from '../../util/fs.ts';
+import { hasDependency } from '../../util/plugin.ts';
 
 // https://vercel.com/docs/project-configuration
 
 const title = 'Vercel';
 
-const enablers = 'This plugin is enabled when a Vercel project configuration file is found in the workspace root.';
+const enablers = ['@vercel/config'];
 
-const entry = ['vercel.{json,js,mjs,cjs,ts,mts}'];
+const entry = ['vercel.{js,mjs,cjs,ts,mts}'];
 
-const configFiles = ['vercel.json', 'vercel.js', 'vercel.mjs', 'vercel.cjs', 'vercel.ts', 'vercel.mts'];
-
-const isEnabled: IsPluginEnabled = ({ cwd }) => configFiles.some(file => isFile(cwd, file));
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
 const plugin: Plugin = {
   title,

--- a/packages/knip/src/plugins/vercel/index.ts
+++ b/packages/knip/src/plugins/vercel/index.ts
@@ -5,7 +5,7 @@ import { isFile } from '../../util/fs.ts';
 
 const title = 'Vercel';
 
-const enablers = 'This plugin is enabled when a Vercel project configuration file is found in the root folder.';
+const enablers = 'This plugin is enabled when a Vercel project configuration file is found in the workspace root.';
 
 const entry = ['vercel.{json,js,mjs,cjs,ts,mts}'];
 
@@ -13,14 +13,11 @@ const configFiles = ['vercel.json', 'vercel.js', 'vercel.mjs', 'vercel.cjs', 've
 
 const isEnabled: IsPluginEnabled = ({ cwd }) => configFiles.some(file => isFile(cwd, file));
 
-const isRootOnly = true;
-
 const plugin: Plugin = {
   title,
   enablers,
   isEnabled,
   entry,
-  isRootOnly,
 };
 
 export default plugin;

--- a/packages/knip/test/plugins/vercel.test.ts
+++ b/packages/knip/test/plugins/vercel.test.ts
@@ -6,9 +6,23 @@ import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
 const cwd = resolve('fixtures/plugins/vercel');
+const workspacesCwd = resolve('fixtures/plugins/vercel-workspaces');
 
 test('Find dependencies with the vercel plugin', async () => {
   const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert.deepEqual(issues.files, {});
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
+  });
+});
+
+test('Find Vercel config files in workspace roots', async () => {
+  const options = await createOptions({ cwd: workspacesCwd });
   const { issues, counters } = await main(options);
 
   assert.deepEqual(issues.files, {});


### PR DESCRIPTION
## Summary

- allow the Vercel plugin to enable from workspace roots instead of root-only projects
- add a workspace fixture covering `apps/web/vercel.ts`
- keep the existing root-level `vercel.ts` fixture passing

Fixes #1725.

## Validation

- `bun test packages/knip/test/plugins/vercel.test.ts`
- `node --test test/plugins/vercel.test.ts` from `packages/knip`
- `pnpm --dir packages/knip build`
- `node scripts/run-test.js --smoke --runtime node` from `packages/knip`
- `pnpm --dir packages/knip lint`
- published `knip@6.12.0` repro: `npm run knip` reports `apps/web/vercel.ts`
- fixed local source against updated repro: clean
- fixed local source against `rip-technologies` with the `**/vercel.ts` ignore removed: clean