### PR TITLE
Detect coverage provider from bare `vitest --coverage` flag

### DIFF
--- a/packages/knip/fixtures/plugins/vitest-coverage-flag-istanbul/package.json
+++ b/packages/knip/fixtures/plugins/vitest-coverage-flag-istanbul/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "@plugins/vitest-coverage-flag",
+  "name": "@plugins/vitest-coverage-flag-istanbul",
   "scripts": {
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "vitest": "*",
-    "@vitest/coverage-v8": "*",
     "@vitest/coverage-istanbul": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/vitest-coverage-flag-istanbul/vitest.config.ts
+++ b/packages/knip/fixtures/plugins/vitest-coverage-flag-istanbul/vitest.config.ts
@@ -1,0 +1,7 @@
+export default {
+  test: {
+    coverage: {
+      provider: 'istanbul',
+    },
+  },
+};

--- a/packages/knip/fixtures/plugins/vitest-coverage-flag/package.json
+++ b/packages/knip/fixtures/plugins/vitest-coverage-flag/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@plugins/vitest-coverage-flag",
+  "scripts": {
+    "coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/knip/fixtures/plugins/vitest-coverage-flag/vitest.config.ts
+++ b/packages/knip/fixtures/plugins/vitest-coverage-flag/vitest.config.ts
@@ -1,0 +1,3 @@
+export default {
+  test: {},
+};

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -184,9 +184,10 @@ const args: Args = {
   resolveInputs: (parsed: ParsedArgs) => {
     const inputs: Input[] = [];
     if (parsed['ui']) inputs.push(toDependency('@vitest/ui', { optional: true }));
-    if (parsed['coverage']) {
-      const provider = typeof parsed['coverage'] === 'object' ? (parsed['coverage'].provider ?? 'v8') : 'v8';
-      inputs.push(toDependency(`@vitest/coverage-${provider}`));
+    if (typeof parsed['coverage'] === 'object' && parsed['coverage'].provider) {
+      inputs.push(toDependency(`@vitest/coverage-${parsed['coverage'].provider}`));
+    } else if (parsed['coverage']) {
+      inputs.push(toDependency('@vitest/coverage-v8', { optional: true }));
     }
     if (parsed['reporter']) {
       for (const reporter of getExternalReporters([parsed['reporter']].flat())) {

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -184,8 +184,9 @@ const args: Args = {
   resolveInputs: (parsed: ParsedArgs) => {
     const inputs: Input[] = [];
     if (parsed['ui']) inputs.push(toDependency('@vitest/ui', { optional: true }));
-    if (typeof parsed['coverage'] === 'object' && parsed['coverage'].provider) {
-      inputs.push(toDependency(`@vitest/coverage-${parsed['coverage'].provider}`));
+    if (parsed['coverage']) {
+      const provider = typeof parsed['coverage'] === 'object' ? (parsed['coverage'].provider ?? 'v8') : 'v8';
+      inputs.push(toDependency(`@vitest/coverage-${provider}`));
     }
     if (parsed['reporter']) {
       for (const reporter of getExternalReporters([parsed['reporter']].flat())) {

--- a/packages/knip/test/plugins/vitest-coverage-flag.test.ts
+++ b/packages/knip/test/plugins/vitest-coverage-flag.test.ts
@@ -4,11 +4,21 @@ import { main } from '../../src/index.ts';
 import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
-const cwd = resolve('fixtures/plugins/vitest-coverage-flag');
-
-test('Find the coverage provider from the bare --coverage flag', async () => {
+test('Use the default v8 provider for a bare --coverage flag, not a stray listed provider', async () => {
+  const cwd = resolve('fixtures/plugins/vitest-coverage-flag');
   const options = await createOptions({ cwd });
   const { issues } = await main(options);
 
-  assert(issues.unlisted['package.json']['@vitest/coverage-v8']);
+  assert(!issues.devDependencies['package.json']?.['@vitest/coverage-v8']);
+  assert(!issues.unlisted['package.json']?.['@vitest/coverage-v8']);
+  assert(issues.devDependencies['package.json']['@vitest/coverage-istanbul']);
+});
+
+test('Do not assume v8 when another provider is configured (--coverage)', async () => {
+  const cwd = resolve('fixtures/plugins/vitest-coverage-flag-istanbul');
+  const options = await createOptions({ cwd });
+  const { issues } = await main(options);
+
+  assert(!issues.unlisted['package.json']?.['@vitest/coverage-v8']);
+  assert(!issues.devDependencies['package.json']?.['@vitest/coverage-istanbul']);
 });

--- a/packages/knip/test/plugins/vitest-coverage-flag.test.ts
+++ b/packages/knip/test/plugins/vitest-coverage-flag.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/vitest-coverage-flag');
+
+test('Find the coverage provider from the bare --coverage flag', async () => {
+  const options = await createOptions({ cwd });
+  const { issues } = await main(options);
+
+  assert(issues.unlisted['package.json']['@vitest/coverage-v8']);
+});

--- a/packages/knip/test/plugins/vitest-npm-script.test.ts
+++ b/packages/knip/test/plugins/vitest-npm-script.test.ts
@@ -13,14 +13,13 @@ test('Find dependencies with the Vitest plugin', async () => {
 
   assert(issues.devDependencies['package.json']['vitest']);
   assert(issues.unlisted['vitest.config.ts']['@vitest/coverage-v8']);
-  assert(issues.unlisted['package.json']['@vitest/coverage-v8']);
   assert(issues.binaries['package.json']['vitest']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 1,
     devDependencies: 1,
-    unlisted: 2,
+    unlisted: 1,
     processed: 1,
     total: 1,
   });

--- a/packages/knip/test/plugins/vitest-npm-script.test.ts
+++ b/packages/knip/test/plugins/vitest-npm-script.test.ts
@@ -13,13 +13,14 @@ test('Find dependencies with the Vitest plugin', async () => {
 
   assert(issues.devDependencies['package.json']['vitest']);
   assert(issues.unlisted['vitest.config.ts']['@vitest/coverage-v8']);
+  assert(issues.unlisted['package.json']['@vitest/coverage-v8']);
   assert(issues.binaries['package.json']['vitest']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 1,
     devDependencies: 1,
-    unlisted: 1,
+    unlisted: 2,
     processed: 1,
     total: 1,
   });


### PR DESCRIPTION
- fixes #1799 

### Description

The Vitest plugin didn't recognize `@vitest/coverage-*` as used when coverage was enabled via the bare `--coverage` flag (e.g. `"test": "vitest run --coverage"`). The arg resolver only handled the provider as an object (`--coverage.provider=v8`):

```ts
if (typeof parsed['coverage'] === 'object' && parsed['coverage'].provider) {
  inputs.push(toDependency(`@vitest/coverage-${parsed['coverage'].provider}`));
}
```

For a plain `--coverage`, `parsed.coverage` is `true`, so it was skipped and `@vitest/coverage-v8` was wrongly reported as an unused devDependency.

### Fix

Detect `@vitest/coverage-v8` when `vitest --coverage` is provided.