### PR TITLE
docs: add links to Discord and Contributing in issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,12 +59,34 @@ Please consider this before opening a pull request:
 - After your first PR is merged, you are automatically added to the [list of
   contributors][8].
 
+### Contribute a new plugin
+
+Missing a plugin for a tool you use? Contributing one is often the fastest path
+to support — Knip ships with 150+ plugins, and most of them started as a PR from
+a user of the tool.
+
+To get started:
+
+1. Read the [Writing A Plugin][9] guide on knip.dev.
+
+2. Scaffold the plugin, tests and fixtures with the built-in generator:
+
+   ```sh
+   cd packages/knip
+   pnpm create-plugin --name your-tool
+   ```
+
+3. Follow the general [development][6] instructions.
+
+Feel free to open a draft PR early to get feedback, and look at similar plugins
+for inspiration.
+
 [1]: ./CODE_OF_CONDUCT.md
 [2]: https://knip.dev
 [3]: #open-an-issue
 [4]: #open-a-pull-request
 [5]: https://github.com/webpro-nl/knip/releases
 [6]: /.github/DEVELOPMENT.md
-[7]:
-  https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
+[7]: https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
 [8]: https://knip.dev/#created-by-awesome-contributors
+[9]: https://knip.dev/writing-a-plugin

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,11 @@
 blank_issues_enabled: false
+contact_links:
+  - name: 🧩 Contribute a new plugin
+    url: https://github.com/webpro-nl/knip/blob/main/.github/CONTRIBUTING.md#contribute-a-new-plugin
+    about: Missing a plugin for a tool you use? Consider contributing one — it's often the fastest path to support.
+  - name: 👾 Chat
+    url: https://chat.e18e.dev/
+    about: Join the `#knip` channel on the e18e Discord to chat with the community.
+  - name: 💁 Support
+    url: https://chat.e18e.dev/
+    about: This issue tracker is not for support questions. Ask for help in the `#knip` channel on the e18e Discord.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,3 @@ contact_links:
   - name: 👾 Chat
     url: https://chat.e18e.dev/
     about: Join the `#knip` channel on the e18e Discord to chat with the community.
-  - name: 💁 Support
-    url: https://chat.e18e.dev/
-    about: This issue tracker is not for support questions. Ask for help in the `#knip` channel on the e18e Discord.


### PR DESCRIPTION
#### Description

This PR adds three helpful links to the issue templates, namely: A link to `CONTRIBUTING.md` for new plugins (which is a new section in the Contribution guide) and two links to the e18e Discord server with notes for the `#knip` channel.

I think this would help people navigate around.