### PR TITLE
Avoid caching failed plugin config loads

### DIFF
--- a/packages/knip/src/CacheConsultant.ts
+++ b/packages/knip/src/CacheConsultant.ts
@@ -9,6 +9,7 @@ export class CacheConsultant<T> {
   private cache: FileEntryCache<T> | undefined;
   getFileDescriptor: (filePath: string) => FileDescriptor<T> = () => dummyFileDescriptor;
   reconcile: () => void = () => {};
+  removeEntry: (filePath: string) => void = () => {};
 
   constructor(name: string, options: MainOptions) {
     if (!options.isCache) return;
@@ -16,6 +17,7 @@ export class CacheConsultant<T> {
     this.cache = new FileEntryCache(cacheName, options.cacheLocation);
     this.getFileDescriptor = timerify(this.cache.getFileDescriptor.bind(this.cache));
     this.reconcile = timerify(this.cache.reconcile.bind(this.cache));
+    this.removeEntry = timerify(this.cache.removeEntry.bind(this.cache));
   }
 
   getCachedFile(filePath: string): T | undefined {

--- a/packages/knip/src/WorkspaceWorker.ts
+++ b/packages/knip/src/WorkspaceWorker.ts
@@ -466,7 +466,9 @@ export class WorkspaceWorker {
           storeConfigFilePath(pluginName, toConfig(pluginName, configFilePath));
           cache.configFile = toEntry(configFilePath);
 
-          if (fd?.changed && fd.meta && !hasLoadConfigError && !seen.get(key)?.has(configFilePath)) {
+          if (hasLoadConfigError) {
+            this.cache.removeEntry(configFilePath);
+          } else if (fd?.changed && fd.meta && !seen.get(key)?.has(configFilePath)) {
             fd.meta.data = cache;
           }
 

--- a/packages/knip/src/WorkspaceWorker.ts
+++ b/packages/knip/src/WorkspaceWorker.ts
@@ -420,6 +420,7 @@ export class WorkspaceWorker {
         };
 
         const cache: CacheItem = {};
+        let hasLoadConfigError = false;
 
         const key = `${wsName}:${pluginName}`;
         if (plugin.resolveConfig && !seen.get(key)?.has(configFilePath)) {
@@ -443,6 +444,7 @@ export class WorkspaceWorker {
                 }
               } catch (error) {
                 if (!(error instanceof Error)) throw error;
+                hasLoadConfigError = true;
                 const relPath = toRelative(configFilePath, this.options.cwd);
                 const cause = formatCauseMessage(error, this.options.cwd);
                 logError(`Error loading ${relPath} (${cause})`);
@@ -464,7 +466,7 @@ export class WorkspaceWorker {
           storeConfigFilePath(pluginName, toConfig(pluginName, configFilePath));
           cache.configFile = toEntry(configFilePath);
 
-          if (fd?.changed && fd.meta && !seen.get(key)?.has(configFilePath)) {
+          if (fd?.changed && fd.meta && !hasLoadConfigError && !seen.get(key)?.has(configFilePath)) {
             fd.meta.data = cache;
           }
 

--- a/packages/knip/test/plugin-config-load-error.test.ts
+++ b/packages/knip/test/plugin-config-load-error.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { main } from '../src/index.ts';
@@ -29,19 +29,32 @@ test('Plugin config that throws on load exits zero with --no-exit-code', () => {
   assert.equal(result.status, 0);
 });
 
-test('Plugin config load errors are not cached as successful runs', () => {
+test('Plugin config load errors are not cached, and recovery is cached', () => {
   const cacheLocation = mkdtempSync(join(tmpdir(), 'knip-cache-'));
+  const fixtureCopy = mkdtempSync(join(tmpdir(), 'knip-fixture-'));
+  cpSync(cwd, fixtureCopy, { recursive: true });
 
   try {
     const command = `knip --no-progress --cache --cache-location ${cacheLocation}`;
-    const coldResult = exec(command, { cwd });
-    const warmResult = exec(command, { cwd });
 
-    assert.match(coldResult.stderr, /^ERROR: Error loading vite\.config\.ts /m);
-    assert.match(warmResult.stderr, /^ERROR: Error loading vite\.config\.ts /m);
-    assert.equal(coldResult.status, 1);
-    assert.equal(warmResult.status, 1);
+    const cold = exec(command, { cwd: fixtureCopy });
+    const warm = exec(command, { cwd: fixtureCopy });
+    assert.match(cold.stderr, /^ERROR: Error loading vite\.config\.ts /m);
+    assert.match(warm.stderr, /^ERROR: Error loading vite\.config\.ts /m);
+    assert.equal(cold.status, 1);
+    assert.equal(warm.status, 1);
+
+    writeFileSync(join(fixtureCopy, 'missing-bootstrap-output.js'), "process.stderr.write('bootstrap-loaded\\n');\n");
+
+    const recovered = exec(command, { cwd: fixtureCopy });
+    assert.match(recovered.stderr, /bootstrap-loaded/);
+    assert.doesNotMatch(recovered.stderr, /^ERROR: Error loading/m);
+
+    const cached = exec(command, { cwd: fixtureCopy });
+    assert.doesNotMatch(cached.stderr, /bootstrap-loaded/);
+    assert.doesNotMatch(cached.stderr, /^ERROR: Error loading/m);
   } finally {
     rmSync(cacheLocation, { recursive: true, force: true });
+    rmSync(fixtureCopy, { recursive: true, force: true });
   }
 });

--- a/packages/knip/test/plugin-config-load-error.test.ts
+++ b/packages/knip/test/plugin-config-load-error.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { main } from '../src/index.ts';
+import { join } from '../src/util/path.ts';
 import { createOptions } from './helpers/create-options.ts';
 import { exec } from './helpers/exec.ts';
 import { resolve } from './helpers/resolve.ts';
@@ -24,4 +27,21 @@ test('Plugin config that throws on load exits zero with --no-exit-code', () => {
   const result = exec('knip --no-progress --no-exit-code', { cwd });
   assert.match(result.stderr, /^ERROR: Error loading vite\.config\.ts /m);
   assert.equal(result.status, 0);
+});
+
+test('Plugin config load errors are not cached as successful runs', () => {
+  const cacheLocation = mkdtempSync(join(tmpdir(), 'knip-cache-'));
+
+  try {
+    const command = `knip --no-progress --cache --cache-location ${cacheLocation}`;
+    const coldResult = exec(command, { cwd });
+    const warmResult = exec(command, { cwd });
+
+    assert.match(coldResult.stderr, /^ERROR: Error loading vite\.config\.ts /m);
+    assert.match(warmResult.stderr, /^ERROR: Error loading vite\.config\.ts /m);
+    assert.equal(coldResult.status, 1);
+    assert.equal(warmResult.status, 1);
+  } finally {
+    rmSync(cacheLocation, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

- avoid writing plugin config cache entries when `resolveConfig` loading throws
- keep failed config loads retried on warm `--cache` runs instead of masking the error
- add a regression test covering cold and warm cached CLI runs

## Validation

- `pnpm --dir packages/knip build`
- `bun test test/plugin-config-load-error.test.ts` from `packages/knip`
- `pnpm --dir packages/knip lint`
- `pnpm --dir packages/knip test --smoke`
- Against rip-technologies: `rm -rf ./node_modules/.cache/knip && node /Users/jakeleventhal/.codex/worktrees/f505/knip/packages/knip/dist/cli.js --no-progress --cache`, then reran the same patched CLI with warm cache; both runs reported the `apps/artelo/sls-api/serverless.ts` and `packages/artelo/integrations/src/codegen.ts` load errors instead of the warm cache passing silently.
