### PR TITLE
Fix GraphQL Codegen script config dependencies

### DIFF
--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config/node_modules/@graphql-codegen/cli/package.json
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config/node_modules/@graphql-codegen/cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@graphql-codegen/cli",
+  "bin": {
+    "gql-gen": "index.js",
+    "graphql-codegen": "index.js",
+    "graphql-code-generator": "index.js",
+    "graphql-codegen-esm": "index.js"
+  }
+}

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config/package.json
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@plugins/graphql-codegen-script-config",
+  "scripts": {
+    "codegen": "graphql-codegen --config ./src/codegen.ts"
+  },
+  "devDependencies": {
+    "@graphql-codegen/cli": "*",
+    "@graphql-codegen/typescript": "*",
+    "@graphql-codegen/typescript-graphql-request": "*",
+    "@graphql-codegen/typescript-operations": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config/src/codegen-helpers.ts
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config/src/codegen-helpers.ts
@@ -1,0 +1,5 @@
+export const getClientPlugins = () => [
+  'typescript',
+  'typescript-operations',
+  'typescript-graphql-request',
+];

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config/src/codegen.ts
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config/src/codegen.ts
@@ -1,0 +1,13 @@
+import { getClientPlugins } from './codegen-helpers.ts';
+
+const config = {
+  schema: './src/schema.graphql',
+  documents: './src/operations.graphql',
+  generates: {
+    './src/generated/graphql.ts': {
+      plugins: getClientPlugins(),
+    },
+  },
+};
+
+export default config;

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config/src/operations.graphql
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config/src/operations.graphql
@@ -1,0 +1,6 @@
+query Viewer {
+  viewer {
+    id
+    name
+  }
+}

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config/src/schema.graphql
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config/src/schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  viewer: User!
+}
+
+type User {
+  id: ID!
+  name: String!
+}

--- a/packages/knip/src/plugins/graphql-codegen/index.ts
+++ b/packages/knip/src/plugins/graphql-codegen/index.ts
@@ -25,6 +25,10 @@ const enablers = [/^@graphql-codegen\//, 'graphql-config'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
+const args = {
+  config: true,
+};
+
 const packageJsonPath: Plugin['packageJsonPath'] = manifest => get(manifest, 'codegen') ?? get(manifest, 'graphql');
 
 const config = [
@@ -89,6 +93,7 @@ const resolveConfig: ResolveConfig<GraphqlCodegenTypes | GraphqlConfigTypes | Gr
 
 const plugin: Plugin = {
   title,
+  args,
   enablers,
   isEnabled,
   packageJsonPath,

--- a/packages/knip/test/plugins/graphql-codegen.test.ts
+++ b/packages/knip/test/plugins/graphql-codegen.test.ts
@@ -6,6 +6,7 @@ import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
 const cwd = resolve('fixtures/plugins/graphql-codegen');
+const scriptConfigCwd = resolve('fixtures/plugins/graphql-codegen-script-config');
 
 test('Find dependencies with the graphql-codegen plugin (codegen.ts function)', async () => {
   const options = await createOptions({ cwd });
@@ -35,5 +36,22 @@ test('Find dependencies with the graphql-codegen plugin (codegen.ts function)', 
     unlisted: 16,
     processed: 1,
     total: 1,
+  });
+});
+
+test('Find dependencies from a graphql-codegen script config', async () => {
+  const options = await createOptions({ cwd: scriptConfigCwd });
+  const { issues, counters } = await main(options);
+
+  assert(!issues.files['src/codegen.ts']);
+  assert(!issues.files['src/codegen-helpers.ts']);
+  assert(!issues.dependencies['package.json']?.['@graphql-codegen/typescript']);
+  assert(!issues.dependencies['package.json']?.['@graphql-codegen/typescript-operations']);
+  assert(!issues.dependencies['package.json']?.['@graphql-codegen/typescript-graphql-request']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
   });
 });


### PR DESCRIPTION
## Summary

- Add GraphQL Codegen CLI `--config` argument handling so package scripts can register non-root config files.
- Add a regression fixture where `package.json` runs `graphql-codegen --config ./src/codegen.ts` and that config imports a helper returning plugin names.
- Assert the config/helper files and GraphQL Codegen plugin packages are no longer reported as unused.

## Reproduction

Standalone repro: https://github.com/jakeleventhal/knip-repro-graphql-codegen-helper-plugins

With published Knip 6.14.1, `npm run knip` reports:

- `src/codegen.ts` and `src/codegen-helpers.ts` as unused files
- `@graphql-codegen/typescript`, `@graphql-codegen/typescript-operations`, and `@graphql-codegen/typescript-graphql-request` as unused devDependencies

## Validation

- `npm run knip` in the standalone repro with Knip 6.14.1 reproduces the false positive.
- `node --test test/plugins/graphql-codegen.test.ts`
- `node --test test/util/get-inputs-from-scripts.test.ts test/plugins/graphql-codegen.test.ts`
- `pnpm build`
- `pnpm test --smoke`
