### PR TITLE
Ignore import() in JSDoc examples

### DIFF
--- a/packages/knip/fixtures/language/jsdoc/index.ts
+++ b/packages/knip/fixtures/language/jsdoc/index.ts
@@ -37,6 +37,12 @@ function doSomething2(myValue) {
 /** @type {import('@jest/types')} */
 module.exports = {};
 
+/** @const {import('const-types').Setting} */
+const setting = null;
+
+/** @member {import('member-types').Field} */
+const field = null;
+
 // import('./should-not-resolve')
 // See import('./also-should-not-resolve') for details
 

--- a/packages/knip/fixtures/language/jsdoc/index.ts
+++ b/packages/knip/fixtures/language/jsdoc/index.ts
@@ -46,3 +46,9 @@ module.exports = {};
  * <LazyLoad component={LazyComponent} />
  */
 function lazyLoad() {}
+
+/**
+ * @example
+ *   { index: true, lazy: lazyComponent(() => import('./Foo'), 'Foo') }
+ */
+export const lazyComponent = (loader, name) => ({ loader, name });

--- a/packages/knip/src/typescript/comments.ts
+++ b/packages/knip/src/typescript/comments.ts
@@ -3,6 +3,8 @@ import { IMPORT_FLAGS } from '../constants.ts';
 
 const jsDocImportRe = /import\(\s*['"]([^'"]+)['"]\s*\)(?:\.(\w+))?/g;
 const jsDocImportTagRe = /@import\s+(?:\{[^}]*\}|\*\s+as\s+\w+)\s+from\s+['"]([^'"]+)['"]/g;
+const jsDocTypeTagRe =
+  /@(?:type|typedef|callback|param|arg|argument|property|prop|returns?|yields?|throws?|exception|this|extends|augments|implements|enum|template|satisfies)\b/;
 const jsxImportSourceRe = /@jsxImportSource\s+(\S+)/;
 const referenceRe = /\s*<reference\s+(types|path)\s*=\s*"([^"]+)"[^/]*\/>/;
 const envPragmaRe = /@(vitest|jest)-environment\s+([@\w./-]+)/g;
@@ -27,6 +29,24 @@ type CommentImportAdder = (
   modifiers: number
 ) => void;
 
+const isInJsDocTypeExpression = (text: string, index: number) => {
+  let depth = 0;
+  for (let pos = index - 1; pos >= 0; pos--) {
+    const char = text.charCodeAt(pos);
+    if (char === 125) {
+      depth++;
+    } else if (char === 123) {
+      if (depth > 0) {
+        depth--;
+      } else {
+        const line = text.slice(text.lastIndexOf('\n', pos - 1) + 1, pos);
+        if (jsDocTypeTagRe.test(line)) return true;
+      }
+    }
+  }
+  return false;
+};
+
 export const extractImportsFromComments = (
   comments: readonly Comment[],
   firstStmtStart: number,
@@ -39,9 +59,7 @@ export const extractImportsFromComments = (
     if (comment.type === 'Block') {
       jsDocImportRe.lastIndex = 0;
       while ((results = jsDocImportRe.exec(text)) !== null) {
-        const before = text.slice(0, results.index);
-        const lastOpen = before.lastIndexOf('{');
-        if (lastOpen === -1 || before.indexOf('}', lastOpen) !== -1) continue;
+        if (!isInJsDocTypeExpression(text, results.index)) continue;
         const specifier = results[1];
         const member = results[2];
         addImport(specifier, member, undefined, undefined, comment.start + results.index, IMPORT_FLAGS.TYPE_ONLY);

--- a/packages/knip/src/typescript/comments.ts
+++ b/packages/knip/src/typescript/comments.ts
@@ -4,7 +4,7 @@ import { IMPORT_FLAGS } from '../constants.ts';
 const jsDocImportRe = /import\(\s*['"]([^'"]+)['"]\s*\)(?:\.(\w+))?/g;
 const jsDocImportTagRe = /@import\s+(?:\{[^}]*\}|\*\s+as\s+\w+)\s+from\s+['"]([^'"]+)['"]/g;
 const jsDocTypeTagRe =
-  /@(?:type|typedef|callback|param|arg|argument|property|prop|returns?|yields?|throws?|exception|this|extends|augments|implements|enum|template|satisfies)\b/;
+  /@(?:type|typedef|callback|param|arg|argument|property|prop|returns?|yields?|throws?|exception|this|extends|augments|implements|enum|template|satisfies|const|constant|member|var|namespace|module)\b/;
 const jsxImportSourceRe = /@jsxImportSource\s+(\S+)/;
 const referenceRe = /\s*<reference\s+(types|path)\s*=\s*"([^"]+)"[^/]*\/>/;
 const envPragmaRe = /@(vitest|jest)-environment\s+([@\w./-]+)/g;

--- a/packages/knip/test/language/jsdoc.test.ts
+++ b/packages/knip/test/language/jsdoc.test.ts
@@ -17,11 +17,13 @@ test('Find imports from jsdoc @type tags', async () => {
   assert(issues.unlisted['index.ts']['some-module']);
   assert(issues.unlisted['index.ts']['some-other-module']);
   assert(issues.unlisted['index.ts']['@jest/types']);
+  assert(issues.unlisted['index.ts']['const-types']);
+  assert(issues.unlisted['index.ts']['member-types']);
   assert(!issues.unresolved['index.ts']?.['./Foo']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    unlisted: 6,
+    unlisted: 8,
     processed: 1,
     total: 1,
   });

--- a/packages/knip/test/language/jsdoc.test.ts
+++ b/packages/knip/test/language/jsdoc.test.ts
@@ -17,6 +17,7 @@ test('Find imports from jsdoc @type tags', async () => {
   assert(issues.unlisted['index.ts']['some-module']);
   assert(issues.unlisted['index.ts']['some-other-module']);
   assert(issues.unlisted['index.ts']['@jest/types']);
+  assert(!issues.unresolved['index.ts']?.['./Foo']);
 
   assert.deepEqual(counters, {
     ...baseCounters,


### PR DESCRIPTION
## Summary

- Restrict JSDoc `import()` extraction to type-expression tags so code shown in `@example` blocks is not analyzed as a real import.
- Add fixture coverage for an object-literal `@example` containing `import('./Foo')`.

Fixes #1842

## Tests

- `pnpm exec oxfmt --check packages/knip/src/typescript/comments.ts packages/knip/test/language/jsdoc.test.ts packages/knip/fixtures/language/jsdoc/index.ts`
- `pnpm exec oxlint packages/knip/src/typescript/comments.ts packages/knip/test/language/jsdoc.test.ts packages/knip/fixtures/language/jsdoc/index.ts`
- `node --test test/language/jsdoc.test.ts test/language/svelte-script-jsdoc-import.test.ts`
- `pnpm build`
- `node packages/knip/src/cli.ts --directory /tmp/oss-pr-pipeline/repro-jsdoc --include unresolved --reporter compact`
