### PR TITLE
Report stale workspaces configuration keys as configuration hints

### DIFF
--- a/packages/docs/src/content/docs/reference/configuration-hints.md
+++ b/packages/docs/src/content/docs/reference/configuration-hints.md
@@ -97,6 +97,17 @@ Remove, or move unused top-level project to one of "workspaces"
 }
 ```
 
+## Stale workspace configuration
+
+A key in the `workspaces` configuration matches no workspace in the project, for
+instance after the workspace was removed or renamed.
+
+```
+Remove from workspaces
+```
+
+**Solution**: Remove the stale key from `workspaces`, or correct its path.
+
 ## Unused entry in ignore group
 
 An entry of an ignore list is no longer needed, remove it.

--- a/packages/knip/fixtures/workspaces/stale-config/package.json
+++ b/packages/knip/fixtures/workspaces/stale-config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@fixtures/workspaces-stale-config",
+  "version": "*",
+  "workspaces": ["packages/*"],
+  "knip": {
+    "workspaces": {
+      "packages/a": {},
+      "packages/removed": {}
+    }
+  }
+}

--- a/packages/knip/fixtures/workspaces/stale-config/package.json
+++ b/packages/knip/fixtures/workspaces/stale-config/package.json
@@ -5,7 +5,9 @@
   "knip": {
     "workspaces": {
       "packages/a": {},
-      "packages/removed": {}
+      "packages/*": {},
+      "packages/removed": {},
+      "apps/*": {}
     }
   }
 }

--- a/packages/knip/fixtures/workspaces/stale-config/packages/a/index.js
+++ b/packages/knip/fixtures/workspaces/stale-config/packages/a/index.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/knip/fixtures/workspaces/stale-config/packages/a/package.json
+++ b/packages/knip/fixtures/workspaces/stale-config/packages/a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixtures/workspaces-stale-config-a",
+  "version": "*"
+}

--- a/packages/knip/src/ConfigurationChief.ts
+++ b/packages/knip/src/ConfigurationChief.ts
@@ -482,11 +482,23 @@ export class ConfigurationChief {
   }
 
   public getUnusedConfiguredWorkspaces() {
-    const configuredWorkspaceNames = this.rawConfig?.workspaces ? Object.keys(this.rawConfig.workspaces) : [];
-    const matchesWorkspace = (pattern: string) => {
-      for (const name of this.workspacePackages.keys()) if (picomatch.isMatch(name, pattern)) return true;
-      return false;
-    };
-    return configuredWorkspaceNames.filter(configuredWorkspaceName => !matchesWorkspace(configuredWorkspaceName));
+    if (!this.rawConfig?.workspaces) return [];
+    const unused: string[] = [];
+    for (const key of Object.keys(this.rawConfig.workspaces)) {
+      if (key.includes('*')) {
+        const isMatch = picomatch(key);
+        let isUsed = false;
+        for (const name of this.workspacePackages.keys()) {
+          if (isMatch(name)) {
+            isUsed = true;
+            break;
+          }
+        }
+        if (!isUsed) unused.push(key);
+      } else if (!this.workspacePackages.has(key)) {
+        unused.push(key);
+      }
+    }
+    return unused;
   }
 }

--- a/packages/knip/src/ConfigurationChief.ts
+++ b/packages/knip/src/ConfigurationChief.ts
@@ -480,4 +480,13 @@ export class ConfigurationChief {
         return !isDirectory(dir) || isFile(dir, 'package.json');
       });
   }
+
+  public getUnusedConfiguredWorkspaces() {
+    const configuredWorkspaceNames = this.rawConfig?.workspaces ? Object.keys(this.rawConfig.workspaces) : [];
+    const matchesWorkspace = (pattern: string) => {
+      for (const name of this.workspacePackages.keys()) if (picomatch.isMatch(name, pattern)) return true;
+      return false;
+    };
+    return configuredWorkspaceNames.filter(configuredWorkspaceName => !matchesWorkspace(configuredWorkspaceName));
+  }
 }

--- a/packages/knip/src/graph/analyze.ts
+++ b/packages/knip/src/graph/analyze.ts
@@ -301,6 +301,11 @@ export const analyze = async ({
     const catalogIssues = await counselor.settleCatalogIssues(options);
     for (const issue of catalogIssues) collector.addIssue(issue);
 
+    const unusedConfiguredWorkspaces = chief.getUnusedConfiguredWorkspaces();
+    for (const identifier of unusedConfiguredWorkspaces) {
+      collector.addConfigurationHint({ type: 'workspaces', identifier });
+    }
+
     const unusedIgnoredWorkspaces = chief.getUnusedIgnoredWorkspaces();
     for (const identifier of unusedIgnoredWorkspaces) {
       collector.addConfigurationHint({ type: 'ignoreWorkspaces', identifier });

--- a/packages/knip/src/reporters/util/configuration-hints.ts
+++ b/packages/knip/src/reporters/util/configuration-hints.ts
@@ -69,6 +69,7 @@ export const hintPrinters = new Map<ConfigurationHintType, { print: (options: Pr
   ['ignoreBinaries', { print: unused }],
   ['ignoreDependencies', { print: unused }],
   ['ignoreUnresolved', { print: unused }],
+  ['workspaces', { print: unused }],
   ['ignoreWorkspaces', { print: unused }],
   ['entry-empty', { print: empty }],
   ['project-empty', { print: empty }],
@@ -85,6 +86,7 @@ export const hintPrinters = new Map<ConfigurationHintType, { print: (options: Pr
 const hintTypesOrder: ConfigurationHintType[][] = [
   ['top-level-unconfigured', 'workspace-unconfigured'],
   ['entry-top-level', 'project-top-level'],
+  ['workspaces'],
   ['ignore', 'ignoreFiles'],
   ['ignoreWorkspaces'],
   ['ignoreDependencies'],

--- a/packages/knip/src/types/issues.ts
+++ b/packages/knip/src/types/issues.ts
@@ -93,6 +93,7 @@ export type ConfigurationHintType =
   | 'ignoreBinaries'
   | 'ignoreDependencies'
   | 'ignoreUnresolved'
+  | 'workspaces'
   | 'ignoreWorkspaces'
   | 'entry-redundant'
   | 'project-redundant'

--- a/packages/knip/test/workspaces/stale-config.test.ts
+++ b/packages/knip/test/workspaces/stale-config.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/workspaces/stale-config');
+
+test('Report config hints for stale workspace configuration keys', async () => {
+  const options = await createOptions({ cwd });
+  const { configurationHints } = await main(options);
+
+  assert.deepEqual(configurationHints, [{ type: 'workspaces', identifier: 'packages/removed' }]);
+});

--- a/packages/knip/test/workspaces/stale-config.test.ts
+++ b/packages/knip/test/workspaces/stale-config.test.ts
@@ -10,5 +10,8 @@ test('Report config hints for stale workspace configuration keys', async () => {
   const options = await createOptions({ cwd });
   const { configurationHints } = await main(options);
 
-  assert.deepEqual(configurationHints, [{ type: 'workspaces', identifier: 'packages/removed' }]);
+  assert.deepEqual(configurationHints, [
+    { type: 'workspaces', identifier: 'packages/removed' },
+    { type: 'workspaces', identifier: 'apps/*' },
+  ]);
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

## Summary

- resolves: #1801 

Reports `workspaces` entries in Knip configuration that no longer match any discovered workspace as configuration hints. This helps large monorepos clean up stale workspace-specific overrides after services are removed or renamed, matching the existing behavior for stale `ignoreWorkspaces` entries.

Tested with `bun test test/workspaces/stale-config.test.ts`.

