### PR TITLE
Add jest.config.{cts,mts}

### DIFF
--- a/packages/knip/src/plugins/jest/index.ts
+++ b/packages/knip/src/plugins/jest/index.ts
@@ -15,7 +15,7 @@ const enablers = ['jest'];
 const isEnabled: IsPluginEnabled = ({ dependencies, manifest }) =>
   hasDependency(dependencies, enablers) || Boolean(manifest.name?.startsWith('jest-presets'));
 
-const config = ['jest.config.{js,ts,mjs,cjs,json}', 'package.json'];
+const config = ['jest.config.{js,ts,mjs,cjs,mts,cts,json}', 'package.json'];
 
 const mocks = ['**/__mocks__/**/*.[jt]s?(x)'];
 


### PR DESCRIPTION
[Jest 30.4](https://github.com/jestjs/jest/releases/tag/v30.4.0) adds support for `jest.config.mts` config files, in addition to the preexisting support for `jest.config.cts`, but these weren't recognized by Knip's Jest plugin.

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
