### PR TITLE
Add default ignore for .context artifacts (for Conductor)

### DIFF
--- a/packages/docs/src/content/docs/reference/configuration.md
+++ b/packages/docs/src/content/docs/reference/configuration.md
@@ -250,6 +250,9 @@ Avoid `ignore` patterns. There is almost always a better solution:
 - Use [production mode][10].
 - Other `ignore*` options.
 
+Knip ignores `.context/**` by default. This excludes AI worktree artifacts
+created by tools such as Conductor.
+
 **NOTE**: An exception to the rule: to _temporarily_ report only issues in files
 that match the negated `ignore` pattern:
 

--- a/packages/knip/fixtures/default-ignore-context/.context/conductor-artifact.ts
+++ b/packages/knip/fixtures/default-ignore-context/.context/conductor-artifact.ts
@@ -1,0 +1,1 @@
+export const conductorArtifact = true;

--- a/packages/knip/fixtures/default-ignore-context/index.ts
+++ b/packages/knip/fixtures/default-ignore-context/index.ts
@@ -1,0 +1,1 @@
+export const main = true;

--- a/packages/knip/fixtures/default-ignore-context/package.json
+++ b/packages/knip/fixtures/default-ignore-context/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/default-ignore-context"
+}

--- a/packages/knip/src/ConfigurationChief.ts
+++ b/packages/knip/src/ConfigurationChief.ts
@@ -1,6 +1,6 @@
 import picomatch from 'picomatch';
 import type { SyncCompilers } from './compilers/types.ts';
