### PR TITLE
Detect dynamic imports in Svelte compiler

### DIFF
--- a/packages/knip/fixtures/svelte-script-jsdoc-import/src/App.svelte
+++ b/packages/knip/fixtures/svelte-script-jsdoc-import/src/App.svelte
@@ -6,7 +6,12 @@
    */
 
   // import Old from './does-not-exist.svelte';
+  import type { WidgetOptions } from './types';
   import Widget from './Widget.svelte';
+
+  const options: WidgetOptions = { eager: true };
+  const LazyWidget = options.eager ? Widget : await import('./LazyWidget.svelte');
 </script>
 
 <Widget />
+<svelte:component this={LazyWidget} />

--- a/packages/knip/fixtures/svelte-script-jsdoc-import/src/LazyWidget.svelte
+++ b/packages/knip/fixtures/svelte-script-jsdoc-import/src/LazyWidget.svelte
@@ -1,0 +1,1 @@
+<div>Lazy widget</div>

--- a/packages/knip/fixtures/svelte-script-jsdoc-import/src/types.ts
+++ b/packages/knip/fixtures/svelte-script-jsdoc-import/src/types.ts
@@ -1,0 +1,3 @@
+export type WidgetOptions = {
+  eager: boolean;
+};

--- a/packages/knip/src/compilers/compilers.ts
+++ b/packages/knip/src/compilers/compilers.ts
@@ -9,13 +9,14 @@ const scriptExtractor = /<script\b(?:[^>"']|"[^"]*"|'[^']*')*>([\s\S]*?)<\/scrip
 const blockCommentMatcher = /\/\*[\s\S]*?\*\//g;
 const lineCommentMatcher = /^[ \t]*\/\/.*$/gm;
 export const importMatcher = /import[^'"]+['"][^'"]+['"]/g;
+const scriptImportMatcher = /import(?:\s*\(\s*['"][^'"]+['"]\s*\)|(?!\s*\()[^'"]+['"][^'"]+['"])/g;
 export const importsWithinScripts: CompilerSync = (text: string) => {
   const scripts = [];
   let scriptMatch: RegExpExecArray | null;
   // oxlint-disable-next-line no-cond-assign
   while ((scriptMatch = scriptExtractor.exec(text))) {
     const body = scriptMatch[1].replace(blockCommentMatcher, '').replace(lineCommentMatcher, '');
-    for (const importMatch of body.matchAll(importMatcher)) {
+    for (const importMatch of body.matchAll(scriptImportMatcher)) {
       scripts.push(importMatch);
     }
   }

--- a/packages/knip/test/svelte-script-jsdoc-import.test.ts
+++ b/packages/knip/test/svelte-script-jsdoc-import.test.ts
@@ -7,13 +7,16 @@ import { resolve } from './helpers/resolve.ts';
 
 const cwd = resolve('fixtures/svelte-script-jsdoc-import');
 
-test('Svelte compiler ignores import-like text inside block and whole-line comments', async () => {
+test('Svelte compiler extracts type imports and dynamic imports from scripts', async () => {
   const options = await createOptions({ cwd });
-  const { counters } = await main(options);
+  const { issues, counters } = await main(options);
+
+  assert(!('src/LazyWidget.svelte' in issues.files));
+  assert(!('src/types.ts' in issues.files));
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 2,
-    total: 2,
+    processed: 4,
+    total: 4,
   });
 });


### PR DESCRIPTION
## Summary

Improve the built-in Svelte compiler so it extracts dynamic imports from `<script>` blocks.

## What changed

- Added dynamic `import('...')` extraction for Svelte script blocks.
- Extended the Svelte compiler regression fixture with a type import and a dynamic component import.
- Kept import-like text in comments ignored by the existing comment stripping.

## Why

In #1670, the built-in Svelte compiler was suggested as the right place to preserve type imports while also detecting dynamic component imports. The existing compiler already handled static and type imports, but dynamic imports inside Svelte scripts were missed and could leave dynamically imported components reported as unused files.

## Testing

- `node --test test/svelte-script-jsdoc-import.test.ts`
- `node --test test/plugins/svelte.test.ts`
- `node --test test/plugins/sveltekit.test.ts`
- `pnpm run ci`
- `pnpm --dir packages/knip build`
- `pnpm --dir packages/knip test --runtime node --smoke`

Refs #1670