### PR TITLE
fix(ci): do not run integration on forks

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   publish:
     name: Build and publish Knip
+    if: ${{ github.repository_owner == 'webpro-nl' }}
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.publish.outputs.sha }}


### PR DESCRIPTION
#### Description

This PR adds a check to the `integration.yml` workflow to prevent it from running in any forks.
The reason is that in forks, the action is [failing every time](https://github.com/trueberryless/webpro-nl-knip/actions/workflows/integration.yml) because the GitHub app is not installed (and not permitted if installed I guess):

```bash
Check failed (404): {"url":"/check","statusCode":404,"statusMessage":"Not Found","message":"The app https://github.com/apps/pkg-pr-new is not installed on trueberryless/webpro-nl-knip.","stack":""}
```