### PR TITLE
fix: enable TypeScript plugin when a tsconfig.json is present (resolv…

### DIFF
--- a/packages/knip/fixtures/plugins/typescript-extends-package/package.json
+++ b/packages/knip/fixtures/plugins/typescript-extends-package/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@plugins/typescript-extends-package",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/node_modules/@plugins/typescript-extends-package__config/base.json
+++ b/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/node_modules/@plugins/typescript-extends-package__config/base.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  }
+}

--- a/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/node_modules/@plugins/typescript-extends-package__config/package.json
+++ b/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/node_modules/@plugins/typescript-extends-package__config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@plugins/typescript-extends-package__config",
+  "files": [
+    "base.json"
+  ]
+}

--- a/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/package.json
+++ b/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@plugins/typescript-extends-package__app",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "@plugins/typescript-extends-package__config": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/src/index.ts
+++ b/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/src/index.ts
@@ -1,0 +1,1 @@
+export const greeting = 'hello';

--- a/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/tsconfig.json
+++ b/packages/knip/fixtures/plugins/typescript-extends-package/packages/app/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@plugins/typescript-extends-package__config/base.json",
+  "include": [
+    "src"
+  ]
+}

--- a/packages/knip/fixtures/plugins/typescript-extends-package/packages/typescript-config/base.json
+++ b/packages/knip/fixtures/plugins/typescript-extends-package/packages/typescript-config/base.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  }
+}

--- a/packages/knip/fixtures/plugins/typescript-extends-package/packages/typescript-config/package.json
+++ b/packages/knip/fixtures/plugins/typescript-extends-package/packages/typescript-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@plugins/typescript-extends-package__config",
+  "files": [
+    "base.json"
+  ]
+}

--- a/packages/knip/src/plugins/typescript/index.ts
+++ b/packages/knip/src/plugins/typescript/index.ts
@@ -2,6 +2,7 @@ import type { ConfigArg } from '../../types/args.ts';
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
 import type { TsConfigJson } from '../../types/tsconfig-json.ts';
 import { compact } from '../../util/array.ts';
+import { isFile } from '../../util/fs.ts';
 import { toAlias, toConfig, toDeferResolve, toProductionDependency } from '../../util/input.ts';
 import { dirname, join } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
@@ -12,7 +13,8 @@ const title = 'TypeScript';
 
 const enablers = ['typescript', '@typescript/native-preview'];
 
-const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+const isEnabled: IsPluginEnabled = ({ cwd, dependencies }) =>
+  hasDependency(dependencies, enablers) || isFile(cwd, 'tsconfig.json');
 
 const config = ['tsconfig.json'];
 

--- a/packages/knip/test/plugins/moonrepo.test.ts
+++ b/packages/knip/test/plugins/moonrepo.test.ts
@@ -25,10 +25,13 @@ test('Find dependencies with the moonrepo plugin', async () => {
 
   assert('libs/b/server/server.ts' in issues.files);
 
+  assert(issues.unlisted['tsconfig.json']['@tsconfig/node20']);
+
   assert.deepEqual(counters, {
     ...baseCounters,
     files: 1,
     devDependencies: 4,
+    unlisted: 1,
     binaries: 6,
     processed: 3,
     total: 3,

--- a/packages/knip/test/plugins/remix.test.ts
+++ b/packages/knip/test/plugins/remix.test.ts
@@ -14,6 +14,7 @@ test('Find dependencies with the Remix plugin', async () => {
   assert(issues.devDependencies['package.json']['npm-run-all']);
 
   assert(issues.unresolved['app/root.tsx']['./session.server']);
+  assert(issues.unresolved['tsconfig.json']['vitest/globals']);
 
   assert(issues.unlisted['package.json']['dotenv']);
   assert(issues.binaries['package.json']['run-s']);
@@ -43,7 +44,7 @@ test('Find dependencies with the Remix plugin', async () => {
     devDependencies: 1,
     unlisted: 12,
     binaries: 5,
-    unresolved: 1,
+    unresolved: 2,
     processed: 8,
     total: 8,
   });

--- a/packages/knip/test/plugins/typescript-extends-package.test.ts
+++ b/packages/knip/test/plugins/typescript-extends-package.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/typescript-extends-package');
+
+test('Credit a tsconfig extends package without a typescript dependency', async () => {
+  const options = await createOptions({ cwd });
+  const { issues } = await main(options);
+
+  assert(!issues.devDependencies['packages/app/package.json']?.['@plugins/typescript-extends-package__config']);
+});


### PR DESCRIPTION
Summary
When a workspace's tsconfig.json extends a package by subpath (e.g. "extends": "@repo/typescript-config/base.json"), knip reports that package as an "Unused devDependency", even though the tsconfig genuinely uses it.

The TypeScript plugin is what credits the extended package as a used dependency (via resolveConfig), but it only runs when typescript (or @typescript/native-preview) is a declared dependency. If a workspace has a tsconfig.json but no direct typescript dependency, and no ancestor provides one, the plugin stays off, the extends chain is never parsed for dependencies, and the config package gets flagged. Note that knip's core already resolves the extends chain (via get-tsconfig) to merge compilerOptions, so it reads the package's file without ever crediting it.

Fix
Enable the TypeScript plugin when a tsconfig.json is present, not only when typescript is a dependency:

const isEnabled: IsPluginEnabled = ({ cwd, dependencies }) =>
  hasDependency(dependencies, enablers) || isFile(cwd, 'tsconfig.json');

This follows the existing pnpm and yarn plugins, which enable on lockfile presence (isFile(cwd, 'yarn.lock')).

Test plan
Added fixture fixtures/plugins/typescript-extends-package (a consumer that extends a workspace config package by subpath, with no typescript dependency) and test/plugins/typescript-extends-package.test.ts. It fails before the fix and passes after.
Updated the moonrepo and remix plugin test expectations. With the plugin now enabled, knip correctly surfaces an extended-but-undeclared @tsconfig/node20 (unlisted) and a compilerOptions.types entry vitest/globals (unresolved).
Full smoke suite shows no new regressions.