### PR TITLE
fix: enable vite and vitest plugins when vite-plus is found

### DIFF
--- a/packages/knip/fixtures/plugins/vite-plus/node_modules/vite-plus/package.json
+++ b/packages/knip/fixtures/plugins/vite-plus/node_modules/vite-plus/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "vite-plus",
+  "version": "1.0.0"
+}

--- a/packages/knip/fixtures/plugins/vite-plus/package.json
+++ b/packages/knip/fixtures/plugins/vite-plus/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@plugins/vite-plus",
+  "devDependencies": {
+    "vite-plus": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/vite-plus/src/index.ts
+++ b/packages/knip/fixtures/plugins/vite-plus/src/index.ts
@@ -1,0 +1,1 @@
+export const hello = 'world';

--- a/packages/knip/src/plugins/vite/index.ts
+++ b/packages/knip/src/plugins/vite/index.ts
@@ -9,7 +9,7 @@ import { createImportMetaGlobVisitor } from './visitors/importMetaGlob.ts';
 
 const title = 'Vite';
 
-const enablers = ['vite', 'vitest'];
+const enablers = ['vite', 'vitest', 'vite-plus'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -15,7 +15,7 @@ import type { AliasOptions, COMMAND, MODE, ViteConfig, ViteConfigOrFn, VitestWor
 
 const title = 'Vitest';
 
-const enablers = ['vitest'];
+const enablers = ['vitest', 'vite-plus'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 

--- a/packages/knip/test/plugins/vite-plus.test.ts
+++ b/packages/knip/test/plugins/vite-plus.test.ts
@@ -10,5 +10,6 @@ test('Vite and vitest plugins are enabled with vite-plus dependency', async () =
   const options = await createOptions({ cwd });
   const { enabledPlugins } = await main(options);
 
-  assert.partialDeepStrictEqual(enabledPlugins, { '.': ['vite', 'vitest'] });
+  assert.ok(enabledPlugins['.'].includes('vite'));
+  assert.ok(enabledPlugins['.'].includes('vitest'));
 });

--- a/packages/knip/test/plugins/vite-plus.test.ts
+++ b/packages/knip/test/plugins/vite-plus.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/vite-plus');
+
+test('Vite and vitest plugins are enabled with vite-plus dependency', async () => {
+  const options = await createOptions({ cwd });
+  const { enabledPlugins } = await main(options);
+
+  assert.partialDeepStrictEqual(enabledPlugins, { '.': ['vite', 'vitest'] });
+});


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Enables the vite/vitest plugins when `vite-plus` is installed as a dependency