### PR TITLE
feat: add Renovate for GitHub actions only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,12 +10,8 @@
       "enabled": false
     },
     {
-      "matchUpdateTypes": ["minor"],
-      "groupName": "all minor dependencies"
-    },
-    {
-      "matchUpdateTypes": ["patch", "digest"],
-      "groupName": "all patch dependencies"
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "dependencies (non-major)"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": ["github-actions"],
+  "pinDigests": true,
+  "labels": ["bot"],
+  "schedule": ["before 5am on Monday"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "groupName": "all minor dependencies"
+    },
+    {
+      "matchUpdateTypes": ["patch", "digest"],
+      "groupName": "all patch dependencies"
+    }
+  ]
+}


### PR DESCRIPTION
#### Description

This PR adds the configuration for Renovate so it manages the following dependencies:

Only GitHub actions are updated when a new minor or patch is released. All patch and minor updates are grouped into the same PR. The PRs will only be generated early on Monday and a `"bot"` label will be assigned to the PR (if you created it).

Let me know if you want anything different. Otherwise, I suggest we can try this config out and if you don't like it, remove or adopt it later again 👍 

#### Setup guide

In order to successfully setup Renovate, two steps have to be completed before merging:

1. Add the Renovate GitHub app to this repository via https://github.com/apps/renovate
2. Create a new label called `"bot"` under https://github.com/webpro-nl/knip/labels