### PR TITLE
Improve Serverless imported handler detection

### DIFF
--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/node_modules/serverless/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/node_modules/serverless/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "serverless",
+  "bin": {
+    "serverless": "bin/serverless.js",
+    "sls": "bin/serverless.js"
+  }
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/package.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@plugins/serverless-framework-typescript-imported-functions",
+  "scripts": {
+    "serverless": "serverless print"
+  },
+  "devDependencies": {
+    "@serverless/typescript": "*",
+    "esbuild": "*",
+    "serverless": "*",
+    "serverless-esbuild": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/scripts/cjs-shim.mjs
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/scripts/cjs-shim.mjs
@@ -1,0 +1,1 @@
+export const require = () => {};

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/scripts/secrets.cjs
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/scripts/secrets.cjs
@@ -1,0 +1,1 @@
+module.exports.getSecrets = () => ({});

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/serverless.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/serverless.ts
@@ -1,0 +1,24 @@
+import type { AWS } from '@serverless/typescript';
+import { processNewFile } from './src/functions/process-new-file';
+
+const config: AWS = {
+  service: 'typescript-serverless-imported-functions',
+  frameworkVersion: '4',
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs22.x',
+  },
+  custom: {
+    SECRETS: '${file(./scripts/secrets.cjs):getSecrets}',
+    esbuild: {
+      inject: ['./scripts/cjs-shim.mjs'],
+      target: 'node22',
+    },
+  },
+  plugins: ['serverless-esbuild'],
+  functions: {
+    processNewFile,
+  },
+};
+
+export default config;

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/functions/process-new-file/handler.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/functions/process-new-file/handler.ts
@@ -1,0 +1,3 @@
+import { createMessage } from './message.ts';
+
+export default () => createMessage();

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/functions/process-new-file/index.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/functions/process-new-file/index.ts
@@ -1,0 +1,17 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { TOPIC_NAME } from '~/libs/constants';
+import handlerPath from '~/libs/handler-resolver';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const processNewFile = {
+  events: [
+    {
+      sns: {
+        topicName: TOPIC_NAME,
+      },
+    },
+  ],
+  handler: `${handlerPath(__dirname)}/handler.default`,
+};

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/functions/process-new-file/message.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/functions/process-new-file/message.ts
@@ -1,0 +1,1 @@
+export const createMessage = () => 'done';

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/functions/process-new-file/unused.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/functions/process-new-file/unused.ts
@@ -1,0 +1,1 @@
+export const unused = true;

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/libs/constants.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/libs/constants.ts
@@ -1,0 +1,1 @@
+export const TOPIC_NAME = 'topic-name';

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/libs/handler-resolver.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/src/libs/handler-resolver.ts
@@ -1,0 +1,3 @@
+const handlerPath = (context: string) => context;
+
+export default handlerPath;

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/tsconfig.json
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-imported-functions/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": {
+      "~/*": ["src/*"]
+    },
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["serverless.ts", "src/**/*.ts"]
+}

