### PR TITLE
Fix false positive for Vitest mocks

### DIFF
--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -20,7 +20,7 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 
 const config = ['vitest.config.{js,mjs,ts,cjs,mts,cts}', 'vitest.{workspace,projects}.{js,mjs,ts,cjs,mts,cts,json}'];
 
-const mocks = ['**/__mocks__/**/*.[jt]s?(x)'];
+const mocks = ['**/__mocks__/**/*.?(c|m)[jt]s?(x)'];
 
 const entry = ['**/*.{bench,test,test-d,spec,spec-d}.?(c|m)[jt]s?(x)', ...mocks];
 


### PR DESCRIPTION
Vitest mocks may use the `cjs`/`mjs`/`cts`/`mts` file extension.