### PR TITLE
Resolve extensionless .sass imports in SCSS compiler

### DIFF
--- a/packages/knip/fixtures/compilers-scss/animations.sass
+++ b/packages/knip/fixtures/compilers-scss/animations.sass
@@ -1,0 +1,5 @@
+@keyframes fade-in
+  from
+    opacity: 0
+  to
+    opacity: 1

--- a/packages/knip/fixtures/compilers-scss/breakpoints.sass
+++ b/packages/knip/fixtures/compilers-scss/breakpoints.sass
@@ -1,0 +1,2 @@
+$tablet: 768px
+$desktop: 1024px

--- a/packages/knip/fixtures/compilers-scss/indented.sass
+++ b/packages/knip/fixtures/compilers-scss/indented.sass
@@ -1,7 +1,10 @@
 @use "./mixins"
 @use './variables' as vars
+@use "./breakpoints" as bp
 @import "./legacy"
+@import "./animations"
 @forward "./utils"
 
 .indented
   color: vars.$secondary
+  max-width: bp.$tablet

--- a/packages/knip/src/compilers/scss.ts
+++ b/packages/knip/src/compilers/scss.ts
@@ -13,9 +13,14 @@ const candidates = (specifier: string): string[] => {
   const spec = specifier.startsWith('.') || isAlias(specifier) ? specifier : `./${specifier}`;
   const name = basename(spec);
   const dir = dirname(spec);
-  const base = name.endsWith('.scss') || name.endsWith('.sass') ? name : `${name}.scss`;
-  const plain = `${dir}/${base}`;
-  return name.startsWith('_') ? [plain] : [plain, `${dir}/_${base}`];
+  const hasExt = name.endsWith('.scss') || name.endsWith('.sass');
+  const bases = hasExt ? [name] : [`${name}.scss`, `${name}.sass`];
+  const out: string[] = [];
+  for (const base of bases) {
+    out.push(`${dir}/${base}`);
+    if (!name.startsWith('_')) out.push(`${dir}/_${base}`);
+  }
+  return out;
 };
 
 const compiler: CompilerSync = text => {

--- a/packages/knip/test/compilers.scss.test.ts
+++ b/packages/knip/test/compilers.scss.test.ts
@@ -17,7 +17,7 @@ test('Built-in compiler for SCSS', async () => {
     ...baseCounters,
     devDependencies: 1,
     files: 1,
-    processed: 14,
-    total: 14,
+    processed: 16,
+    total: 16,
   });
 });


### PR DESCRIPTION
Extensionless imports (`@use`/`@import`/`@forward`) now resolve to .sass and _*.sass candidates in addition to .scss, so imports like `@use "./foo"` finds also `foo.sass`. This fixes matches current [sass-lang guide syntax information](https://sass-lang.com/guide/).

Adds fixtures and test coverage.

_Disclaimer:_ The code fix was done assisted by AI tools, as informed in the commit.
