### PR TITLE
fix: Update timerifyMethods to include resolveFromAST

### DIFF
--- a/packages/knip/src/plugins.ts
+++ b/packages/knip/src/plugins.ts
@@ -11,7 +11,7 @@ const { values } = parseArgs({ strict: false, options: { performance: { type: 'b
 
 const isEnabled = !!values.performance;
 
-const timerifyMethods = ['resolve', 'resolveConfig', 'resolveAST'] as const;
+const timerifyMethods = ['resolve', 'resolveConfig', 'resolveFromAST'] as const;
 
 const PluginEntries = Object.entries(PMap) as Entries;
 


### PR DESCRIPTION
Summary

This PR fixes a typo in the plugin performance instrumentation hook list.

packages/knip/src/plugins.ts currently includes resolveAST as one of the hooks to wrap with timerify. However, the actual plugin hook is named resolveFromAST, as defined in the Plugin type.

Because of this mismatch, --performance did not collect function-level timing information for plugin resolveFromAST hooks.

Changes

* Replace resolveAST with resolveFromAST in the performance hook list.
* Align the performance instrumentation with the actual Plugin hook name.

Verification

I verified the change with:
```
pnpm lint
pnpm run --dir packages/knip build
node packages/knip/dist/cli.js --directory packages/knip/fixtures/plugins/next --performance --no-exit-code
```
After this change, the performance output includes timing information for resolveFromAST plugin hooks.