### PR TITLE
Fix symbol reporter file paths with --directory

### DIFF
--- a/packages/knip/fixtures/symbol-reporter-directory/package.json
+++ b/packages/knip/fixtures/symbol-reporter-directory/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixtures/symbol-reporter-directory",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "knip": {
+    "entry": ["src/index.ts"],
+    "project": ["src/**/*.ts", "packages/client/src/**/*.ts"]
+  }
+}

--- a/packages/knip/fixtures/symbol-reporter-directory/packages/client/src/unused.ts
+++ b/packages/knip/fixtures/symbol-reporter-directory/packages/client/src/unused.ts
@@ -1,0 +1,1 @@
+export const unusedClient = true;

--- a/packages/knip/fixtures/symbol-reporter-directory/src/index.ts
+++ b/packages/knip/fixtures/symbol-reporter-directory/src/index.ts
@@ -1,0 +1,1 @@
+export const used = true;

--- a/packages/knip/fixtures/symbol-reporter-directory/src/unused.ts
+++ b/packages/knip/fixtures/symbol-reporter-directory/src/unused.ts
@@ -1,0 +1,1 @@
+export const unusedRoot = true;

--- a/packages/knip/src/reporters/util/util.ts
+++ b/packages/knip/src/reporters/util/util.ts
@@ -39,13 +39,9 @@ export const convert = (issue: Issue | IssueSymbol) => ({
 });
 
 const sortByPos = (a: Issue, b: Issue) => {
-  const [filePathA, rowA, colA] = a.filePath.split(':');
-  const [filePathB, rowB, colB] = b.filePath.split(':');
-  return filePathA === filePathB
-    ? Number(rowA) === Number(rowB)
-      ? Number(colA) - Number(colB)
-      : Number(rowA) - Number(rowB)
-    : filePathA.localeCompare(filePathB);
+  if (a.filePath !== b.filePath) return a.filePath.localeCompare(b.filePath);
+  if (a.line !== b.line) return (a.line ?? 0) - (b.line ?? 0);
+  return (a.col ?? 0) - (b.col ?? 0);
 };
 
 const highlightSymbol =

--- a/packages/knip/src/reporters/util/util.ts
+++ b/packages/knip/src/reporters/util/util.ts
@@ -81,7 +81,8 @@ export const getTableForType = (
     table.cell('symbolType', issue.symbolType && issue.symbolType !== SYMBOL_TYPE.UNKNOWN && print(issue.symbolType));
 
     const pos = issue.line === undefined ? '' : `:${issue.line}${issue.col === undefined ? '' : `:${issue.col}`}`;
-    const cell = isFileIssue ? relative(cwd, symbol) : `${relative(cwd, issue.filePath)}${pos}`;
+    const filePath = relative(cwd, issue.filePath);
+    const cell = isFileIssue ? filePath : `${filePath}${pos}`;
     table.cell('filePath', print(cell));
 
     table.cell('fixed', issue.isFixed && print('(removed)'));

--- a/packages/knip/src/util/create-options.ts
+++ b/packages/knip/src/util/create-options.ts
@@ -29,8 +29,8 @@ interface CreateOptions extends Partial<Options> {
  */
 export const createOptions = async (options: CreateOptions) => {
   const { args = {} } = options;
-  const pcwd = process.cwd();
-  const cwd = normalize(toPosix(toAbsolute(options.cwd ?? args.directory ?? pcwd, pcwd)));
+  const pcwd = toPosix(process.cwd());
+  const cwd = normalize(toAbsolute(toPosix(options.cwd ?? args.directory ?? pcwd), pcwd));
 
   const manifestPath = findFile(cwd, 'package.json');
   const manifest: PackageJson = manifestPath && (await loadJSON(manifestPath));

--- a/packages/knip/test/cli/cli-reporter-symbols-directory.test.ts
+++ b/packages/knip/test/cli/cli-reporter-symbols-directory.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { exec } from '../helpers/exec.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/symbol-reporter-directory/packages/config');
+
+test('knip --reporter symbols with --directory from another cwd', () => {
+  const expected = `packages/client/src/unused.ts
+src/unused.ts`;
+
+  const result = exec('knip --directory ../.. --reporter symbols --include files --no-config-hints', { cwd }).stdout;
+
+  assert.equal(result, expected);
+});


### PR DESCRIPTION
Fixes #1713.

## Summary
- compute symbols reporter file issue locations from the absolute issue file path and configured cwd
- add a regression fixture for running Knip from a subdirectory with `--directory ../..`

## Verification
- `pnpm build`
- `pnpm lint`
- `pnpm exec oxfmt -c ../../.oxfmtrc.json --ignore-path ../../.prettierignore --check src/reporters/util/util.ts test/cli/cli-reporter-symbols-directory.test.ts fixtures/symbol-reporter-directory/src/index.ts fixtures/symbol-reporter-directory/src/unused.ts fixtures/symbol-reporter-directory/packages/client/src/unused.ts`
- `node --test test/cli/cli-reporter-symbols-directory.test.ts`
- `pnpm test --smoke`
- `git diff --check HEAD~1 HEAD`
