### PR TITLE
Load plugin configs from workspace cwd

### DIFF
--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/config/codegen-plugins.json
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/config/codegen-plugins.json
@@ -1,0 +1,5 @@
+[
+  "typescript",
+  "typescript-operations",
+  "typescript-graphql-request"
+]

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/node_modules/@graphql-codegen/cli/package.json
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/node_modules/@graphql-codegen/cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@graphql-codegen/cli",
+  "bin": {
+    "gql-gen": "index.js",
+    "graphql-codegen": "index.js",
+    "graphql-code-generator": "index.js",
+    "graphql-codegen-esm": "index.js"
+  }
+}

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/package.json
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@plugins/graphql-codegen-script-config-cwd-context",
+  "scripts": {
+    "codegen": "graphql-codegen --config ./src/codegen.ts"
+  },
+  "devDependencies": {
+    "@graphql-codegen/cli": "*",
+    "@graphql-codegen/typescript": "*",
+    "@graphql-codegen/typescript-graphql-request": "*",
+    "@graphql-codegen/typescript-operations": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/src/codegen.ts
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/src/codegen.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+
+const plugins = JSON.parse(readFileSync('./config/codegen-plugins.json', 'utf8'));
+
+const config = {
+  schema: './src/schema.graphql',
+  documents: './src/operations.graphql',
+  generates: {
+    './src/generated/graphql.ts': {
+      plugins,
+    },
+  },
+};
+
+export default config;

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/src/operations.graphql
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/src/operations.graphql
@@ -1,0 +1,6 @@
+query Viewer {
+  viewer {
+    id
+    name
+  }
+}

--- a/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/src/schema.graphql
+++ b/packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/src/schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  viewer: User!
+}
+
+type User {
+  id: ID!
+  name: String!
+}

--- a/packages/knip/src/util/plugin.ts
+++ b/packages/knip/src/util/plugin.ts
@@ -42,6 +42,18 @@ export const normalizePluginConfig = (pluginConfig: RawPluginConfiguration) => {
   return { config, entry, project };
 };
 
+const loadWorkspaceConfigFile = async (configFilePath: string, cwd: string) => {
+  if (cwd === process.cwd()) return await load(configFilePath);
+
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(cwd);
+    return await load(configFilePath);
+  } finally {
+    process.chdir(originalCwd);
+  }
+};
+
 export const loadConfigForPlugin = async (
   configFilePath: string,
   plugin: Plugin,
@@ -55,5 +67,5 @@ export const loadConfigForPlugin = async (
     ? typeof packageJsonPath === 'function'
       ? packageJsonPath(manifest)
       : get(manifest, packageJsonPath ?? pluginName)
-    : await load(configFilePath);
+    : await loadWorkspaceConfigFile(configFilePath, options.cwd);
 };

--- a/packages/knip/test/plugins/graphql-codegen.test.ts
+++ b/packages/knip/test/plugins/graphql-codegen.test.ts
@@ -7,6 +7,7 @@ import { resolve } from '../helpers/resolve.ts';
 
 const cwd = resolve('fixtures/plugins/graphql-codegen');
 const scriptConfigCwd = resolve('fixtures/plugins/graphql-codegen-script-config');
+const scriptConfigCwdContextCwd = resolve('fixtures/plugins/graphql-codegen-script-config-cwd-context');
 
 test('Find dependencies with the graphql-codegen plugin (codegen.ts function)', async () => {
   const options = await createOptions({ cwd });
@@ -53,5 +54,25 @@ test('Find dependencies from a graphql-codegen script config', async () => {
     ...baseCounters,
     processed: 2,
     total: 2,
+  });
+});
+
+test('Find dependencies from a graphql-codegen script config loaded from the workspace cwd', async () => {
+  const processCwd = process.cwd();
+  const options = await createOptions({ cwd: scriptConfigCwdContextCwd });
+  const { issues, counters } = await main(options);
+
+  assert.equal(process.cwd(), processCwd);
+  assert(!issues.dependencies['package.json']?.['@graphql-codegen/typescript']);
+  assert(!issues.dependencies['package.json']?.['@graphql-codegen/typescript-operations']);
+  assert(!issues.dependencies['package.json']?.['@graphql-codegen/typescript-graphql-request']);
+  assert(!issues.devDependencies['package.json']?.['@graphql-codegen/typescript']);
+  assert(!issues.devDependencies['package.json']?.['@graphql-codegen/typescript-operations']);
+  assert(!issues.devDependencies['package.json']?.['@graphql-codegen/typescript-graphql-request']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
   });
 });


### PR DESCRIPTION
## Summary

- Load JavaScript/TypeScript plugin config files with the workspace/package cwd, while restoring the original process cwd afterward.
- Keep the cwd switch scoped to plugin config loading instead of changing the generic loader API/behavior for every `load()` caller.
- Add a GraphQL Codegen regression fixture whose `--config ./src/codegen.ts` file reads package-relative config and only resolves when evaluated from the package cwd.

## Root Cause

`graphql-codegen --config ./src/codegen.ts` is discovered from the package script, so the config should be evaluated the same way that package script runs: from the workspace/package cwd. When Knip loads the config from the repo-root cwd, relative paths inside the config resolve incorrectly and plugin dependencies referenced by the loaded config can be reported as unused.

## Validation

- `node --test packages/knip/test/plugins/graphql-codegen.test.ts`
- `pnpm exec oxfmt --check packages/knip/src/util/loader.ts packages/knip/src/util/plugin.ts packages/knip/test/plugins/graphql-codegen.test.ts packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/**/*.ts packages/knip/fixtures/plugins/graphql-codegen-script-config-cwd-context/**/*.json`
- `pnpm run --dir packages/knip lint`
- `pnpm run --dir packages/knip build`
- No-cache riptech validation with the GraphQL Codegen ignore removed and the original relative dotenv path left in place: `node /Users/jakeleventhal/Documents/Codex/2026-05-22/update-my-pr-based-on-this/knip/packages/knip/src/cli.ts --directory /Users/jakeleventhal/Developer/rip-technologies --no-progress --workspace @artelo/integrations`
