### PR TITLE
Add support for Prettier overrides

### DIFF
--- a/packages/knip/fixtures/plugins/prettier/prettier.config.js
+++ b/packages/knip/fixtures/plugins/prettier/prettier.config.js
@@ -1,4 +1,4 @@
 export default {
   plugins: ['prettier-plugin-xml', import.meta.resolve('prettier-plugin-astro')],
-  overrides: [{ options: 'prettier-plugin-java' }],
+  overrides: [{ options: { plugins: ['prettier-plugin-java'] } }],
 };

--- a/packages/knip/fixtures/plugins/prettier/prettier.config.js
+++ b/packages/knip/fixtures/plugins/prettier/prettier.config.js
@@ -1,3 +1,4 @@
 export default {
   plugins: ['prettier-plugin-xml', import.meta.resolve('prettier-plugin-astro')],
+  overrides: [{ options: 'prettier-plugin-java' }],
 };

--- a/packages/knip/src/plugins/prettier/index.ts
+++ b/packages/knip/src/plugins/prettier/index.ts
@@ -1,8 +1,8 @@
 import type { Args } from '../../types/args.ts';
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
-import { toDeferResolve, toDependency } from '../../util/input.ts';
+import { toDeferResolve, toDependency, type Input } from '../../util/input.ts';
 import { hasDependency } from '../../util/plugin.ts';
-import type { PrettierConfig } from './types.ts';
+import type { PrettierConfig, PrettierOptions } from './types.ts';
 
 // https://prettier.io/docs/en/configuration.html
 // https://github.com/prettier/prettier/blob/main/src/config/prettier-config/config-searcher.js
@@ -23,9 +23,28 @@ const config = [
 const resolveConfig: ResolveConfig<PrettierConfig> = config => {
   if (typeof config === 'string') return [toDeferResolve(config)];
 
-  return Array.isArray(config.plugins)
-    ? config.plugins.filter((plugin): plugin is string => typeof plugin === 'string').map(id => toDependency(id))
-    : [];
+  const result = new Set<Input>()
+
+  const processOptions = (options: PrettierOptions) => {
+    if(Array.isArray(options.plugins)) {
+      for(const plugin of options.plugins) {
+        if(typeof plugin === 'string') {
+          result.add(toDependency(plugin))
+        }
+      }
+    }
+  }
+
+  processOptions(config)
+  if(config.overrides) {
+    for(const override of config.overrides) {
+      if(override.options) {
+        processOptions(override.options)
+      }
+    }
+  }
+
+  return Array.from(result)
 };
 
 const args: Args = {

--- a/packages/knip/src/plugins/prettier/index.ts
+++ b/packages/knip/src/plugins/prettier/index.ts
@@ -23,28 +23,28 @@ const config = [
 const resolveConfig: ResolveConfig<PrettierConfig> = config => {
   if (typeof config === 'string') return [toDeferResolve(config)];
 
-  const result = new Set<Input>()
+  const result = new Set<Input>();
 
   const processOptions = (options: PrettierOptions) => {
-    if(Array.isArray(options.plugins)) {
-      for(const plugin of options.plugins) {
-        if(typeof plugin === 'string') {
-          result.add(toDependency(plugin))
+    if (Array.isArray(options.plugins)) {
+      for (const plugin of options.plugins) {
+        if (typeof plugin === 'string') {
+          result.add(toDependency(plugin));
         }
       }
     }
-  }
+  };
 
-  processOptions(config)
-  if(config.overrides) {
-    for(const override of config.overrides) {
-      if(override.options) {
-        processOptions(override.options)
+  processOptions(config);
+  if (config.overrides) {
+    for (const override of config.overrides) {
+      if (override.options) {
+        processOptions(override.options);
       }
     }
   }
 
-  return Array.from(result)
+  return Array.from(result);
 };
 
 const args: Args = {

--- a/packages/knip/src/plugins/prettier/types.ts
+++ b/packages/knip/src/plugins/prettier/types.ts
@@ -1,4 +1,4 @@
-export type PrettierConfig = {
+export type PrettierOptions = {
   plugins?: (
     | string
     | {
@@ -9,3 +9,9 @@ export type PrettierConfig = {
       }
   )[];
 };
+
+export type PrettierConfig = PrettierOptions & {
+  overrides?: {
+    options?: PrettierOptions
+  }[]
+}

--- a/packages/knip/src/plugins/prettier/types.ts
+++ b/packages/knip/src/plugins/prettier/types.ts
@@ -12,6 +12,6 @@ export type PrettierOptions = {
 
 export type PrettierConfig = PrettierOptions & {
   overrides?: {
-    options?: PrettierOptions
-  }[]
-}
+    options?: PrettierOptions;
+  }[];
+};

--- a/packages/knip/test/cli/cli-reporter-symbols-pathlike.test.ts
+++ b/packages/knip/test/cli/cli-reporter-symbols-pathlike.test.ts
@@ -8,10 +8,11 @@ const cwd = resolve('fixtures/plugins/prettier');
 test('knip --reporter symbols (path-like specifier)', () => {
   const expected = `Unused devDependencies (1)
 prettier  package.json:5:6
-Unlisted dependencies (3)
+Unlisted dependencies (4)
 @company/prettier-config  package.json
 prettier-plugin-xml       prettier.config.js
-prettier-plugin-astro     prettier.config.js`;
+prettier-plugin-astro     prettier.config.js
+prettier-plugin-java      prettier.config.js`;
 
   const result = exec('knip --reporter symbols', { cwd }).stdout.replace(/ +$/gm, '');
 

--- a/packages/knip/test/plugins/prettier.test.ts
+++ b/packages/knip/test/plugins/prettier.test.ts
@@ -14,12 +14,13 @@ test('Find dependencies with the Prettier plugin', async () => {
   assert(issues.devDependencies['package.json']['prettier']);
   assert(issues.unlisted['prettier.config.js']['prettier-plugin-xml']);
   assert(issues.unlisted['prettier.config.js']['prettier-plugin-astro']);
+  assert(issues.unlisted['prettier.config.js']['prettier-plugin-java']);
   assert(issues.unlisted['package.json']['@company/prettier-config']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     devDependencies: 1,
-    unlisted: 3,
+    unlisted: 4,
     processed: 1,
     total: 1,
   });


### PR DESCRIPTION
Prettier overrides may define plugins in addition to the top-level config.