### PR TITLE
Remove stale root watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
   "workspaces": [
     "packages/*"
   ],
-  "type": "module",
+  "type": "module", 
   "scripts": {
-    "watch": "pnpm run --dir packages/knip watch",
     "docs": "pnpm run --dir packages/docs dev",
     "test": "pnpm run --dir packages/knip test",
     "fmt": "oxfmt",


### PR DESCRIPTION
## Summary

Remove the stale root watch script. The package-level script it pointed to no longer exists.

## Verification

Not run. Script removal only.

Closes #1730