### PR TITLE
Don't disable configuration hints in workspace-scoped runs

### DIFF
--- a/packages/knip/fixtures/workspaces/config-hints/knip.json
+++ b/packages/knip/fixtures/workspaces/config-hints/knip.json
@@ -1,0 +1,11 @@
+{
+  "ignoreDependencies": ["unused-ignore-root"],
+  "workspaces": {
+    "packages/a": {
+      "ignoreDependencies": ["unused-ignore-a"]
+    },
+    "packages/b": {
+      "ignoreDependencies": ["unused-ignore-b"]
+    }
+  }
+}

--- a/packages/knip/fixtures/workspaces/config-hints/knip.json
+++ b/packages/knip/fixtures/workspaces/config-hints/knip.json
@@ -1,5 +1,5 @@
 {
-  "ignoreDependencies": ["unused-ignore-root"],
+  "ignoreDependencies": ["unused-ignore-root", "used-by-a"],
   "workspaces": {
     "packages/a": {
       "ignoreDependencies": ["unused-ignore-a"]

--- a/packages/knip/fixtures/workspaces/config-hints/package.json
+++ b/packages/knip/fixtures/workspaces/config-hints/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixtures/workspaces-config-hints",
+  "version": "*",
+  "workspaces": ["packages/*"]
+}

--- a/packages/knip/fixtures/workspaces/config-hints/packages/a/index.js
+++ b/packages/knip/fixtures/workspaces/config-hints/packages/a/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/knip/fixtures/workspaces/config-hints/packages/a/package.json
+++ b/packages/knip/fixtures/workspaces/config-hints/packages/a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixtures/workspaces-config-hints-a",
+  "version": "*"
+}

--- a/packages/knip/fixtures/workspaces/config-hints/packages/a/package.json
+++ b/packages/knip/fixtures/workspaces/config-hints/packages/a/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@fixtures/workspaces-config-hints-a",
-  "version": "*"
+  "version": "*",
+  "dependencies": {
+    "used-by-a": "*"
+  }
 }

--- a/packages/knip/fixtures/workspaces/config-hints/packages/b/index.js
+++ b/packages/knip/fixtures/workspaces/config-hints/packages/b/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/knip/fixtures/workspaces/config-hints/packages/b/package.json
+++ b/packages/knip/fixtures/workspaces/config-hints/packages/b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixtures/workspaces-config-hints-b",
+  "version": "*"
+}

--- a/packages/knip/src/IssueCollector.ts
+++ b/packages/knip/src/IssueCollector.ts
@@ -177,8 +177,11 @@ export class IssueCollector {
   }
 
   addConfigurationHint(issue: ConfigurationHint) {
-    if (this.selectedWorkspaces && !this.selectedWorkspaces.has(issue.workspaceName ?? ROOT_WORKSPACE_NAME)) return;
-    
+    if (this.selectedWorkspaces) {
+      const workspaceName = issue.workspaceName ?? ROOT_WORKSPACE_NAME;
+      if (workspaceName === ROOT_WORKSPACE_NAME || !this.selectedWorkspaces.has(workspaceName)) return;
+    }
+
     const key = `${issue.workspaceName}::${issue.type}::${issue.identifier}`;
     if (!this.configurationHints.has(key)) this.configurationHints.set(key, issue);
   }

--- a/packages/knip/src/IssueCollector.ts
+++ b/packages/knip/src/IssueCollector.ts
@@ -1,4 +1,5 @@
 import picomatch from 'picomatch';
+import { ROOT_WORKSPACE_NAME } from './constants.ts';
 import type { IgnoreIssues } from './types/config.ts';
 import type { ConfigurationHint, ConfigurationHints, Issue, IssueType, Rules, TagHint } from './types/issues.ts';
 import { partition } from './util/array.ts';
