### PR TITLE
chore(ci): improve security through specific permissions

### DIFF
--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -9,6 +9,8 @@ on:
     tags:
       - '!**'
 
+permissions: {}
+
 jobs:
   test:
     strategy:
@@ -19,6 +21,8 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/ci-legacy-5.0.4.yml
+++ b/.github/workflows/ci-legacy-5.0.4.yml
@@ -11,6 +11,8 @@ on:
     tags:
       - '!**'
 
+permissions: {}
+
 jobs:
   test:
     strategy:
@@ -25,6 +27,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} (Node v${{ matrix.node }})
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/ci-legacy-latest.yml
+++ b/.github/workflows/ci-legacy-latest.yml
@@ -11,10 +11,14 @@ on:
     tags:
       - '!**'
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Ubuntu/Node v22
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,14 @@ on:
     tags:
       - '!**'
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Ubuntu/Node v24
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,13 +14,15 @@ on:
     tags:
       - '!**'
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   publish:
     name: Build and publish Knip
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # comment on referenced issues
     outputs:
       sha: ${{ steps.publish.outputs.sha }}
     steps:
@@ -64,6 +66,8 @@ jobs:
     name: Run Knip in ${{ matrix.project.name }}
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       PKG_URL: https://pkg.pr.new/knip@${{ needs.publish.outputs.sha }}
       SNAP: ${{ github.workspace }}/.github/workflows/scripts/snap.sh
@@ -237,6 +241,8 @@ jobs:
     if: ${{ inputs.update_snapshots }}
     needs: integration
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,9 +7,13 @@ on:
     tags:
       - '!**'
 
+permissions: {}
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 


### PR DESCRIPTION
#### Description

This PR sets more specific permissions in the GitHub workflows, so that they are as minimal as possible for security reasons.

Discussed in #1849