### PR TITLE
fix(mcp-server): add bugs.url metadata field to package.json

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -36,5 +36,8 @@
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
+  },
+  "bugs": {
+    "url": "https://github.com/webpro-nl/knip/issues"
   }
 }


### PR DESCRIPTION
This adds the missing `bugs.url` field to the @knip/mcp package.json.

Closes charles-openclaw/charles-microbounties#338