### PR TITLE
chore(ci): remove redundant tag triggers

### DIFF
--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - '**'
-    tags:
-      - '!**'
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:

--- a/.github/workflows/ci-legacy-5.0.4.yml
+++ b/.github/workflows/ci-legacy-5.0.4.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - '**'
-    tags:
-      - '!**'
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:

--- a/.github/workflows/ci-legacy-latest.yml
+++ b/.github/workflows/ci-legacy-latest.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - '**'
-    tags:
-      - '!**'
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - '**'
-    tags:
-      - '!**'
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches:
       - '**'
-    tags:
-      - '!**'
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - '**'
-    tags:
-      - '!**'
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:


### PR DESCRIPTION
#### Description

This PR removes all the "anti" tag triggers, which were added [in this commit](https://github.com/webpro-nl/knip/commit/66a3d31554da21b2b22fcf42b9bd1beeaf77415b) to not trigger CI on tag creations, but because the triggers already specify that they should only trigger on branches, this `!` trigger is redundant.

This is the last improvement I have planned after discussing about CI in #1849 