### PR TITLE
Reproduce unused Serverless TypeScript plugin dependencies

### DIFF
--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/esbuild/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/esbuild/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "esbuild",
+  "bin": {
+    "esbuild": "bin/esbuild"
+  }
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-esbuild/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-esbuild/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "serverless-esbuild"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline-sns/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline-sns/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "serverless-offline-sns"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline-sqs/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline-sqs/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "serverless-offline-sqs"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "serverless-offline"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "serverless",
+  "bin": {
+    "serverless": "bin/serverless.js",
+    "sls": "bin/serverless.js"
+  }
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@plugins/serverless-framework-typescript-plugins",
+  "devDependencies": {
+    "esbuild": "*",
+    "serverless": "*",
+    "serverless-esbuild": "*",
+    "serverless-offline": "*",
+    "serverless-offline-sns": "*",
+    "serverless-offline-sqs": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/serverless.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/serverless.ts
@@ -1,0 +1,28 @@
+const config = {
+  service: 'typescript-serverless-plugins',
+  frameworkVersion: '3',
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs20.x',
+  },
+  build: {
+    esbuild: {
+      bundle: true,
+      minify: false,
+    },
+  },
+  custom: {
+    esbuild: {
+      bundle: true,
+      target: 'node20',
+    },
+  },
+  plugins: ['serverless-esbuild', 'serverless-offline', 'serverless-offline-sns', 'serverless-offline-sqs'],
+  functions: {
+    worker: {
+      handler: 'src/handler.run',
+    },
+  },
+};
+
+export default config;

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/src/handler.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/src/handler.ts
@@ -1,0 +1,1 @@
+export const run = async () => {};

--- a/packages/knip/test/plugins/serverless-framework.test.ts
+++ b/packages/knip/test/plugins/serverless-framework.test.ts
@@ -6,6 +6,7 @@ import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
 const cwd = resolve('fixtures/plugins/serverless-framework');
+const typescriptPluginsCwd = resolve('fixtures/plugins/serverless-framework-typescript-plugins');
 
 test('Find dependencies with the Serverless Framework plugin', async () => {
   const options = await createOptions({ cwd });
@@ -16,4 +17,11 @@ test('Find dependencies with the Serverless Framework plugin', async () => {
     processed: 2,
     total: 2,
   });
+});
+
+test('Find dependencies from Serverless Framework TypeScript plugins', async () => {
+  const options = await createOptions({ cwd: typescriptPluginsCwd });
+  const { issues } = await main(options);
+
+  assert.deepEqual(Object.keys(issues.devDependencies['package.json'] ?? {}).sort(), []);
 });


### PR DESCRIPTION
This PR adds an intentionally failing reproduction for Serverless Framework TypeScript config dependency detection.

The new fixture uses `serverless.ts` with `plugins` entries for:

- `serverless-esbuild`
- `serverless-offline`
- `serverless-offline-sns`
- `serverless-offline-sqs`

It also includes `build.esbuild` and `custom.esbuild` config, with `esbuild` listed in `devDependencies`.

Expected behavior: these packages should not be reported as unused devDependencies because they are referenced by the Serverless config.

Current behavior: the focused test fails and reports these devDependencies as unused:

- `esbuild`
- `serverless`
- `serverless-esbuild`
- `serverless-offline`
- `serverless-offline-sns`
- `serverless-offline-sqs`

Validation run:

```sh
cd packages/knip
bun test test/plugins/serverless-framework.test.ts
```

Result: intentionally fails, with 1 passing test and 1 failing test. The failing assertion compares the reported devDependency issue keys to `[]` and currently receives the six packages listed above.