--- a/packages/knip/src/plugins/serverless-framework/helpers.ts
+++ b/packages/knip/src/plugins/serverless-framework/helpers.ts
@@ -1,5 +1,5 @@
-import { toDependency, toProductionEntry } from '../../util/input.ts';
-import { isInternal, join } from '../../util/path.ts';
+import { toDeferResolve, toDeferResolveProductionEntry, toProductionEntry } from '../../util/input.ts';
+import { isInternal } from '../../util/path.ts';
 
 export const handlerToEntry = (handler: string) => {
   const dot = handler.lastIndexOf('.');
@@ -7,4 +7,4 @@ export const handlerToEntry = (handler: string) => {
 };
 
 export const pluginToInput = (plugin: string, dir: string) =>
-  isInternal(plugin) ? toProductionEntry(join(dir, plugin)) : toDependency(plugin);
+  isInternal(plugin) ? toDeferResolveProductionEntry(plugin, { dir }) : toDeferResolve(plugin, { dir });

--- a/packages/knip/src/plugins/serverless-framework/helpers.ts
+++ b/packages/knip/src/plugins/serverless-framework/helpers.ts
@@ -1,0 +1,10 @@
+import { toDependency, toProductionEntry } from '../../util/input.ts';
+import { isInternal, join } from '../../util/path.ts';
+
+export const handlerToEntry = (handler: string) => {
+  const dot = handler.lastIndexOf('.');
+  return toProductionEntry(`${handler.slice(0, dot)}.{js,ts}`);
+};
+
+export const pluginToInput = (plugin: string, dir: string) =>
+  isInternal(plugin) ? toProductionEntry(join(dir, plugin)) : toDependency(plugin);

--- a/packages/knip/src/plugins/serverless-framework/index.ts
+++ b/packages/knip/src/plugins/serverless-framework/index.ts
@@ -1,8 +1,10 @@
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
 import { arrayify } from '../../util/array.ts';
 import { toDependency, toProductionEntry } from '../../util/input.ts';
-import { isInternal, join } from '../../util/path.ts';
+import { join } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
+import { handlerToEntry, pluginToInput } from './helpers.ts';
+import { getInputsFromAST } from './resolveFromAST.ts';
 import type { EsbuildConfig, PluginConfig } from './types.ts';
 
 // https://www.serverless.com/framework/docs
@@ -14,14 +16,6 @@ const enablers = ['serverless'];
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
 const config = ['serverless.{js,cjs,mjs,ts,cts,mts,yml,yaml}'];
-
-const handlerToEntry = (handler: string) => {
-  const dot = handler.lastIndexOf('.');
-  return toProductionEntry(`${handler.slice(0, dot)}.{js,ts}`);
-};
-
-const pluginToInput = (plugin: string, dir: string) =>
-  isInternal(plugin) ? toProductionEntry(join(dir, plugin)) : toDependency(plugin);
 
 const getInjectEntries = (esbuild: EsbuildConfig | undefined, dir: string) =>
   esbuild && typeof esbuild === 'object' ? arrayify(esbuild.inject).map(id => toProductionEntry(join(dir, id))) : [];
@@ -51,6 +45,7 @@ const plugin: Plugin = {
   isEnabled,
   config,
   resolveConfig,
+  resolveFromAST: getInputsFromAST,
 };
 
 export default plugin;

--- a/packages/knip/src/plugins/serverless-framework/resolveFromAST.ts
+++ b/packages/knip/src/plugins/serverless-framework/resolveFromAST.ts
@@ -1,6 +1,15 @@
-import { Visitor, type Program } from 'oxc-parser';
+import type {
+  BindingIdentifier,
+  Expression,
+  IdentifierName,
+  IdentifierReference,
+  Node,
+  ObjectExpression,
+  Program,
+  TemplateLiteral,
+} from 'oxc-parser';
 import type { ResolveFromAST } from '../../types/config.ts';
-import { collectPropertyValues, getImportMap, getPropertyKey, getStringValues } from '../../typescript/ast-helpers.ts';
+import { getImportMap, getPropertyKey, getStringValues } from '../../typescript/ast-helpers.ts';
 import { _parseFile, getStringValue } from '../../typescript/ast-nodes.ts';
 import type { Input } from '../../util/input.ts';
 import { toDependency, toProductionEntry } from '../../util/input.ts';
@@ -10,12 +19,38 @@ import { handlerToEntry, pluginToInput } from './helpers.ts';
 
 const serverlessFileReference = /\$\{file\(([^):]+)\)(?::[^}]*)?\}/g;
 
