### PR TITLE
Add @knip/mcp npm bugs metadata

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -14,6 +14,9 @@
     "url": "git+https://github.com/webpro-nl/knip.git",
     "directory": "packages/mcp-server"
   },
+  "bugs": {
+    "url": "https://github.com/webpro-nl/knip/issues"
+  },
   "bin": {
     "knip-mcp": "./src/cli.js"
   },


### PR DESCRIPTION
## What changed

Adds the standard npm `bugs.url` metadata field to the `@knip/mcp` package.

## Why

The published `@knip/mcp@0.0.31` package currently exposes `repository` metadata, but `npm view @knip/mcp@0.0.31 bugs --json` returns no issue tracker metadata. Adding `bugs.url` gives npm users and package tooling a direct issue-reporting link.

## Verification

```sh
npm view @knip/mcp@0.0.31 name version repository bugs --json
node -e "const p=require('./packages/mcp-server/package.json'); if(!p.repository?.url||!p.bugs?.url) process.exit(1); console.log(p.repository.url); console.log(p.bugs.url);"
npm pack --dry-run --ignore-scripts ./packages/mcp-server
git diff --check
```