-import { DEFAULT_EXTENSIONS, ROOT_WORKSPACE_NAME } from './constants.ts';
+import { DEFAULT_EXTENSIONS, DEFAULT_IGNORE_PATTERNS, ROOT_WORKSPACE_NAME } from './constants.ts';
 import type {
   Configuration,
   IgnorePatterns,
@@ -49,7 +49,7 @@ const getDefaultWorkspaceConfig = (extensions: string[] = []) => {
 const isPluginName = (name: string): name is PluginName => pluginNames.includes(name as PluginName);
 
 const defaultConfig: Configuration = {
-  ignore: [],
+  ignore: DEFAULT_IGNORE_PATTERNS,
   ignoreBinaries: [],
   ignoreDependencies: [],
   ignoreFiles: [],
@@ -137,7 +137,7 @@ export class ConfigurationChief {
   }
 
   private normalize(rawConfig: RawConfiguration): Configuration {
-    const ignore = arrayify(rawConfig.ignore ?? defaultConfig.ignore);
+    const ignore = [...defaultConfig.ignore, ...arrayify(rawConfig.ignore)];
     const ignoreFiles = arrayify(rawConfig.ignoreFiles ?? defaultConfig.ignoreFiles);
     const ignoreBinaries = rawConfig.ignoreBinaries ?? [];
     const ignoreDependencies = rawConfig.ignoreDependencies ?? [];

--- a/packages/knip/src/IssueCollector.ts
+++ b/packages/knip/src/IssueCollector.ts
@@ -18,6 +18,7 @@ const createMatcher = (patterns: Set<string>) => {
 
 export type CollectorIssues = ReturnType<IssueCollector['getIssues']>;
 
+type IgnorePatternEntry = { pattern: string; id: string; workspaceName?: string; isTrackUnused?: boolean };
 type TrackedPattern = { hint: ConfigurationHint; isMatch: (path: string) => boolean };
 
 /**
@@ -33,8 +34,10 @@ export class IssueCollector {
   private referencedFiles = new Set<string>();
   private configurationHints: ConfigurationHints = new Map();
   private tagHints = new Set<TagHint>();
+  private defaultIgnorePatterns = new Set<string>();
   private ignorePatterns = new Set<string>();
   private ignoreFilesPatterns = new Set<string>();
+  private isDefaultMatch: (filePath: string) => boolean;
   private isMatch: (filePath: string) => boolean;
   private isFileMatch: (filePath: string) => boolean;
   private issueMatchers: Map<IssueType, (filePath: string) => boolean> = new Map();
@@ -46,6 +49,7 @@ export class IssueCollector {
     this.cwd = options.cwd;
     this.rules = options.rules;
     this.workspaceFilter = () => true;
+    this.isDefaultMatch = () => false;
     this.isMatch = () => false;
     this.isFileMatch = () => false;
     this.isTrackUnusedIgnorePatterns = !options.isDisableConfigHints;
@@ -56,7 +60,7 @@ export class IssueCollector {
   }
 
   private collectIgnorePatterns(
-    entries: { pattern: string; id: string; workspaceName?: string }[],
+    entries: IgnorePatternEntry[],
     patterns: Set<string>,
     unused: typeof this.unusedIgnorePatterns,
     type: 'ignore' | 'ignoreFiles'
@@ -64,6 +68,7 @@ export class IssueCollector {
     for (const entry of entries) {
       patterns.add(entry.pattern);
       if (!this.isTrackUnusedIgnorePatterns) continue;
+      if (entry.isTrackUnused === false) continue;
       if (entry.pattern.startsWith('!')) continue;
       if (unused.has(entry.pattern)) continue;
       unused.set(entry.pattern, {
@@ -74,11 +79,22 @@ export class IssueCollector {
     return createMatcher(patterns);
   }
 
-  addIgnorePatterns(entries: { pattern: string; id: string; workspaceName?: string }[]) {
-    this.isMatch = this.collectIgnorePatterns(entries, this.ignorePatterns, this.unusedIgnorePatterns, 'ignore');
+  addIgnorePatterns(entries: IgnorePatternEntry[]) {
+    const [defaultEntries, userEntries] = partition(entries, entry => entry.isTrackUnused === false);
+    if (defaultEntries.length > 0) {
+      this.isDefaultMatch = this.collectIgnorePatterns(
+        defaultEntries,
+        this.defaultIgnorePatterns,
+        this.unusedIgnorePatterns,
+        'ignore'
+      );
+    }
+    if (userEntries.length > 0) {
+      this.isMatch = this.collectIgnorePatterns(userEntries, this.ignorePatterns, this.unusedIgnorePatterns, 'ignore');
+    }
   }
 
-  addIgnoreFilesPatterns(entries: { pattern: string; id: string; workspaceName?: string }[]) {
+  addIgnoreFilesPatterns(entries: IgnorePatternEntry[]) {
     this.isFileMatch = this.collectIgnorePatterns(
       entries,
       this.ignoreFilesPatterns,
@@ -119,6 +135,10 @@ export class IssueCollector {
     return matcher(relative(this.cwd, filePath));
   }
 
+  private shouldIgnore(filePath: string) {
+    return this.isDefaultMatch(filePath) || this.isMatch(filePath);
+  }
+
   addFileCounts({ processed, unused }: { processed: number; unused: number }) {
     this.counters.processed += processed;
     this.counters.total += processed + unused;
@@ -128,7 +148,7 @@ export class IssueCollector {
     for (const filePath of filePaths) {
       if (!this.workspaceFilter(filePath)) continue;
       if (this.referencedFiles.has(filePath)) continue;
-      if (this.isMatch(filePath)) {
+      if (this.shouldIgnore(filePath)) {
         this.markUsedPatterns(filePath, this.unusedIgnorePatterns);
         continue;
       }
@@ -150,7 +170,7 @@ export class IssueCollector {
 
   addIssue(issue: Issue) {
     if (!this.workspaceFilter(issue.filePath)) return;
-    if (this.isMatch(issue.filePath)) {
+    if (this.shouldIgnore(issue.filePath)) {
       this.markUsedPatterns(issue.filePath, this.unusedIgnorePatterns);
       return;
     }

--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -14,6 +14,7 @@ export const KNIP_CONFIG_LOCATIONS = [
 ];
 
 export const DEFAULT_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx', '.mts', '.cts']);
+export const DEFAULT_IGNORE_PATTERNS = ['.context/**'];
 
 export const DTS_EXTENSIONS = ['.d.ts', '.d.mts', '.d.cts'];
 

--- a/packages/knip/src/graph/build.ts
+++ b/packages/knip/src/graph/build.ts
@@ -3,7 +3,7 @@ import type { CatalogCounselor } from '../CatalogCounselor.ts';
 import type { ConfigurationChief, Workspace } from '../ConfigurationChief.ts';
 import type { ConsoleStreamer } from '../ConsoleStreamer.ts';
 import { getCompilerExtensions, getIncludedCompilers, normalizeCompilerExtension } from '../compilers/index.ts';
-import { DEFAULT_EXTENSIONS, FOREIGN_FILE_EXTENSIONS, IS_DTS } from '../constants.ts';
+import { DEFAULT_EXTENSIONS, DEFAULT_IGNORE_PATTERNS, FOREIGN_FILE_EXTENSIONS, IS_DTS } from '../constants.ts';
 import type { DependencyDeputy } from '../DependencyDeputy.ts';
 import type { IssueCollector } from '../IssueCollector.ts';
 import type { ProjectPrincipal } from '../ProjectPrincipal.ts';
@@ -100,7 +100,14 @@ export async function build({
 
   deputy.setWorkspacePkgNames(chief.availableWorkspacePkgNames);
 
-  collector.addIgnorePatterns(chief.config.ignore.map(id => ({ pattern: prependDir(options.cwd, id), id })));
+  collector.addIgnorePatterns(
+    DEFAULT_IGNORE_PATTERNS.map(id => ({ pattern: prependDir(options.cwd, id), id, isTrackUnused: false }))
+  );
+  collector.addIgnorePatterns(
+    chief.config.ignore
+      .filter(id => !DEFAULT_IGNORE_PATTERNS.includes(id))
+      .map(id => ({ pattern: prependDir(options.cwd, id), id }))
+  );
   collector.addIgnoreFilesPatterns(chief.config.ignoreFiles.map(id => ({ pattern: prependDir(options.cwd, id), id })));
 
   if (options.configFilePath) {

--- a/packages/knip/test/default-ignore-context.test.ts
+++ b/packages/knip/test/default-ignore-context.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../src/index.ts';
+import baseCounters from './helpers/baseCounters.ts';
+import { createOptions } from './helpers/create-options.ts';
+import { resolve } from './helpers/resolve.ts';
+
+test('Ignore Conductor .context artifacts by default', async () => {
+  const cwd = resolve('fixtures/default-ignore-context');
+  const options = await createOptions({ cwd });
+  const { configurationHints, counters, issues } = await main(options);
+
+  assert.deepEqual(configurationHints, []);
+  assert.deepEqual(issues.files, {});
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 2,
+  });
+});


### PR DESCRIPTION
## What changed

- Adds `.context/**` as a built-in default ignore pattern so Conductor AI worktree artifacts are suppressed without user configuration.

- Keeps built-in ignores out of unused ignore-pattern configuration hints and preserves negated user ignore behavior by evaluating default ignores separately.

- Adds a regression fixture/test and documents the default in the configuration reference.
## Validation
- `bun test packages/knip/test/default-ignore-context.test.ts packages/knip/test/ignore-negated.test.ts packages/knip/test/ignore-patterns.test.ts`
- `corepack pnpm exec oxfmt --check packages/knip/src/constants.ts packages/knip/src/ConfigurationChief.ts packages/knip/src/IssueCollector.ts packages/knip/src/graph/build.ts packages/knip/test/default-ignore-context.test.ts packages/docs/src/content/docs/reference/configuration.md`
- `corepack pnpm exec oxlint packages/knip/src/constants.ts packages/knip/src/ConfigurationChief.ts packages/knip/src/IssueCollector.ts packages/knip/src/graph/build.ts packages/knip/test/default-ignore-context.test.ts`

- `corepack pnpm --dir packages/knip build`

- `corepack pnpm --dir packages/knip test`