### PR TITLE
fix: remove format_on_save: true settings from Zed settings to respect user settings

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -22,7 +22,6 @@
   },
   "languages": {
     "CSS": {
-      "format_on_save": "on",
       "prettier": {
         "allowed": false
       },
@@ -35,7 +34,6 @@
       ]
     },
     "HTML": {
-      "format_on_save": "on",
       "prettier": {
         "allowed": false
       },
@@ -48,7 +46,6 @@
       ]
     },
     "JavaScript": {
-      "format_on_save": "on",
       "prettier": {
         "allowed": false
       },
@@ -64,7 +61,6 @@
       ]
     },
     "JSON": {
-      "format_on_save": "on",
       "prettier": {
         "allowed": false
       },
@@ -77,7 +73,6 @@
       ]
     },
     "JSONC": {
-      "format_on_save": "on",
       "prettier": {
         "allowed": false
       },
@@ -90,7 +85,6 @@
       ]
     },
     "Markdown": {
-      "format_on_save": "on",
       "prettier": {
         "allowed": false
       },
@@ -103,7 +97,6 @@
       ]
     },
     "TypeScript": {
-      "format_on_save": "on",
       "prettier": {
         "allowed": false
       },
@@ -116,7 +109,6 @@
       ]
     },
     "TSX": {
-      "format_on_save": "on",
       "prettier": {
         "allowed": false
       },
@@ -129,7 +121,6 @@
       ]
     },
     "YAML": {
-      "format_on_save": "on",
       "prettier": {
         "allowed": false
       },


### PR DESCRIPTION
#### Description

Thanks to @mootari for mentioning on Discord that the `format_on_save` option should ideally not be overridden in our projects Zed settings, so users can experience it in the way the want.

Since we'll probably add pre-commit hooks in #1837 anyway, it doesn't really matter if the user always formats when saving the files 👍 