### PR TITLE
fix(astro): add "src/middleware/index.{js,ts}" entry point

### DIFF
--- a/packages/knip/src/plugins/astro/index.ts
+++ b/packages/knip/src/plugins/astro/index.ts
@@ -24,6 +24,7 @@ const production = [
   '!src/pages/**/_*/**', // negate folders prefixed with _. The pattern _** would be collapsed into _* so we have to use **/_*/**
   'src/content/**/*.mdx',
   'src/middleware.{js,ts}',
+  'src/middleware/index.{js,ts}',
   'src/actions/index.{js,ts}',
 ];
 


### PR DESCRIPTION
## Summary

Knip's Astro plugin currently only adds  as an entry in the  array. However, Astro also supports  as an alternative middleware entry point (see [Astro Middleware docs](https://docs.astro.build/guides/middleware/)).

This causes dependencies used in  to be incorrectly reported as unused.

## Change

Added  to the  array in the Astro plugin, right after .

Fixes #1748