### PR TITLE
Add regression coverage for workspace tsconfig paths

### DIFF
--- a/packages/knip/fixtures/workspaces/tsconfig-paths/apps/web/package.json
+++ b/packages/knip/fixtures/workspaces/tsconfig-paths/apps/web/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/workspaces-tsconfig-paths__web"
+}

--- a/packages/knip/fixtures/workspaces/tsconfig-paths/apps/web/src/index.ts
+++ b/packages/knip/fixtures/workspaces/tsconfig-paths/apps/web/src/index.ts
@@ -1,0 +1,3 @@
+import { used } from '~/utils';
+
+used();

--- a/packages/knip/fixtures/workspaces/tsconfig-paths/apps/web/src/utils.ts
+++ b/packages/knip/fixtures/workspaces/tsconfig-paths/apps/web/src/utils.ts
@@ -1,0 +1,1 @@
+export const used = () => true;

--- a/packages/knip/fixtures/workspaces/tsconfig-paths/apps/web/tsconfig.json
+++ b/packages/knip/fixtures/workspaces/tsconfig-paths/apps/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/knip/fixtures/workspaces/tsconfig-paths/package.json
+++ b/packages/knip/fixtures/workspaces/tsconfig-paths/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixtures/workspaces-tsconfig-paths",
+  "workspaces": ["apps/*"],
+  "knip": {
+    "workspaces": {
+      "apps/web": {}
+    }
+  }
+}

--- a/packages/knip/test/workspaces/tsconfig-paths.test.ts
+++ b/packages/knip/test/workspaces/tsconfig-paths.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/workspaces/tsconfig-paths');
+
+test('Resolve workspace imports using compilerOptions.paths from workspace tsconfig', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a workspace fixture where a package imports through `~/*` and only declares that alias in the workspace `tsconfig.json`.
- Covers the case where `knip.json` has an explicit workspace object but no duplicate `paths` config.

## Context

This mirrors a real monorepo shape where `knip@6.15.0` reports unresolved `~/...` imports unless the same alias is repeated under `workspaces.*.paths` in `knip.jsonc`.

Current `main` already resolves this correctly, so this PR preserves that behavior with focused regression coverage.

## Validation

- `bun test packages/knip/test/workspaces/tsconfig-paths.test.ts`
- `bun test packages/knip/test/workspaces/paths.test.ts packages/knip/test/workspaces/workspace-scoped-paths.test.ts packages/knip/test/resolution/module-resolution-tsconfig-paths.test.ts`
- Verified against the rip-technologies repo with those workspace `paths` overrides removed: current `knip@6.15.0` reports unresolved `~/...` imports, while Knip `main` reports no `files` or `unresolved` issues; only unrelated stale ignore-dependency hints remain.
