### PR TITLE
fix(capacitor): detect iOS platform with Swift Package Manager

### DIFF
--- a/packages/knip/fixtures/plugins/capacitor-spm/capacitor.config.ts
+++ b/packages/knip/fixtures/plugins/capacitor-spm/capacitor.config.ts
@@ -1,0 +1,9 @@
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.company.name',
+  appName: 'name',
+  plugins: {},
+};
+
+export default config;

--- a/packages/knip/fixtures/plugins/capacitor-spm/ios/App/CapApp-SPM/Package.swift
+++ b/packages/knip/fixtures/plugins/capacitor-spm/ios/App/CapApp-SPM/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands
+let package = Package(
+    name: "CapApp-SPM",
+    platforms: [.iOS(.v14)],
+    products: [
+        .library(
+            name: "CapApp-SPM",
+            targets: ["CapApp-SPM"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "6.0.0")
+    ],
+    targets: [
+        .target(
+            name: "CapApp-SPM",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm")
+            ]
+        )
+    ]
+)

--- a/packages/knip/fixtures/plugins/capacitor-spm/package.json
+++ b/packages/knip/fixtures/plugins/capacitor-spm/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@plugins/capacitor-spm",
+  "devDependencies": {
+    "@capacitor/cli": "*"
+  }
+}

--- a/packages/knip/src/plugins/capacitor/index.ts
+++ b/packages/knip/src/plugins/capacitor/index.ts
@@ -17,7 +17,8 @@ const config = ['capacitor.config.{json,ts}'];
 const resolveConfig: ResolveConfig<CapacitorConfig> = async (config, { configFileDir }) => {
   const plugins = config.includePlugins ?? [];
   const android = isFile(configFileDir, 'android/capacitor.settings.gradle') ? ['@capacitor/android'] : [];
-  const ios = isFile(configFileDir, 'ios/App/Podfile') ? ['@capacitor/ios'] : [];
+  const hasIOS = isFile(configFileDir, 'ios/App/Podfile') || isFile(configFileDir, 'ios/App/CapApp-SPM/Package.swift');
+  const ios = hasIOS ? ['@capacitor/ios'] : [];
 
   return [...plugins, ...android, ...ios].map(id => toDependency(id));
 };

--- a/packages/knip/test/plugins/capacitor-spm.test.ts
+++ b/packages/knip/test/plugins/capacitor-spm.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/capacitor-spm');
+
+test('Find dependencies with the Capacitor plugin (Swift Package Manager)', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.unlisted['capacitor.config.ts']['@capacitor/ios']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    unlisted: 1,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
Fixes #1785. 

Capacitor 6+ supports Swift Package Manager (SPM) for the iOS platform, which generates `ios/App/CapApp-SPM/Package.swift` instead of a CocoaPods `Podfile`. The plugin only checked for the `Podfile`, so SPM-based projects had `@capacitor/ios` falsely reported as an unused dependency. 

Note: I authored this with Claude, but manually verified and reviewed. If you'd like a different implementation, please let me know and I'd be happy to take another look.