### PR TITLE
Use selected tsconfig paths for module resolution

### DIFF
--- a/packages/knip/fixtures/resolution/tsconfig-cli-paths/package.json
+++ b/packages/knip/fixtures/resolution/tsconfig-cli-paths/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixtures/tsconfig-cli-paths",
+  "knip": {
+    "entry": ["src/main.ts"],
+    "project": ["src/**/*.ts"]
+  }
+}

--- a/packages/knip/fixtures/resolution/tsconfig-cli-paths/src/main.ts
+++ b/packages/knip/fixtures/resolution/tsconfig-cli-paths/src/main.ts
@@ -1,0 +1,3 @@
+import { used } from '@app/used';
+
+used();

--- a/packages/knip/fixtures/resolution/tsconfig-cli-paths/src/unused.ts
+++ b/packages/knip/fixtures/resolution/tsconfig-cli-paths/src/unused.ts
@@ -1,0 +1,1 @@
+export const unused = () => 'unused';

--- a/packages/knip/fixtures/resolution/tsconfig-cli-paths/src/used.ts
+++ b/packages/knip/fixtures/resolution/tsconfig-cli-paths/src/used.ts
@@ -1,0 +1,1 @@
+export const used = () => 'used';

--- a/packages/knip/fixtures/resolution/tsconfig-cli-paths/tsconfig.app.json
+++ b/packages/knip/fixtures/resolution/tsconfig-cli-paths/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@app/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/knip/fixtures/resolution/tsconfig-cli-paths/tsconfig.json
+++ b/packages/knip/fixtures/resolution/tsconfig-cli-paths/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "strict": true
+  }
+}

--- a/packages/knip/src/graph/build.ts
+++ b/packages/knip/src/graph/build.ts
@@ -200,6 +200,7 @@ export async function build({
 
     for (const dep of getManifestImportDependencies(manifest)) deputy.addReferencedDependency(name, dep);
 
+    principal.addPaths(compilerOptions.paths, compilerOptions.pathsBasePath ?? dir, dir);
     principal.addPaths(config.paths, dir, dir);
     principal.addRootDirs(compilerOptions.rootDirs, dir);
 

--- a/packages/knip/test/resolution/tsconfig-cli-paths.test.ts
+++ b/packages/knip/test/resolution/tsconfig-cli-paths.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/resolution/tsconfig-cli-paths');
+
+test('Resolve modules using paths from the selected tsconfig file', async () => {
+  const options = await createOptions({ cwd, args: { include: ['files'], tsConfig: 'tsconfig.app.json' } });
+  const { issues } = await main(options);
+
+  assert('src/unused.ts' in issues.files);
+  assert(!('src/used.ts' in issues.files));
+  assert.deepEqual(Object.keys(issues.files), ['src/unused.ts']);
+});


### PR DESCRIPTION
Fixes #1794.

This restores v5 behavior for `--tsConfig <file>` by adding `compilerOptions.paths` from the selected tsconfig to Knip's module resolver path mappings.

Also adds a regression fixture where:

- `tsconfig.json` has no paths
- `tsconfig.app.json` defines `@app/*`
- Knip is run with `--tsConfig tsconfig.app.json`
- only the truly unused file should be reported

Validation run locally:

```sh
node --test test/resolution/module-resolution-tsconfig-paths.test.ts test/resolution/tsconfig-paths-extends.test.ts test/resolution/tsconfig-nested-paths.test.ts test/resolution/tsconfig-cli-paths.test.ts
pnpm --dir packages/knip build
pnpm --dir packages/knip lint
pnpm exec oxfmt -c .oxfmtrc.json --ignore-path .prettierignore --check packages/knip/src/graph/build.ts packages/knip/test/resolution/tsconfig-cli-paths.test.ts
pnpm --dir packages/knip test --runtime=node --smoke
```
