### PR TITLE
Handle Serverless esbuild inject entries

### DIFF
--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/serverless.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/serverless.ts
@@ -11,7 +11,13 @@ const config: AWS = {
   custom: {
     esbuild: {
       bundle: true,
+      inject: ['./src/libs/commonjs-globals.ts'],
       target: 'node22',
+    },
+  },
+  build: {
+    esbuild: {
+      inject: ['./src/libs/production-globals.ts'],
     },
   },
   plugins: ['serverless-esbuild', 'serverless-offline', 'serverless-offline-sns', 'serverless-offline-sqs'],

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/src/libs/commonjs-globals.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/src/libs/commonjs-globals.ts
@@ -1,0 +1,1 @@
+export const commonjsGlobal = 'commonjs';

--- a/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/src/libs/production-globals.ts
+++ b/packages/knip/fixtures/plugins/serverless-framework-typescript-plugins/src/libs/production-globals.ts
@@ -1,0 +1,1 @@
+export const productionGlobal = 'production';

--- a/packages/knip/src/plugins/serverless-framework/index.ts
+++ b/packages/knip/src/plugins/serverless-framework/index.ts
@@ -1,8 +1,9 @@
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
+import { arrayify } from '../../util/array.ts';
 import { toDependency, toProductionEntry } from '../../util/input.ts';
 import { isInternal, join } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
-import type { PluginConfig } from './types.ts';
+import type { EsbuildConfig, PluginConfig } from './types.ts';
 
 // https://www.serverless.com/framework/docs
 
@@ -22,14 +23,26 @@ const handlerToEntry = (handler: string) => {
 const pluginToInput = (plugin: string, dir: string) =>
   isInternal(plugin) ? toProductionEntry(join(dir, plugin)) : toDependency(plugin);
 
+const getInjectEntries = (esbuild: EsbuildConfig | undefined, dir: string) =>
+  esbuild && typeof esbuild === 'object' ? arrayify(esbuild.inject).map(id => toProductionEntry(join(dir, id))) : [];
+
 const resolveConfig: ResolveConfig<PluginConfig> = async (config, options) => {
   const functions = config.functions
     ? Object.values(config.functions).flatMap(fn => (fn.handler ? [handlerToEntry(fn.handler)] : []))
     : [];
   const plugins = config.plugins?.filter((plugin): plugin is string => typeof plugin === 'string') ?? [];
   const esbuild = config.custom?.esbuild || config.build?.esbuild ? [toDependency('esbuild', { optional: true })] : [];
+  const injectEntries = [
+    ...getInjectEntries(config.custom?.esbuild, options.configFileDir),
+    ...getInjectEntries(config.build?.esbuild, options.configFileDir),
+  ];
 
-  return [...functions, ...plugins.map(plugin => pluginToInput(plugin, options.configFileDir)), ...esbuild];
+  return [
+    ...functions,
+    ...plugins.map(plugin => pluginToInput(plugin, options.configFileDir)),
+    ...esbuild,
+    ...injectEntries,
+  ];
 };
 
 const plugin: Plugin = {

--- a/packages/knip/src/plugins/serverless-framework/types.ts
+++ b/packages/knip/src/plugins/serverless-framework/types.ts
@@ -1,13 +1,19 @@
 export type PluginConfig = {
   build?: {
-    esbuild?: unknown;
+    esbuild?: EsbuildConfig;
   };
   custom?: {
-    esbuild?: unknown;
+    esbuild?: EsbuildConfig;
   };
   functions?: Record<string, ServerlessFunction>;
   plugins?: unknown[];
 };
+
+export type EsbuildConfig =
+  | {
+      inject?: string | string[];
+    }
+  | boolean;
 
 type ServerlessFunction = {
   handler?: string;

--- a/packages/knip/src/plugins/serverless-framework/types.ts
+++ b/packages/knip/src/plugins/serverless-framework/types.ts
@@ -11,7 +11,7 @@ export type PluginConfig = {
 
 export type EsbuildConfig =
   | {
-      inject?: string | string[];
+      inject?: string[];
     }
   | boolean;
 

--- a/packages/knip/test/plugins/serverless-framework.test.ts
+++ b/packages/knip/test/plugins/serverless-framework.test.ts
@@ -25,8 +25,8 @@ test('Find dependencies from Serverless Framework TypeScript plugins', async () 
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 3,
-    total: 3,
+    processed: 5,
+    total: 5,
   });
   assert.deepEqual(issues.devDependencies, {});
 });


### PR DESCRIPTION
## Summary

- add Serverless Framework plugin entries for esbuild `inject` files from `custom.esbuild` and `build.esbuild`
- keep the existing optional `esbuild` dependency detection
- extend the TypeScript Serverless fixture to cover injected files

## Validation

- `node --test packages/knip/test/plugins/serverless-framework.test.ts`
- `corepack pnpm --dir packages/knip build`
- `corepack pnpm --dir packages/knip lint`