-const unwrapExpression = (node: any): any => {
+type Identifier = BindingIdentifier | IdentifierName | IdentifierReference;
+
+const isIdentifier = (node: Node | null | undefined, name?: string): node is Identifier =>
+  node?.type === 'Identifier' && (name === undefined || node.name === name);
+
+const isNode = (value: unknown): value is Node =>
+  value !== null &&
+  typeof value === 'object' &&
+  'type' in value &&
+  typeof (value as { type?: unknown }).type === 'string';
+
+const walkNode = (node: Node, visit: (node: Node) => void, seen = new Set<Node>()) => {
+  if (seen.has(node)) return;
+  seen.add(node);
+  visit(node);
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'parent') continue;
+    if (Array.isArray(value)) {
+      for (const item of value) if (isNode(item)) walkNode(item, visit, seen);
+    } else if (isNode(value)) {
+      walkNode(value, visit, seen);
+    }
+  }
+};
+
+const unwrapExpression = (node: Expression): Expression => {
   if (
-    node?.type === 'ParenthesizedExpression' ||
-    node?.type === 'TSAsExpression' ||
-    node?.type === 'TSSatisfiesExpression' ||
-    node?.type === 'TSTypeAssertion'
+    node.type === 'ParenthesizedExpression' ||
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSTypeAssertion'
   ) {
     return unwrapExpression(node.expression);
   }
@@ -23,33 +58,26 @@ const unwrapExpression = (node: any): any => {
   return node;
 };
 
-const containsIdentifier = (node: any, name: string, seen = new Set<any>()): boolean => {
-  if (!node || typeof node !== 'object') return false;
-  if (seen.has(node)) return false;
-  if (node.type === 'Identifier' && node.name === name) return true;
-
-  seen.add(node);
-
-  for (const value of Object.values(node)) {
-    if (Array.isArray(value)) {
-      if (value.some(item => containsIdentifier(item, name, seen))) return true;
-    } else if (containsIdentifier(value, name, seen)) {
-      return true;
-    }
-  }
-
-  return false;
+const containsIdentifier = (node: Node, name: string) => {
+  let result = false;
+  walkNode(node, node => {
+    if (isIdentifier(node, name)) result = true;
+  });
+  return result;
 };
 
-const getTemplateHandler = (node: any, containingFilePath: string, options: Parameters<ResolveFromAST>[1]) => {
-  if (node?.type !== 'TemplateLiteral') return;
-  if (node.expressions?.length !== 1) return;
+const getTemplateHandler = (
+  node: TemplateLiteral,
+  containingFilePath: string,
+  options: Parameters<ResolveFromAST>[1]
+) => {
+  if (node.expressions.length !== 1) return;
   if (!containsIdentifier(node.expressions[0], '__dirname')) return;
 
-  const prefix = node.quasis?.[0]?.value?.cooked ?? node.quasis?.[0]?.value?.raw;
-  const suffix = node.quasis?.[1]?.value?.cooked ?? node.quasis?.[1]?.value?.raw;
+  const prefix = node.quasis[0]?.value.cooked ?? node.quasis[0]?.value.raw;
+  const suffix = node.quasis[1]?.value.cooked ?? node.quasis[1]?.value.raw;
 
-  if (prefix !== '' || !suffix?.startsWith('/')) return;
+  if (prefix !== '' || !suffix.startsWith('/')) return;
 
   const absoluteContainingFilePath = toAbsolute(containingFilePath, options.cwd);
   const configRelativeDir = relative(options.configFileDir, dirname(absoluteContainingFilePath));
@@ -57,27 +85,178 @@ const getTemplateHandler = (node: any, containingFilePath: string, options: Para
   return join(configRelativeDir, suffix);
 };
 
-const getHandlerInputs = (node: any, containingFilePath: string, options: Parameters<ResolveFromAST>[1]) => {
-  const handler = getStringValue(node) ?? getTemplateHandler(node, containingFilePath, options);
+const getHandlerInputs = (node: Expression, containingFilePath: string, options: Parameters<ResolveFromAST>[1]) => {
+  const expression = unwrapExpression(node);
+  const handler =
+    getStringValue(expression) ??
+    (expression.type === 'TemplateLiteral' ? getTemplateHandler(expression, containingFilePath, options) : undefined);
   return handler ? [handlerToEntry(handler)] : [];
 };
 
-const getHandlerInputsFromProgram = (
-  program: Program,
+const getObjectPropertyValue = (node: ObjectExpression, name: string) => {
+  for (const prop of node.properties) {
+    if (prop.type === 'Property' && getPropertyKey(prop) === name) return prop.value;
+  }
+};
+
+const getTopLevelObjectDeclarations = (program: Program) => {
+  const declarations = new Map<string, Expression>();
+
+  const addDeclaration = (node: Node) => {
+    if (node.type === 'FunctionDeclaration' && node.id) {
+      declarations.set(node.id.name, node);
+      return;
+    }
+
+    if (node.type !== 'VariableDeclaration') return;
+    for (const declaration of node.declarations) {
+      if (isIdentifier(declaration.id) && declaration.init) declarations.set(declaration.id.name, declaration.init);
+    }
+  };
+
+  for (const statement of program.body) {
+    addDeclaration(statement);
+    if (statement.type === 'ExportNamedDeclaration' && statement.declaration) addDeclaration(statement.declaration);
+  }
+
+  return declarations;
+};
+
+type Declarations = ReturnType<typeof getTopLevelObjectDeclarations>;
+
+const getReturnedObjectExpressions = (node: Expression, declarations: Declarations) => {
+  const expression = unwrapExpression(node);
+
+  if (expression.type === 'ArrowFunctionExpression') {
+    if (expression.body.type !== 'BlockStatement') return getObjectExpressions(expression.body, declarations);
+
+    return expression.body.body.flatMap(statement =>
+      statement.type === 'ReturnStatement' && statement.argument
+        ? getObjectExpressions(statement.argument, declarations)
+        : []
+    );
+  }
+
+  if (expression.type === 'FunctionDeclaration' || expression.type === 'FunctionExpression') {
+    if (!expression.body) return [];
+
+    return expression.body.body.flatMap(statement =>
+      statement.type === 'ReturnStatement' && statement.argument
+        ? getObjectExpressions(statement.argument, declarations)
+        : []
+    );
+  }
+
+  return [];
+};
+
+const getObjectExpressions = (
+  node: Expression | undefined,
+  declarations: Declarations,
+  seen = new Set<string>()
+): ObjectExpression[] => {
+  if (!node) return [];
+
+  const expression = unwrapExpression(node);
+
+  if (expression.type === 'ObjectExpression') return [expression];
+  if (expression.type === 'ConditionalExpression') {
+    return [
+      ...getObjectExpressions(expression.consequent, declarations, seen),
+      ...getObjectExpressions(expression.alternate, declarations, seen),
+    ];
+  }
+  if (expression.type === 'CallExpression' && isIdentifier(expression.callee)) {
+    const declaration = declarations.get(expression.callee.name);
+    return declaration ? getReturnedObjectExpressions(declaration, declarations) : [];
+  }
+  if (isIdentifier(expression)) {
+    if (seen.has(expression.name)) return [];
+    const declaration = declarations.get(expression.name);
+    if (!declaration) return [];
+
+    seen.add(expression.name);
+    return getObjectExpressions(declaration, declarations, seen);
+  }
+
+  return getReturnedObjectExpressions(expression, declarations);
+};
+
+const getObjectExpression = (node: Expression | undefined, declarations: Declarations) =>
+  getObjectExpressions(node, declarations)[0];
+
+const walkResolvedNode = (
+  node: Node,
+  declarations: Declarations,
+  visit: (node: Node) => void,
+  seen = new Set<Node>()
+) => {
+  if (seen.has(node)) return;
+  seen.add(node);
+  visit(node);
+
+  if (isIdentifier(node)) {
+    const declaration = declarations.get(node.name);
+    if (declaration) walkResolvedNode(declaration, declarations, visit, seen);
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'parent') continue;
+    if (Array.isArray(value)) {
+      for (const item of value) if (isNode(item)) walkResolvedNode(item, declarations, visit, seen);
+    } else if (isNode(value)) {
+      walkResolvedNode(value, declarations, visit, seen);
+    }
+  }
+};
+
+const getServerlessConfigObject = (program: Program, declarations: Declarations) => {
+  const getConfig = (node: Expression) => getObjectExpression(node, declarations);
+
+  for (const statement of program.body) {
+    if (statement.type === 'ExportDefaultDeclaration') {
+      if (statement.declaration.type === 'TSInterfaceDeclaration') continue;
+      const config = getConfig(statement.declaration);
+      if (config) return config;
+    }
+
+    if (statement.type !== 'ExpressionStatement') continue;
+    const expression = statement.expression;
+    if (expression.type !== 'AssignmentExpression') continue;
+    if (!isMemberExpressionPath(expression.left, ['module', 'exports'])) continue;
+    const config = getConfig(expression.right);
+    if (config) return config;
+  }
+};
+
+const isMemberExpressionPath = (node: Node, path: string[]): boolean => {
+  const [first, ...rest] = path;
+  if (!first) return false;
+  if (rest.length === 0) return isIdentifier(node, first);
+  if (node.type !== 'MemberExpression' || node.computed) return false;
+  return isMemberExpressionPath(node.object, path.slice(0, -1)) && isIdentifier(node.property, path.at(-1));
+};
+
+const getHandlerInputsFromFunctionObject = (
+  functionConfig: ObjectExpression,
   containingFilePath: string,
   options: Parameters<ResolveFromAST>[1]
 ) => {
-  const inputs: Input[] = [];
-  const visitor = new Visitor({
-    Property(node) {
-      if (getPropertyKey(node) === 'handler') inputs.push(...getHandlerInputs(node.value, containingFilePath, options));
-    },
-  });
-  visitor.visit(program);
-  return inputs;
+  const handler = getObjectPropertyValue(functionConfig, 'handler');
+  return handler ? getHandlerInputs(handler, containingFilePath, options) : [];
 };
 
-const getHandlerInputsFromImportedFunctionConfigs = (program: Program, options: Parameters<ResolveFromAST>[1]) => {
+const getImportedFunctionObject = (program: Program, identifierName: string) => {
+  const declarations = getTopLevelObjectDeclarations(program);
+  const declaration = declarations.get(identifierName);
+  return getObjectExpression(declaration, declarations);
+};
+
+const getFunctionInputsFromObject = (
+  functions: ObjectExpression,
+  program: Program,
+  options: Parameters<ResolveFromAST>[1]
+) => {
   const inputs: Input[] = [];
   const importMap = getImportMap(program);
   const visited = new Set<string>();
@@ -93,34 +272,49 @@ const getHandlerInputsFromImportedFunctionConfigs = (program: Program, options: 
     if (visited.has(resolvedFilePath)) return;
 
     visited.add(resolvedFilePath);
+    inputs.push(toProductionEntry(relative(options.configFileDir, resolvedFilePath)));
 
-    const sourceText = options.readFile(resolvedFilePath);
-    if (!sourceText) return;
+    try {
+      const sourceText = options.readFile(resolvedFilePath);
+      if (!sourceText) return;
 
-    const importedProgram = _parseFile(resolvedFilePath, sourceText).program;
-    inputs.push(...getHandlerInputsFromProgram(importedProgram, resolvedFilePath, options));
+      const importedProgram = _parseFile(resolvedFilePath, sourceText).program;
+      const functionConfig = getImportedFunctionObject(importedProgram, identifierName);
+      if (functionConfig) inputs.push(...getHandlerInputsFromFunctionObject(functionConfig, resolvedFilePath, options));
+    } catch {}
   };
 
-  const visitor = new Visitor({
-    Property(node) {
-      if (getPropertyKey(node) !== 'functions') return;
-      const functions = unwrapExpression(node.value);
-      if (functions?.type !== 'ObjectExpression') return;
+  for (const prop of functions.properties) {
+    if (prop.type !== 'Property') continue;
+    const value = unwrapExpression(prop.value);
 
-      for (const prop of functions.properties ?? []) {
-        if (prop.type !== 'Property') continue;
-        if (prop.value?.type === 'Identifier') addImportedFunctionConfig(prop.value.name);
-      }
-    },
-  });
-  visitor.visit(program);
+    if (value.type === 'Identifier') {
+      addImportedFunctionConfig(value.name);
+    } else if (value.type === 'ObjectExpression') {
+      inputs.push(...getHandlerInputsFromFunctionObject(value, options.configFilePath, options));
+    }
+  }
 
   return inputs;
 };
 
-const getServerlessFileReferenceInputs = (program: Program, configFileDir: string) => {
+const getFunctionInputs = (
+  config: ObjectExpression,
+  program: Program,
+  declarations: Declarations,
+  options: Parameters<ResolveFromAST>[1]
+) => {
+  const functions = getObjectExpression(getObjectPropertyValue(config, 'functions'), declarations);
+  return functions ? getFunctionInputsFromObject(functions, program, options) : [];
+};
+
+const getServerlessFileReferenceInputs = (
+  config: ObjectExpression,
+  declarations: Declarations,
+  configFileDir: string
+) => {
   const inputs: Input[] = [];
-  const addFileReferences = (node: any) => {
+  const addFileReferences = (node: Node) => {
     const value = getStringValue(node);
     if (!value) return;
 
@@ -130,35 +324,56 @@ const getServerlessFileReferenceInputs = (program: Program, configFileDir: strin
     }
   };
 
-  const visitor = new Visitor({
-    Property(node) {
-      addFileReferences(node.value);
-    },
-  });
-  visitor.visit(program);
+  walkResolvedNode(config, declarations, addFileReferences);
 
   return inputs;
 };
 
-const getEsbuildInjectInputs = (program: Program, configFileDir: string) => {
+const getPluginInputs = (config: ObjectExpression, configFileDir: string) => {
+  const plugins = getObjectPropertyValue(config, 'plugins');
+  return plugins ? Array.from(getStringValues(plugins)).map(plugin => pluginToInput(plugin, configFileDir)) : [];
+};
+
+const getEsbuildConfigObjects = (config: ObjectExpression, declarations: Declarations) => {
+  const objects: ObjectExpression[] = [];
+  const customObjects = getObjectExpressions(getObjectPropertyValue(config, 'custom'), declarations);
+  const buildObjects = getObjectExpressions(getObjectPropertyValue(config, 'build'), declarations);
+
+  for (const custom of customObjects) {
+    objects.push(...getObjectExpressions(getObjectPropertyValue(custom, 'esbuild'), declarations));
+  }
+
+  for (const build of buildObjects) {
+    objects.push(...getObjectExpressions(getObjectPropertyValue(build, 'esbuild'), declarations));
+  }
+
+  return objects;
+};
+
+const getEsbuildInjectInputs = (config: ObjectExpression, declarations: Declarations, configFileDir: string) => {
   const inputs: Input[] = [];
-  const visitor = new Visitor({
-    Property(node) {
-      if (getPropertyKey(node) !== 'inject') return;
+  for (const esbuildConfig of getEsbuildConfigObjects(config, declarations)) {
+    for (const node of esbuildConfig.properties) {
+      if (node.type !== 'Property' || getPropertyKey(node) !== 'inject') continue;
       for (const value of getStringValues(node.value)) {
         if (value.startsWith('.')) inputs.push(toProductionEntry(join(configFileDir, value)));
       }
-    },
-  });
-  visitor.visit(program);
+    }
+  }
+
   return inputs;
 };
 
-export const getInputsFromAST: ResolveFromAST = (program, options) => [
-  ...getHandlerInputsFromProgram(program, options.configFilePath, options),
-  ...getHandlerInputsFromImportedFunctionConfigs(program, options),
-  ...Array.from(collectPropertyValues(program, 'plugins')).map(plugin => pluginToInput(plugin, options.configFileDir)),
-  ...getServerlessFileReferenceInputs(program, options.configFileDir),
-  ...getEsbuildInjectInputs(program, options.configFileDir),
-  ...(collectPropertyValues(program, 'esbuild').size > 0 ? [toDependency('esbuild', { optional: true })] : []),
-];
+export const getInputsFromAST: ResolveFromAST = (program, options) => {
+  const declarations = getTopLevelObjectDeclarations(program);
+  const config = getServerlessConfigObject(program, declarations);
+  if (!config) return [];
+
+  return [
+    ...getFunctionInputs(config, program, declarations, options),
+    ...getPluginInputs(config, options.configFileDir),
+    ...getServerlessFileReferenceInputs(config, declarations, options.configFileDir),
+    ...getEsbuildInjectInputs(config, declarations, options.configFileDir),
+    ...(getEsbuildConfigObjects(config, declarations).length > 0 ? [toDependency('esbuild', { optional: true })] : []),
+  ];
+};

--- a/packages/knip/src/plugins/serverless-framework/resolveFromAST.ts
+++ b/packages/knip/src/plugins/serverless-framework/resolveFromAST.ts
@@ -1,0 +1,164 @@
+import { Visitor, type Program } from 'oxc-parser';
+import type { ResolveFromAST } from '../../types/config.ts';
+import { collectPropertyValues, getImportMap, getPropertyKey, getStringValues } from '../../typescript/ast-helpers.ts';
+import { _parseFile, getStringValue } from '../../typescript/ast-nodes.ts';
+import type { Input } from '../../util/input.ts';
+import { toDependency, toProductionEntry } from '../../util/input.ts';
+import { dirname, join, relative, toAbsolute } from '../../util/path.ts';
+import { _resolveSync } from '../../util/resolve.ts';
+import { handlerToEntry, pluginToInput } from './helpers.ts';
+
+const serverlessFileReference = /\$\{file\(([^):]+)\)(?::[^}]*)?\}/g;
+
+const unwrapExpression = (node: any): any => {
+  if (
+    node?.type === 'ParenthesizedExpression' ||
+    node?.type === 'TSAsExpression' ||
+    node?.type === 'TSSatisfiesExpression' ||
+    node?.type === 'TSTypeAssertion'
+  ) {
+    return unwrapExpression(node.expression);
+  }
+
+  return node;
+};
+
+const containsIdentifier = (node: any, name: string, seen = new Set<any>()): boolean => {
+  if (!node || typeof node !== 'object') return false;
+  if (seen.has(node)) return false;
+  if (node.type === 'Identifier' && node.name === name) return true;
+
+  seen.add(node);
+
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      if (value.some(item => containsIdentifier(item, name, seen))) return true;
+    } else if (containsIdentifier(value, name, seen)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const getTemplateHandler = (node: any, containingFilePath: string, options: Parameters<ResolveFromAST>[1]) => {
+  if (node?.type !== 'TemplateLiteral') return;
+  if (node.expressions?.length !== 1) return;
+  if (!containsIdentifier(node.expressions[0], '__dirname')) return;
+
+  const prefix = node.quasis?.[0]?.value?.cooked ?? node.quasis?.[0]?.value?.raw;
+  const suffix = node.quasis?.[1]?.value?.cooked ?? node.quasis?.[1]?.value?.raw;
+
+  if (prefix !== '' || !suffix?.startsWith('/')) return;
+
+  const absoluteContainingFilePath = toAbsolute(containingFilePath, options.cwd);
+  const configRelativeDir = relative(options.configFileDir, dirname(absoluteContainingFilePath));
+
+  return join(configRelativeDir, suffix);
+};
+
+const getHandlerInputs = (node: any, containingFilePath: string, options: Parameters<ResolveFromAST>[1]) => {
+  const handler = getStringValue(node) ?? getTemplateHandler(node, containingFilePath, options);
+  return handler ? [handlerToEntry(handler)] : [];
+};
+
+const getHandlerInputsFromProgram = (
+  program: Program,
+  containingFilePath: string,
+  options: Parameters<ResolveFromAST>[1]
+) => {
+  const inputs: Input[] = [];
+  const visitor = new Visitor({
+    Property(node) {
+      if (getPropertyKey(node) === 'handler') inputs.push(...getHandlerInputs(node.value, containingFilePath, options));
+    },
+  });
+  visitor.visit(program);
+  return inputs;
+};
+
+const getHandlerInputsFromImportedFunctionConfigs = (program: Program, options: Parameters<ResolveFromAST>[1]) => {
+  const inputs: Input[] = [];
+  const importMap = getImportMap(program);
+  const visited = new Set<string>();
+
+  const addImportedFunctionConfig = (identifierName: string) => {
+    const importPath = importMap.get(identifierName);
+    if (!importPath) return;
+
+    const resolvedPath = _resolveSync(importPath, options.configFileDir);
+    if (!resolvedPath) return;
+
+    const resolvedFilePath = toAbsolute(resolvedPath, options.cwd);
+    if (visited.has(resolvedFilePath)) return;
+
+    visited.add(resolvedFilePath);
+
+    const sourceText = options.readFile(resolvedFilePath);
+    if (!sourceText) return;
+
+    const importedProgram = _parseFile(resolvedFilePath, sourceText).program;
+    inputs.push(...getHandlerInputsFromProgram(importedProgram, resolvedFilePath, options));
+  };
+
+  const visitor = new Visitor({
+    Property(node) {
+      if (getPropertyKey(node) !== 'functions') return;
+      const functions = unwrapExpression(node.value);
+      if (functions?.type !== 'ObjectExpression') return;
+
+      for (const prop of functions.properties ?? []) {
+        if (prop.type !== 'Property') continue;
+        if (prop.value?.type === 'Identifier') addImportedFunctionConfig(prop.value.name);
+      }
+    },
+  });
+  visitor.visit(program);
+
+  return inputs;
+};
+
+const getServerlessFileReferenceInputs = (program: Program, configFileDir: string) => {
+  const inputs: Input[] = [];
+  const addFileReferences = (node: any) => {
+    const value = getStringValue(node);
+    if (!value) return;
+
+    for (const match of value.matchAll(serverlessFileReference)) {
+      const filePath = match[1];
+      if (filePath) inputs.push(toProductionEntry(join(configFileDir, filePath)));
+    }
+  };
+
+  const visitor = new Visitor({
+    Property(node) {
+      addFileReferences(node.value);
+    },
+  });
+  visitor.visit(program);
+
+  return inputs;
+};
+
+const getEsbuildInjectInputs = (program: Program, configFileDir: string) => {
+  const inputs: Input[] = [];
+  const visitor = new Visitor({
+    Property(node) {
+      if (getPropertyKey(node) !== 'inject') return;
+      for (const value of getStringValues(node.value)) {
+        if (value.startsWith('.')) inputs.push(toProductionEntry(join(configFileDir, value)));
+      }
+    },
+  });
+  visitor.visit(program);
+  return inputs;
+};
+
+export const getInputsFromAST: ResolveFromAST = (program, options) => [
+  ...getHandlerInputsFromProgram(program, options.configFilePath, options),
+  ...getHandlerInputsFromImportedFunctionConfigs(program, options),
+  ...Array.from(collectPropertyValues(program, 'plugins')).map(plugin => pluginToInput(plugin, options.configFileDir)),
+  ...getServerlessFileReferenceInputs(program, options.configFileDir),
+  ...getEsbuildInjectInputs(program, options.configFileDir),
+  ...(collectPropertyValues(program, 'esbuild').size > 0 ? [toDependency('esbuild', { optional: true })] : []),
+];

--- a/packages/knip/test/plugins/serverless-framework.test.ts
+++ b/packages/knip/test/plugins/serverless-framework.test.ts
@@ -34,12 +34,12 @@ test('Find dependencies from Serverless Framework TypeScript plugins', async () 
 
 test('Find imported TypeScript function handlers from Serverless Framework config', async () => {
   const options = await createOptions({ cwd: typescriptImportedFunctionsCwd });
-  const { issues } = await main(options);
+  const { counters } = await main(options);
 
-  assert(!('scripts/cjs-shim.mjs' in issues.files));
-  assert(!('scripts/secrets.cjs' in issues.files));
-  assert(!('src/functions/process-new-file/handler.ts' in issues.files));
-  assert(!('src/functions/process-new-file/message.ts' in issues.files));
-  assert('src/functions/process-new-file/unused.ts' in issues.files);
-  assert.deepEqual(issues.devDependencies, {});
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    files: 1,
+    processed: 9,
+    total: 9,
+  });
 });

--- a/packages/knip/test/plugins/serverless-framework.test.ts
+++ b/packages/knip/test/plugins/serverless-framework.test.ts
@@ -7,6 +7,7 @@ import { resolve } from '../helpers/resolve.ts';
 
 const cwd = resolve('fixtures/plugins/serverless-framework');
 const typescriptPluginsCwd = resolve('fixtures/plugins/serverless-framework-typescript-plugins');
+const typescriptImportedFunctionsCwd = resolve('fixtures/plugins/serverless-framework-typescript-imported-functions');
 
 test('Find dependencies with the Serverless Framework plugin', async () => {
   const options = await createOptions({ cwd });
@@ -28,5 +29,17 @@ test('Find dependencies from Serverless Framework TypeScript plugins', async () 
     processed: 5,
     total: 5,
   });
+  assert.deepEqual(issues.devDependencies, {});
+});
+
+test('Find imported TypeScript function handlers from Serverless Framework config', async () => {
+  const options = await createOptions({ cwd: typescriptImportedFunctionsCwd });
+  const { issues } = await main(options);
+
+  assert(!('scripts/cjs-shim.mjs' in issues.files));
+  assert(!('scripts/secrets.cjs' in issues.files));
+  assert(!('src/functions/process-new-file/handler.ts' in issues.files));
+  assert(!('src/functions/process-new-file/message.ts' in issues.files));
+  assert('src/functions/process-new-file/unused.ts' in issues.files);
   assert.deepEqual(issues.devDependencies, {});
 });


### PR DESCRIPTION
## Summary

Improves the Serverless Framework plugin so it can discover production entries from TypeScript configs that cannot be fully loaded but are still statically inspectable.

This adds an AST fallback that:

- reads `functions` object entries that reference imported local function configs
- resolves handler templates based on `__dirname`, such as `` `${handlerPath(__dirname)}/handler.default` ``
- marks local Serverless `${file(...)}` references and esbuild `inject` files as production entries
- keeps the existing loaded-config behavior for simple/literal configs

## Why

Projects can split Serverless function configs into imported modules. If those modules use path aliases or other runtime-only config, loading the full `serverless.ts` can fail or be incomplete, so Knip may miss Lambda handler entrypoints and report reachable files as unused.

## Validation

- `node --test packages/knip/test/plugins/serverless-framework.test.ts`
- `corepack pnpm --dir packages/knip fmt`
- `corepack pnpm --dir packages/knip lint`
- `corepack pnpm --dir packages/knip build`
- `corepack pnpm --dir packages/knip test`