@@ -42,6 +43,7 @@ export class IssueCollector {
   private isTrackUnusedIgnorePatterns: boolean;
   private unusedIgnorePatterns: Map<string, TrackedPattern> = new Map();
   private unusedIgnoreFilesPatterns: Map<string, TrackedPattern> = new Map();
+  private selectedWorkspaces: Set<string> | undefined;
 
   constructor(options: MainOptions) {
     this.cwd = options.cwd;
@@ -54,6 +56,10 @@ export class IssueCollector {
 
   setWorkspaceFilter(workspaceFilePathFilter: WorkspaceFilePathFilter | undefined) {
     if (workspaceFilePathFilter) this.workspaceFilter = workspaceFilePathFilter;
+  }
+
+  setSelectedWorkspaces(selectedWorkspaces: Set<string> | undefined) {
+    this.selectedWorkspaces = selectedWorkspaces;
   }
 
   private collectIgnorePatterns(
@@ -171,6 +177,8 @@ export class IssueCollector {
   }
 
   addConfigurationHint(issue: ConfigurationHint) {
+    if (this.selectedWorkspaces && !this.selectedWorkspaces.has(issue.workspaceName ?? ROOT_WORKSPACE_NAME)) return;
+    
     const key = `${issue.workspaceName}::${issue.type}::${issue.identifier}`;
     if (!this.configurationHints.has(key)) this.configurationHints.set(key, issue);
   }

--- a/packages/knip/src/run.ts
+++ b/packages/knip/src/run.ts
@@ -43,6 +43,7 @@ export const run = async (options: MainOptions) => {
   const principal = new ProjectPrincipal(options, toSourceFilePath, findWorkspaceManifestImports);
 
   collector.setWorkspaceFilter(chief.workspaceFilePathFilter);
+  collector.setSelectedWorkspaces(chief.selectedWorkspaces);
   collector.setIgnoreIssues(chief.getIgnoreIssues());
 
   debugLogObject('*', 'Included workspaces', () => workspaces.map(w => w.pkgName));

--- a/packages/knip/src/util/create-options.ts
+++ b/packages/knip/src/util/create-options.ts
@@ -138,7 +138,7 @@ export const createOptions = async (options: CreateOptions) => {
     includedIssueTypes,
     isCache: args.cache ?? false,
     isDebug,
-    isDisableConfigHints: args['no-config-hints'] || isProduction || Boolean(workspace),
+    isDisableConfigHints: args['no-config-hints'] || isProduction,
     isDisableTagHints: Boolean(args['no-tag-hints']),
     isFix: args.fix ?? options.isFix ?? isFixFiles ?? fixTypes.length > 0,
     isFixCatalog: fixTypes.length === 0 || fixTypes.includes('catalog'),

--- a/packages/knip/test/workspaces/config-hints.test.ts
+++ b/packages/knip/test/workspaces/config-hints.test.ts
@@ -39,11 +39,9 @@ test('Report config hints for multiple selected workspaces (--workspace)', async
   ]);
 });
 
-test('Report config hints for the selected root workspace only (--workspace .)', async () => {
+test('Do not report root config hints in scoped runs (--workspace .)', async () => {
   const options = await createOptions({ cwd, workspace: '.' });
   const { configurationHints } = await main(options);
 
-  assert.deepEqual(configurationHints, [
-    { type: 'ignoreDependencies', workspaceName: '.', identifier: 'unused-ignore-root' },
-  ]);
+  assert.deepEqual(configurationHints, []);
 });

--- a/packages/knip/test/workspaces/config-hints.test.ts
+++ b/packages/knip/test/workspaces/config-hints.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/workspaces/config-hints');
+
+const byIdentifier = (a: { identifier: string | RegExp }, b: { identifier: string | RegExp }) =>
+  String(a.identifier).localeCompare(String(b.identifier));
+
+test('Report config hints for all workspaces', async () => {
+  const options = await createOptions({ cwd });
+  const { configurationHints } = await main(options);
+
+  assert.deepEqual(configurationHints.sort(byIdentifier), [
+    { type: 'ignoreDependencies', workspaceName: 'packages/a', identifier: 'unused-ignore-a' },
+    { type: 'ignoreDependencies', workspaceName: 'packages/b', identifier: 'unused-ignore-b' },
+    { type: 'ignoreDependencies', workspaceName: '.', identifier: 'unused-ignore-root' },
+  ]);
+});
+
+test('Report config hints for the selected workspace only (--workspace)', async () => {
+  const options = await createOptions({ cwd, workspace: 'packages/a' });
+  const { configurationHints } = await main(options);
+
+  assert.deepEqual(configurationHints, [
+    { type: 'ignoreDependencies', workspaceName: 'packages/a', identifier: 'unused-ignore-a' },
+  ]);
+});
+
+test('Report config hints for multiple selected workspaces (--workspace)', async () => {
+  const options = await createOptions({ cwd, workspace: ['packages/a', 'packages/b'] });
+  const { configurationHints } = await main(options);
+
+  assert.deepEqual(configurationHints.sort(byIdentifier), [
+    { type: 'ignoreDependencies', workspaceName: 'packages/a', identifier: 'unused-ignore-a' },
+    { type: 'ignoreDependencies', workspaceName: 'packages/b', identifier: 'unused-ignore-b' },
+  ]);
+});
+
+test('Report config hints for the selected root workspace only (--workspace .)', async () => {
+  const options = await createOptions({ cwd, workspace: '.' });
+  const { configurationHints } = await main(options);
+
+  assert.deepEqual(configurationHints, [
+    { type: 'ignoreDependencies', workspaceName: '.', identifier: 'unused-ignore-root' },
+  ]);
+});


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

- fixes: #1790 

`--workspace` unconditionally disables configuration hints:

```ts
// src/util/create-options.ts
isDisableConfigHints: args['no-config-hints'] || isProduction || Boolean(workspace),
```

So `--treat-config-hints-as-errors` is a silent no-op in workspace-scoped runs — in monorepo CI that lints only changed workspaces, stale `ignoreDependencies` entries can never fail CI.

This PR filters hints to the selected workspaces instead of disabling them, mirroring how issues are filtered. Hints without a `workspaceName` are treated as root workspace hints.


`--no-config-hints` and production mode are unchanged. Tests added in `test/workspaces/config-hints.test.ts`. 