### PR TITLE
docs: update npmjs.com links to npmx.dev

### DIFF
--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/webpro-nl/knip' },
         { icon: 'blueSky', label: 'Bluesky', href: 'https://bsky.app/profile/webpro.nl' },
-        { icon: 'npm', label: 'npm', href: 'https://www.npmjs.com/package/knip' },
+        { icon: 'npm', label: 'npm', href: 'https://www.npmx.dev/package/knip' },
       ],
       components: {
         Head: './src/components/Head.astro',

--- a/packages/docs/src/assets/testimonials.json
+++ b/packages/docs/src/assets/testimonials.json
@@ -248,11 +248,11 @@
         "urls": [
           {
             "url": "https://t.co/kA81p5gkmP",
-            "expanded_url": "https://www.npmjs.com/package/knip",
-            "display_url": "npmjs.com/package/knip",
+            "expanded_url": "https://www.npmx.dev/package/knip",
+            "display_url": "npmx.dev/package/knip",
             "title": "Knip",
             "description": "Find unused dependencies, exports and files in your TypeScript and JavaScript projects.",
-            "unwound_url": "https://www.npmjs.com/package/knip"
+            "unwound_url": "https://www.npmx.dev/package/knip"
           }
         ]
       },

--- a/packages/docs/src/content/docs/blog/for-editors-and-agents.md
+++ b/packages/docs/src/content/docs/blog/for-editors-and-agents.md
@@ -108,14 +108,14 @@ barrel files. Knip warns:
 ![VS Code Extension Settings][21]
 
 [1]: https://github.com/webpro-nl/knip/network/dependents
-[2]: https://www.npmjs.com/package/knip
+[2]: https://www.npmx.dev/package/knip
 [3]: #editor-extension
 [4]: #lint-findings
 [5]: #imports--exports
 [6]: #mcp-server
 [7]: https://marketplace.visualstudio.com/items?itemName=webpro.vscode-knip
 [8]: https://open-vsx.org/extension/webpro/vscode-knip
-[9]: https://www.npmjs.com/package/@knip/mcp
+[9]: https://www.npmx.dev/package/@knip/mcp
 [10]: https://github.com/webpro-nl/knip/blob/main/packages/language-server/README.md
 [11]: #contention
 [12]: #circular-dependencies

--- a/packages/docs/src/content/docs/guides/handling-issues.mdx
+++ b/packages/docs/src/content/docs/guides/handling-issues.mdx
@@ -658,7 +658,7 @@ issue on GitHub. It'll make Knip better for everyone!
 [31]: #external-aliased-imports
 [32]: ../reference/configuration.md#paths
 [33]: ../reference/configuration.md#ignoreunresolved
-[34]: https://www.npmjs.com/package/unplugin-icons
+[34]: https://www.npmx.dev/package/unplugin-icons
 [35]: https://github.com/unplugin/unplugin-icons/tree/main/types
 [36]: #namespace-enumerations
 [37]: #external-libraries

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -130,7 +130,7 @@ A curated selection of articles about Knip, most recent first:
 - [Unused dependencies][26]
 - [Unused exports][27]
 
-[1]: https://www.npmjs.com/package/knip
+[1]: https://www.npmx.dev/package/knip
 [2]: https://img.shields.io/npm/v/knip?color=f56e0f
 [3]: https://img.shields.io/npm/dm/knip?color=f56e0f
 [4]: https://github.com/webpro-nl/knip

--- a/packages/docs/src/content/docs/reference/cli.md
+++ b/packages/docs/src/content/docs/reference/cli.md
@@ -516,7 +516,7 @@ Trace file to see where its exports are imported. Implies [--trace][17].
 [2]: https://bun.sh
 [3]: ../reference/known-issues.md
 [4]: https://no-color.org/
-[5]: https://www.npmjs.com/package/picocolors
+[5]: https://www.npmx.dev/package/picocolors
 [6]: ./configuration.md#includeentryexports
 [7]: ../features/production-mode.md
 [8]: #--production

