### PR TITLE
feat: detect execaNode scripts in execa visitor

### DIFF
--- a/packages/knip/fixtures/plugin-config/script-visitors-execa/execa-node-tag.mjs
+++ b/packages/knip/fixtures/plugin-config/script-visitors-execa/execa-node-tag.mjs
@@ -1,0 +1,1 @@
+export default 1;

--- a/packages/knip/fixtures/plugin-config/script-visitors-execa/execa-node.mjs
+++ b/packages/knip/fixtures/plugin-config/script-visitors-execa/execa-node.mjs
@@ -1,0 +1,1 @@
+export default 1;

--- a/packages/knip/fixtures/plugin-config/script-visitors-execa/methods.mjs
+++ b/packages/knip/fixtures/plugin-config/script-visitors-execa/methods.mjs
@@ -10,4 +10,8 @@ await execaCommand('bunx executable7');
 
 execaCommandSync('pnpx executable8');
 
+await execaNode('execa-node.mjs');
+
+await execaNode`execa-node-tag.mjs`;
+
 await execa('node', ['build && phantomexeca']);

--- a/packages/knip/src/plugins/execa/visitors/execa.ts
+++ b/packages/knip/src/plugins/execa/visitors/execa.ts
@@ -2,7 +2,7 @@ import type { PluginVisitorContext, PluginVisitorObject } from '../../../types/c
 import { getSafeScriptFromArgs, getStringValue, isStringLiteral } from '../../../typescript/ast-nodes.ts';
 
 const tags = new Set(['$', '$sync']);
-const methods = new Set(['execa', 'execaSync', 'execaCommand', 'execaCommandSync', '$sync']);
+const methods = new Set(['execa', 'execaSync', 'execaCommand', 'execaCommandSync', 'execaNode', '$sync']);
 
 export function createExecaVisitor(ctx: PluginVisitorContext): PluginVisitorObject {
   return {
@@ -14,7 +14,11 @@ export function createExecaVisitor(ctx: PluginVisitorContext): PluginVisitorObje
           : tag.type === 'CallExpression' && tag.callee.type === 'Identifier'
             ? tag.callee.name
             : undefined;
-      if (tagName && tags.has(tagName)) {
+      if (tagName === 'execaNode') {
+        for (const q of node.quasi.quasis) {
+          if (q.value.raw) ctx.addScript(`node ${q.value.raw}`);
+        }
+      } else if (tagName && tags.has(tagName)) {
         for (const q of node.quasi.quasis) {
           if (q.value.raw) ctx.addScript(q.value.raw);
         }
@@ -23,7 +27,10 @@ export function createExecaVisitor(ctx: PluginVisitorContext): PluginVisitorObje
     CallExpression(node) {
       if (node.callee.type !== 'Identifier' || !methods.has(node.callee.name)) return;
       const fnName = node.callee.name;
-      if (fnName.startsWith('execaCommand')) {
+      if (fnName === 'execaNode') {
+        const script = getSafeScriptFromArgs(node.arguments[0], node.arguments[1]);
+        if (script) ctx.addScript(`node ${script}`);
+      } else if (fnName.startsWith('execaCommand')) {
         if (node.arguments[0] && isStringLiteral(node.arguments[0])) {
           const val = getStringValue(node.arguments[0]);
           if (val) ctx.addScript(val);

--- a/packages/knip/test/plugin-config/script-visitors-execa.test.ts
+++ b/packages/knip/test/plugin-config/script-visitors-execa.test.ts
@@ -12,10 +12,12 @@ test('Find dependencies with custom script visitors (execa)', async () => {
   const { counters, issues } = await main(options);
 
   assert(!issues.binaries['methods.mjs']?.phantomexeca);
+  assert(!issues.files['execa-node.mjs']);
+  assert(!issues.files['execa-node-tag.mjs']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 6,
-    total: 6,
+    processed: 8,
+    total: 8,
   });
 });


### PR DESCRIPTION
## Problem

The Execa script visitor did not detect Node.js scripts executed with `execaNode`.

For example:

```js
await execaNode('build.mjs');
await execaNode`build.mjs`;
```

Both calls execute `build.mjs` as a Node.js script, so Knip should treat `build.mjs` as a used entry file. Without this handling, files executed only through `execaNode` could be reported as unused.

## Cause

Knip collects scripts from Execa APIs in `packages/knip/src/plugins/execa/visitors/execa.ts`.

The visitor already handled APIs such as:

```js
execa(...)
execaSync(...)
execaCommand(...)
execaCommandSync(...)
$sync(...)
$`...`
```

However, it did not handle `execaNode`.

This looks like an omission rather than intentional behavior. The existing fixture in `packages/knip/fixtures/plugin-config/script-visitors-execa/methods.mjs` already imported `execaNode`, but it did not include any actual `execaNode` call:

```js
import { execa, execaSync, execaCommand, execaCommandSync, execaNode, $sync } from 'execa';
```

So the fixture acknowledged the API, but the visitor did not verify that scripts executed through that API were collected.

The Execa API reference documents `execaNode(scriptPath, arguments?, options?)` as the preferred API for executing Node.js files. It runs a Node.js file as `node scriptPath ...arguments`.

References:

- Execa API reference for `execaNode`: https://github.com/sindresorhus/execa/blob/main/docs/api.md#execanodescriptpath-arguments-options
- Execa API reference for template string methods, including `execaNode\`command\``: https://github.com/sindresorhus/execa/blob/main/docs/api.md#execacommand
- Execa README examples using `execaNode`: https://github.com/sindresorhus/execa#ipc

Because of this, `execaNode('build.mjs')` and `execaNode\`build.mjs\`` should be treated as script entry usage by Knip.

## Changes

This PR adds `execaNode` support to the Execa script visitor.

- Detects `execaNode('file.mjs')`.
- Detects `execaNode\`file.mjs\``.
- Converts those calls to `node file.mjs` before passing them to the existing script parser.
- Keeps the existing `$` and `$sync` tagged template handling unchanged.
- Extends the existing Execa fixture with `execaNode` call and tagged template cases.
- Adds assertions to verify that files executed through `execaNode` are not reported as unused.

## Impact

Files executed through `execaNode` will no longer be reported as unused files.

This reduces false positives in projects that use Execa to run build scripts, release scripts, code generation scripts, or other local Node.js entry files.

## Verification

```sh
node_modules/.bin/tsx --test test/plugin-config/script-visitors-execa.test.ts
```

The related Execa script visitor test passes.