### PR TITLE
docs: fix semi-broken link to DEVELOPMENT.md in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Please consider this before opening a pull request:
 [3]: #open-an-issue
 [4]: #open-a-pull-request
 [5]: https://github.com/webpro-nl/knip/releases
-[6]: ./DEVELOPMENT.md
+[6]: /.github/DEVELOPMENT.md
 [7]:
   https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
 [8]: https://knip.dev/#created-by-awesome-contributors


### PR DESCRIPTION
This might arguably be a GitHub bug, but on the repo homepage there's a "Contributing" tab that renders the CONTRIBUTING.md file. In that context, relative links are resolved relative to the repo root instead of the actual path of the CONTRIBUTING.md file, for some reason.

<img width="754" height="368" alt="Screenshot 2026-06-27 at 08 54 35" src="https://github.com/user-attachments/assets/3d234a07-5ffd-4cc8-943a-19585b17f35c" />

The link to DEVELOPMENT.md is broken when clicked from that view.

In any case, using [a path relative to the repo root](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) fixes this and works everywhere, so why not.