### PR TITLE
Reproduce google-apps-script ambient types false positive

### DIFF
--- a/packages/knip/fixtures/tsconfig-types-from-extends/package.json
+++ b/packages/knip/fixtures/tsconfig-types-from-extends/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixtures/tsconfig-types-from-extends",
+  "workspaces": ["packages/*"]
+}

--- a/packages/knip/fixtures/tsconfig-types-from-extends/packages/script/index.ts
+++ b/packages/knip/fixtures/tsconfig-types-from-extends/packages/script/index.ts
@@ -1,0 +1,3 @@
+declare const sheet: GoogleAppsScript.Spreadsheet.Sheet;
+
+console.log(sheet.getName());

--- a/packages/knip/fixtures/tsconfig-types-from-extends/packages/script/package.json
+++ b/packages/knip/fixtures/tsconfig-types-from-extends/packages/script/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixtures/tsconfig-types-from-extends__script",
+  "main": "index.ts",
+  "devDependencies": {
+    "@types/google-apps-script": "*",
+    "typescript": "*"
+  }
+}

--- a/packages/knip/fixtures/tsconfig-types-from-extends/packages/script/tsconfig.json
+++ b/packages/knip/fixtures/tsconfig-types-from-extends/packages/script/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/knip/fixtures/tsconfig-types-from-extends/tsconfig.base.json
+++ b/packages/knip/fixtures/tsconfig-types-from-extends/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["google-apps-script"]
+  }
+}

--- a/packages/knip/test/tsconfig-types-from-extends.test.ts
+++ b/packages/knip/test/tsconfig-types-from-extends.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../src/index.ts';
+import baseCounters from './helpers/baseCounters.ts';
+import { createOptions } from './helpers/create-options.ts';
+import { resolve } from './helpers/resolve.ts';
+
+const cwd = resolve('fixtures/tsconfig-types-from-extends');
+
+test('Treat extended tsconfig compilerOptions.types entries as type-only', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(!issues.devDependencies['packages/script/package.json']?.['@types/google-apps-script']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
## Summary

This adds an intentionally failing reproduction for a false positive where a workspace source file uses ambient Google Apps Script types supplied by `@types/google-apps-script`, with `compilerOptions.types` inherited from an extended shared tsconfig.

The fixture has a workspace package depending on `@types/google-apps-script`, extends a root `tsconfig.base.json` containing `types: ["google-apps-script"]`, and references `GoogleAppsScript.Spreadsheet.Sheet` from the source entry.

## Expected current result

This PR is intentionally failing on current `main`: Knip reports `@types/google-apps-script` as an unused devDependency for the workspace package even though the ambient type is used through inherited `compilerOptions.types`.

## Validation

`pnpm --dir packages/knip exec node --test test/tsconfig-types-from-extends.test.ts`

Expected failure:

```
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert(!issues.devDependencies['packages/script/package.json']?.['@types/google-apps-script'])
```