### PR TITLE
fix(reporters): always print the issue-type title for a single group

### DIFF
--- a/packages/knip/src/reporters/compact.ts
+++ b/packages/knip/src/reporters/compact.ts
@@ -8,12 +8,11 @@ const logIssueRecord = (issues: Issue[], cwd: string) => {
 };
 
 export default ({ report, issues, isShowProgress, cwd }: ReporterOptions) => {
-  const reportMultipleGroups = Object.values(report).filter(Boolean).length > 1;
   let totalIssues = 0;
 
   for (const [reportType, isReportType] of Object.entries(report) as Entries<typeof report>) {
     if (isReportType) {
-      const title = reportMultipleGroups && getIssueTypeTitle(reportType);
+      const title = getIssueTypeTitle(reportType);
       const issuesForType =
         reportType === 'duplicates'
           ? flattenIssues(issues[reportType])

--- a/packages/knip/src/reporters/symbols.ts
+++ b/packages/knip/src/reporters/symbols.ts
@@ -5,12 +5,11 @@ import { dim, flattenIssues, getColoredTitle, getIssueTypeTitle, getTableForType
 
 export default (options: ReporterOptions) => {
   const { report, issues, isDisableConfigHints, isDisableTagHints, isShowProgress } = options;
-  const reportMultipleGroups = Object.values(report).filter(Boolean).length > 1;
   let totalIssues = 0;
 
   for (const [reportType, isReportType] of Object.entries(report) as Entries<typeof report>) {
     if (isReportType) {
-      const title = reportMultipleGroups && getIssueTypeTitle(reportType);
+      const title = getIssueTypeTitle(reportType);
 
       const issuesForType = flattenIssues(issues[reportType]);
       if (issuesForType.length > 0) {

--- a/packages/knip/test/cli/cli-reporter-compact.test.ts
+++ b/packages/knip/test/cli/cli-reporter-compact.test.ts
@@ -6,7 +6,19 @@ import { resolve } from '../helpers/resolve.ts';
 const cwd = resolve('fixtures/compact-reporter');
 
 test('knip --reporter compact (with empty issue records after ignore)', () => {
+  const expected = `Unused dependencies (1)
+package.json: unused-dep`;
+
   const { stdout, stderr } = exec('knip --reporter compact', { cwd });
   assert.equal(stderr, '');
-  assert.match(stdout, /unused-dep/);
+  assert.equal(stdout, expected);
+});
+
+test('knip --reporter compact (single included issue type)', () => {
+  const expected = `Unused dependencies (1)
+package.json: unused-dep`;
+
+  const { stdout, stderr } = exec('knip --reporter compact --include dependencies --strict --no-config-hints', { cwd });
+  assert.equal(stderr, '');
+  assert.equal(stdout, expected);
 });

--- a/packages/knip/test/cli/cli-reporter-symbols-directory.test.ts
+++ b/packages/knip/test/cli/cli-reporter-symbols-directory.test.ts
@@ -6,7 +6,8 @@ import { resolve } from '../helpers/resolve.ts';
 const cwd = resolve('fixtures/symbol-reporter-directory/packages/config');
 
 test('knip --reporter symbols with --directory from another cwd', () => {
-  const expected = `packages/client/src/unused.ts
+  const expected = `Unused files (2)
+packages/client/src/unused.ts
 src/unused.ts`;
 
   const result = exec('knip --directory ../.. --reporter symbols --include files --no-config-hints', { cwd }).stdout;

--- a/packages/knip/test/cli/cli-reporter-symbols-single-group.test.ts
+++ b/packages/knip/test/cli/cli-reporter-symbols-single-group.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { exec } from '../helpers/exec.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/compact-reporter');
+
+test('knip --reporter symbols (single included issue type)', () => {
+  const expected = `Unused dependencies (1)
+unused-dep  package.json:8:6`;
+
+  const { stdout, stderr } = exec('knip --reporter symbols --include dependencies --strict --no-config-hints', { cwd });
+  assert.equal(stderr, '');
+  assert.equal(stdout, expected);
+});


### PR DESCRIPTION
The default and compact reporters gate the issue-type heading behind `reportMultipleGroups`, so a single issue type prints without its title or count. This drops that gate in both reporters so the group title and count always show. Other reporters are unchanged.

Fixes #1793
