### PR TITLE
feat: add support for Starlight plugins config dep detection

### DIFF
--- a/packages/knip/fixtures/plugins/starlight/plugins/astro.config.mjs
+++ b/packages/knip/fixtures/plugins/starlight/plugins/astro.config.mjs
@@ -1,0 +1,16 @@
+import starlight from '@astrojs/starlight';
+import starlightBlog from 'starlight-blog';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  integrations: [
+    starlight({
+      title: 'Docs',
+      plugins: [
+        starlightBlog({
+          title: 'Blog',
+        }),
+      ],
+    }),
+  ],
+});

--- a/packages/knip/fixtures/plugins/starlight/plugins/package.json
+++ b/packages/knip/fixtures/plugins/starlight/plugins/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@plugins/starlight-plugins",
+  "dependencies": {
+    "@astrojs/starlight": "*",
+    "astro": "*",
+    "starlight-blog": "*"
+  }
+}

--- a/packages/knip/src/plugins/starlight/index.ts
+++ b/packages/knip/src/plugins/starlight/index.ts
@@ -1,9 +1,9 @@
 import type { IsPluginEnabled, Plugin, ResolveFromAST } from '../../types/config.ts';
 import { findCallArg, getDefaultImportName, getImportMap, getPropertyValues } from '../../typescript/ast-helpers.ts';
-import { toProductionEntry } from '../../util/input.ts';
+import { toDependency, toProductionEntry } from '../../util/input.ts';
 import { hasDependency } from '../../util/plugin.ts';
 import { config } from '../astro/index.ts';
-import { getComponentPathsFromSourceFile } from './resolveFromAST.ts';
+import { getCalleeImportSources, getComponentPathsFromSourceFile } from './resolveFromAST.ts';
 
 // https://starlight.astro.build/reference/configuration/
 
@@ -26,6 +26,11 @@ const resolveFromAST: ResolveFromAST = program => {
       const customCssPaths = getPropertyValues(starlightConfig, 'customCss');
       for (const id of customCssPaths) {
         inputs.push(toProductionEntry(id));
+      }
+
+      const pluginSources = getCalleeImportSources(starlightConfig, 'plugins', importMap);
+      for (const source of pluginSources) {
+        inputs.push(toDependency(source));
       }
     }
   }

--- a/packages/knip/src/plugins/starlight/resolveFromAST.ts
+++ b/packages/knip/src/plugins/starlight/resolveFromAST.ts
@@ -8,3 +8,23 @@ export const getComponentPathsFromSourceFile = (program: Program) => {
   const arg = findCallArg(program, starlightImportName);
   return arg ? getPropertyValues(arg, 'components') : new Set<string>();
 };
+
+export const getCalleeImportSources = (node: any, propertyName: string, importMap: Map<string, string>) => {
+  const sources = new Set<string>();
+  if (node?.type !== 'ObjectExpression') return sources;
+  for (const prop of node.properties ?? []) {
+    if (prop.type !== 'Property') continue;
+    const key = prop.key?.name ?? prop.key?.value;
+    if (key !== propertyName) continue;
+    const init = prop.value;
+    if (init?.type !== 'ArrayExpression') continue;
+    for (const el of init.elements ?? []) {
+      if (el?.type !== 'CallExpression') continue;
+      if (el.callee?.type === 'Identifier' && el.callee.name) {
+        const source = importMap.get(el.callee.name);
+        if (source) sources.add(source);
+      }
+    }
+  }
+  return sources;
+};

--- a/packages/knip/test/plugins/starlight.test.ts
+++ b/packages/knip/test/plugins/starlight.test.ts
@@ -30,3 +30,19 @@ test('Find custom CSS with the starlight plugin', async () => {
     files: 1,
   });
 });
+
+test('Find plugins with the starlight plugin (production strict)', async () => {
+  const cwd = resolve('fixtures/plugins/starlight/plugins');
+  const options = await createOptions({ cwd, isProduction: true, isStrict: true });
+  const { issues, counters } = await main(options);
+
+  assert(
+    !issues.dependencies['package.json']?.['starlight-blog'],
+    'starlight-blog should be detected as used via starlight `plugins`'
+  );
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    dependencies: 2,
+  });
+});


### PR DESCRIPTION
#### Description

This PR adds support for [`plugins`](https://starlight.astro.build/reference/configuration/#plugins) in the Starlight Knip plugin.

- [x] I used AI to generate the code because I was playing around with it on the weekend for some time and couldn't figure out how to create a good test case. TIL there is the `isProduction` and `isStrict` option 🙌 