### PR TITLE
Fix Serverless TypeScript plugin dependencies

### DIFF
--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/@serverless/typescript/index.d.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/@serverless/typescript/index.d.ts
@@ -1,0 +1,1 @@
+export type AWS = Record<string, unknown>;

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/@serverless/typescript/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/@serverless/typescript/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@serverless/typescript",
+  "types": "index.d.ts"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/esbuild/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/esbuild/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "esbuild"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-esbuild/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-esbuild/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "serverless-esbuild"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline-sns/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline-sns/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "serverless-offline-sns"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline-sqs/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline-sqs/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "serverless-offline-sqs"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless-offline/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "serverless-offline"
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/node_modules/serverless/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "serverless",
+  "bin": {
+    "serverless": "bin/serverless.js",
+    "sls": "bin/serverless.js"
+  }
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@plugins/serverless-framework-typescript-plugins",
+  "scripts": {
+    "serverless": "serverless print"
+  },
+  "devDependencies": {
+    "@serverless/typescript": "*",
+    "esbuild": "*",
+    "serverless": "*",
+    "serverless-esbuild": "*",
+    "serverless-offline": "*",
+    "serverless-offline-sns": "*",
+    "serverless-offline-sqs": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/serverless.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/serverless.ts
@@ -1,0 +1,24 @@
+import type { AWS } from '@serverless/typescript';
+
+const config: AWS = {
+  service: 'typescript-serverless-plugins',
+  frameworkVersion: '4',
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs22.x',
+  },
+  custom: {
+    esbuild: {
+      bundle: true,
+      target: 'node22',
+    },
+  },
+  plugins: ['serverless-esbuild', 'serverless-offline', 'serverless-offline-sns', 'serverless-offline-sqs'],
+  functions: {
+    hello: {
+      handler: 'src/functions/hello/handler.main',
+    },
+  },
+};
+
+export default config;

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/src/functions/hello/handler.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/src/functions/hello/handler.ts
@@ -1,0 +1,1 @@
+export const main = async () => {};

--- a/packages/knip/src/plugins/serverless-framework/index.ts
+++ b/packages/knip/src/plugins/serverless-framework/index.ts
@@ -1,5 +1,6 @@
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
-import { toProductionEntry } from '../../util/input.ts';
+import { toDependency, toProductionEntry } from '../../util/input.ts';
+import { isInternal, join } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
 import type { PluginConfig } from './types.ts';
 
@@ -11,16 +12,24 @@ const enablers = ['serverless'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['serverless.{yml,yaml}'];
+const config = ['serverless.{js,cjs,mjs,ts,cts,mts,yml,yaml}'];
 
 const handlerToEntry = (handler: string) => {
   const dot = handler.lastIndexOf('.');
   return toProductionEntry(`${handler.slice(0, dot)}.{js,ts}`);
 };
 
-const resolveConfig: ResolveConfig<PluginConfig> = async config => {
-  if (!config.functions) return [];
-  return Object.values(config.functions).flatMap(fn => (fn.handler ? [handlerToEntry(fn.handler)] : []));
+const pluginToInput = (plugin: string, dir: string) =>
+  isInternal(plugin) ? toProductionEntry(join(dir, plugin)) : toDependency(plugin);
+
+const resolveConfig: ResolveConfig<PluginConfig> = async (config, options) => {
+  const functions = config.functions
+    ? Object.values(config.functions).flatMap(fn => (fn.handler ? [handlerToEntry(fn.handler)] : []))
+    : [];
+  const plugins = config.plugins?.filter((plugin): plugin is string => typeof plugin === 'string') ?? [];
+  const esbuild = config.custom?.esbuild || config.build?.esbuild ? [toDependency('esbuild', { optional: true })] : [];
+
+  return [...functions, ...plugins.map(plugin => pluginToInput(plugin, options.configFileDir)), ...esbuild];
 };
 
 const plugin: Plugin = {

--- a/packages/knip/src/plugins/serverless-framework/types.ts
+++ b/packages/knip/src/plugins/serverless-framework/types.ts
@@ -1,5 +1,12 @@
 export type PluginConfig = {
+  build?: {
+    esbuild?: unknown;
+  };
+  custom?: {
+    esbuild?: unknown;
+  };
   functions?: Record<string, ServerlessFunction>;
+  plugins?: unknown[];
 };
 
 type ServerlessFunction = {

--- a/packages/knip/test/plugins/serverless-framework.test.ts
+++ b/packages/knip/test/plugins/serverless-framework.test.ts
@@ -6,9 +6,21 @@ import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
 const cwd = resolve('fixtures/plugins/serverless-framework');
+const typescriptPluginsCwd = resolve('fixtures/plugins/serverless-framework-typescript-plugins');
 
 test('Find dependencies with the Serverless Framework plugin', async () => {
   const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
+  });
+});
+
+test('Find dependencies from Serverless Framework TypeScript plugins', async () => {
+  const options = await createOptions({ cwd: typescriptPluginsCwd });
   const { counters } = await main(options);
 
   assert.deepEqual(counters, {


### PR DESCRIPTION
## Summary

- Treat `serverless.ts` and other JS/TS Serverless config files as Serverless Framework configs.
- Mark Serverless `plugins` entries as dependency inputs.
- Mark `esbuild` as an optional dependency input when Serverless esbuild config is present.
- Add a regression fixture for TypeScript Serverless configs with plugin packages.

Standalone repro: https://github.com/jakeleventhal/knip-repro-serverless-ts-plugins

## Validation

- `pnpm --dir packages/knip exec tsx --test test/plugins/serverless-framework.test.ts`
- `pnpm --dir packages/knip exec oxlint src/plugins/serverless-framework/index.ts src/plugins/serverless-framework/types.ts test/plugins/serverless-framework.test.ts`
- `pnpm --dir /Users/jakeleventhal/Developer/knip-fix-serverless-ts-plugins/packages/knip exec tsx src/cli.ts --directory /Users/jakeleventhal/Developer/knip-standalone-repros/serverless-ts-plugins`