### PR TITLE
fix(tsdown): handle template literal entries in config

### DIFF
--- a/packages/knip/fixtures/plugins/tsdown/tsdown.config-4.ts
+++ b/packages/knip/fixtures/plugins/tsdown/tsdown.config-4.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['entry-4.ts'],
+  entry: `entry-4.ts`,
 });

--- a/packages/knip/src/typescript/ast-helpers.ts
+++ b/packages/knip/src/typescript/ast-helpers.ts
@@ -53,15 +53,15 @@ export const getPropertyValues = (node: any, propertyName: string) => {
     if (name !== propertyName) continue;
     const init = prop.value;
     if (isStringLiteral(init)) {
-      values.add(init.value);
+      values.add(getStringValue(init)!);
     } else if (init?.type === 'ArrayExpression') {
       for (const el of init.elements ?? []) {
-        if (isStringLiteral(el)) values.add(el.value);
+        if (isStringLiteral(el)) values.add(getStringValue(el)!);
       }
     } else if (init?.type === 'ObjectExpression') {
       for (const p of init.properties ?? []) {
         if (p.type === 'Property' && isStringLiteral(p.value)) {
-          values.add(p.value.value);
+          values.add(getStringValue(p.value)!);
         }
       }
     }


### PR DESCRIPTION
## Summary

`getPropertyValues` in `ast-helpers.ts` uses `init.value` to read string content from AST nodes. However, `isStringLiteral()` also accepts `TemplateLiteral` nodes (backtick strings without expressions), which don't have a `.value` property -- their content lives in `quasis[0].value.cooked`. This causes `undefined` to propagate into the input set, crashing `WorkspaceWorker` when it calls `input.specifier.startsWith('!')`.

The fix replaces the three `.value` accesses in `getPropertyValues` with `getStringValue()`, which is already imported in the same file and handles `TemplateLiteral` correctly.

## Verification

- Modified the existing `tsdown.config-4.ts` fixture to use a backtick template literal instead of an array of regular strings, exercising the exact crash path.
- `bun test test/plugins/tsdown.test.ts` -- 2 pass, 0 fail.
- Related plugin tests (tsup, rollup, rolldown, rslib) -- all pass.
- Diff: 2 files changed, 4 insertions, 4 deletions.

Fixes #1776