### PR TITLE
Reproduce graphql-codegen helper plugin dependency false positive

### DIFF
--- a/packages/knip/fixtures/plugins/graphql-codegen-helper-plugins/node_modules/@graphql-codegen/cli/package.json
+++ b/packages/knip/fixtures/plugins/graphql-codegen-helper-plugins/node_modules/@graphql-codegen/cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@graphql-codegen/cli",
+  "bin": {
+    "gql-gen": "index.js",
+    "graphql-codegen": "index.js",
+    "graphql-code-generator": "index.js",
+    "graphql-codegen-esm": "index.js"
+  }
+}

--- a/packages/knip/fixtures/plugins/graphql-codegen-helper-plugins/package.json
+++ b/packages/knip/fixtures/plugins/graphql-codegen-helper-plugins/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@plugins/graphql-codegen-helper-plugins",
+  "scripts": {
+    "codegen": "graphql-codegen --config ./src/codegen.ts"
+  },
+  "devDependencies": {
+    "@graphql-codegen/cli": "*",
+    "@graphql-codegen/typescript": "*",
+    "@graphql-codegen/typescript-graphql-request": "*",
+    "@graphql-codegen/typescript-operations": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/graphql-codegen-helper-plugins/src/codegen-helper.ts
+++ b/packages/knip/fixtures/plugins/graphql-codegen-helper-plugins/src/codegen-helper.ts
@@ -1,0 +1,9 @@
+export const getCodegenConfig = () => ({
+  schema: 'schema.graphql',
+  generates: {
+    './src/generated/graphql.ts': {
+      documents: ['./src/**/*.graphql'],
+      plugins: ['typescript', 'typescript-operations', 'typescript-graphql-request'],
+    },
+  },
+});

--- a/packages/knip/fixtures/plugins/graphql-codegen-helper-plugins/src/codegen.ts
+++ b/packages/knip/fixtures/plugins/graphql-codegen-helper-plugins/src/codegen.ts
@@ -1,0 +1,3 @@
+import { getCodegenConfig } from './codegen-helper.ts';
+
+export default getCodegenConfig();

--- a/packages/knip/test/plugins/graphql-codegen-helper-plugins.test.ts
+++ b/packages/knip/test/plugins/graphql-codegen-helper-plugins.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/graphql-codegen-helper-plugins');
+
+test('Find dependencies with the graphql-codegen plugin (helper config module)', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(!issues.devDependencies['package.json']?.['@graphql-codegen/typescript']);
+  assert(!issues.devDependencies['package.json']?.['@graphql-codegen/typescript-operations']);
+  assert(!issues.devDependencies['package.json']?.['@graphql-codegen/typescript-graphql-request']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
## Summary

This adds an intentionally failing reproduction for a graphql-codegen dependency false positive. The fixture has a workspace script using `graphql-codegen --config ./src/codegen.ts`; that TypeScript config imports a helper module whose GraphQL Code Generator config lists plugin names (`typescript`, `typescript-operations`, and `typescript-graphql-request`).

Those plugin packages are declared in the generating workspace, so the test asserts they should not be reported as unused devDependencies. On current `main`, the focused test fails because Knip reports `@graphql-codegen/typescript` and the related plugin packages as unused.

## Validation

Intentionally failing reproduction:

```sh
bun test packages/knip/test/plugins/graphql-codegen-helper-plugins.test.ts
```

Result: fails on the assertion that `@graphql-codegen/typescript` is not an unused devDependency.