### PR TITLE
Fix extended tsconfig type dependency attribution

### DIFF
--- a/packages/knip/fixtures/tsconfig-types-extends/package.json
+++ b/packages/knip/fixtures/tsconfig-types-extends/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/tsconfig-types-extends",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/knip/fixtures/tsconfig-types-extends/packages/script/node_modules/@types/chrome/index.d.ts
+++ b/packages/knip/fixtures/tsconfig-types-extends/packages/script/node_modules/@types/chrome/index.d.ts
@@ -1,0 +1,7 @@
+declare namespace chrome {
+  namespace runtime {
+    interface MessageSender {
+      id?: string;
+    }
+  }
+}

--- a/packages/knip/fixtures/tsconfig-types-extends/packages/script/node_modules/@types/chrome/package.json
+++ b/packages/knip/fixtures/tsconfig-types-extends/packages/script/node_modules/@types/chrome/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@types/chrome",
+  "version": "1.0.0",
+  "types": "index.d.ts"
+}

--- a/packages/knip/fixtures/tsconfig-types-extends/packages/script/package.json
+++ b/packages/knip/fixtures/tsconfig-types-extends/packages/script/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixtures/tsconfig-types-extends__script",
+	"main": "src/index.ts",
+	"devDependencies": {
+		"@types/chrome": "*",
+		"typescript": "*"
+	}
+}

--- a/packages/knip/fixtures/tsconfig-types-extends/packages/script/src/index.ts
+++ b/packages/knip/fixtures/tsconfig-types-extends/packages/script/src/index.ts
@@ -1,0 +1,2 @@
+declare const sender: chrome.runtime.MessageSender;
+console.log(sender.id);

--- a/packages/knip/fixtures/tsconfig-types-extends/packages/script/tsconfig.json
+++ b/packages/knip/fixtures/tsconfig-types-extends/packages/script/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/knip/fixtures/tsconfig-types-extends/tsconfig.base.json
+++ b/packages/knip/fixtures/tsconfig-types-extends/tsconfig.base.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"types": [
+			"chrome"
+		]
+	}
+}

--- a/packages/knip/src/plugins/typescript/index.ts
+++ b/packages/knip/src/plugins/typescript/index.ts
@@ -52,7 +52,7 @@ const resolveConfig: ResolveConfig<TsConfigJson> = async (localConfig, options) 
   return compact([
     ...extend,
     ...references,
-    ...types.map(id => toDeferResolve(id, { isTypeOnly: true })),
+    ...types.map(id => toDeferResolve(id, { isTypeOnly: true, dir: options.cwd })),
     ...[...plugins, ...importHelpers].map(id => toDeferResolve(id)),
     ...jsx,
     ...aliases,

--- a/packages/knip/test/tsconfig-types-extends.test.ts
+++ b/packages/knip/test/tsconfig-types-extends.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../src/index.ts';
+import baseCounters from './helpers/baseCounters.ts';
+import { createOptions } from './helpers/create-options.ts';
+import { resolve } from './helpers/resolve.ts';
+
+const cwd = resolve('fixtures/tsconfig-types-extends');
+
+test('Treat extended tsconfig.json compilerOptions.types entries as type-only in the workspace', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(!issues.devDependencies['packages/script/package.json']?.['@types/chrome']);
+  assert(!issues.unresolved['tsconfig.base.json']?.['chrome']);
+  assert(!issues.unlisted['tsconfig.base.json']?.['chrome']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
## Summary
- Attribute `compilerOptions.types` dependencies from extended tsconfig chains to the workspace currently being analyzed
- Add a regression fixture for a workspace package that consumes ambient `@types/chrome` through a root/base tsconfig

Standalone repro: https://github.com/jakeleventhal/knip-repro-extended-tsconfig-types

## Validation
- `npm exec tsc -- -p packages/script/tsconfig.json --noEmit` in the standalone repro passes
- `npm run knip` in the standalone repro fails with published Knip and reports `@types/chrome` as unused plus `chrome` unresolved from `tsconfig.base.json`
- `node --test test/tsconfig-types-extends.test.ts`
- `node packages/knip/src/cli.ts --directory /Users/jakeleventhal/Developer/knip-standalone-repros/extended-tsconfig-types`