--- a/packages/docs/src/content/docs/reference/integrations.md
+++ b/packages/docs/src/content/docs/reference/integrations.md
@@ -95,7 +95,7 @@ dependencies.
 [6]: https://open-vsx.org/extension/webpro/vscode-knip
 [7]: #vs-code-extension-screenshots
 [8]: https://plugins.jetbrains.com/plugin/29765-knip
-[9]: https://www.npmjs.com/package/@knip/mcp
+[9]: https://www.npmx.dev/package/@knip/mcp
 [10]: https://github.com/webpro-nl/knip/blob/main/packages/language-server/README.md
 [11]: /screenshots/editors-and-agents/diagnostics.webp
 [12]: /screenshots/editors-and-agents/imports-exports.webp

--- a/packages/knip/README.md
+++ b/packages/knip/README.md
@@ -46,16 +46,16 @@ following projects:
 - [file-entry-cache][22] ([MIT][23])
 - [json-parse-even-better-errors][24] ([MIT][25])
 
-[1]: https://www.npmjs.com/package/knip
+[1]: https://www.npmx.dev/package/knip
 [2]: https://img.shields.io/npm/v/knip?color=f56e0f
 [3]: https://img.shields.io/npm/dm/knip?color=f56e0f
 [4]: https://github.com/webpro-nl/knip
 [5]:
   https://img.shields.io/github/stars/webpro-nl/knip?style=flat-square&color=f56e0f
 [6]: https://knip.dev
-[7]: https://www.npmjs.com/package/@knip/create-config
-[8]: https://www.npmjs.com/package/@knip/language-server
-[9]: https://www.npmjs.com/package/@knip/mcp
+[7]: https://www.npmx.dev/package/@knip/create-config
+[8]: https://www.npmx.dev/package/@knip/language-server
+[9]: https://www.npmx.dev/package/@knip/mcp
 [10]: https://marketplace.visualstudio.com/items?itemName=webpro.vscode-knip
 [11]: https://open-vsx.org/extension/webpro/vscode-knip
 [12]: https://github.com/webpro-nl/knip/blob/main/.github/CONTRIBUTING.md

--- a/packages/knip/src/plugins/c8/index.ts
+++ b/packages/knip/src/plugins/c8/index.ts
@@ -2,7 +2,7 @@ import type { ParsedArgs } from '../../util/parse-args.ts';
 import { argsFrom } from '../../binaries/util.ts';
 import type { Plugin } from '../../types/config.ts';
 
-// https://www.npmjs.com/package/c8
+// https://www.npmx.dev/package/c8
 
 const title = 'c8';
 

--- a/packages/knip/src/plugins/dotenv/index.ts
+++ b/packages/knip/src/plugins/dotenv/index.ts
@@ -2,7 +2,7 @@ import type { ParsedArgs } from '../../util/parse-args.ts';
 import { argsFrom } from '../../binaries/util.ts';
 import type { Plugin } from '../../types/config.ts';
 
-// https://www.npmjs.com/package/dotenv
+// https://www.npmx.dev/package/dotenv
 
 const title = 'dotenv';
 

--- a/packages/knip/src/plugins/nyc/index.ts
+++ b/packages/knip/src/plugins/nyc/index.ts
@@ -3,7 +3,7 @@ import { toDeferResolve } from '../../util/input.ts';
 import { hasDependency } from '../../util/plugin.ts';
 import type { NycConfig } from './types.ts';
 
-// https://www.npmjs.com/package/nyc
+// https://www.npmx.dev/package/nyc
 
 const title = 'nyc';
 

--- a/packages/knip/src/plugins/playwright-test/index.ts
+++ b/packages/knip/src/plugins/playwright-test/index.ts
@@ -1,7 +1,7 @@
 import type { IsPluginEnabled, Plugin } from '../../types/config.ts';
 import { hasDependency } from '../../util/plugin.ts';
 
-// https://www.npmjs.com/package/playwright-test
+// https://www.npmx.dev/package/playwright-test
 
 const title = 'playwright-test';
 


### PR DESCRIPTION
👋🏼 Hi, friend. This unsolicited PR updates npmjs.com/* links in the knip docs to use npmx.dev.

Please feel free to close this if this isn't desirable!