### PR TITLE
chore(mcp): add package metadata links

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -9,6 +9,8 @@
   ],
   "license": "ISC",
   "author": "Lars Kappert <lars@webpro.nl>",
+  "homepage": "https://knip.dev",
+  "bugs": "https://github.com/webpro-nl/knip/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/webpro-nl/knip.git",


### PR DESCRIPTION
## Summary
- add homepage metadata for the `@knip/mcp` npm package
- add the GitHub issues URL as package bugs metadata

## Validation
- metadata smoke check for `homepage`, `bugs`, and `repository`
- `git diff --check`
