### PR TITLE
Add conditions config for package export and import resolution

### DIFF
--- a/packages/docs/src/content/docs/reference/configuration.md
+++ b/packages/docs/src/content/docs/reference/configuration.md
@@ -86,6 +86,42 @@ TypeScript semantics:
 - Path values are an array of relative paths.
 - Paths without an `*` are exact matches.
 
+### `conditions`
+
+Use `conditions` to replace the condition names Knip uses to resolve
+`package.json#exports` and `#imports`. The configured array applies to all module
+resolvers. By default, Knip uses `require`, `import`, and `node`, while the
+browser fallback uses `require`, `import`, and `browser`. Include those names
+explicitly if you still want them to participate. Package map `default` targets
+remain fallbacks.
+
+Condition names form a set: their order in this array does not determine which
+target wins. When multiple conditions match, the order of keys in the `exports`
+or `imports` object determines precedence.
+
+This is useful in monorepos where packages expose their uncompiled sources
+through a custom condition, so Knip follows imports into source files instead of
+(possibly non-existent) build artifacts:
+
+```json title="knip.json"
+{
+  "conditions": ["source", "require", "import", "node", "default"]
+}
+```
+
+```json title="package.json"
+{
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  }
+}
+```
+
+Also see [source mapping][13].
+
 ## Workspaces
 
 ### `workspaces`
@@ -489,3 +525,4 @@ Also see [Compilers][12].
 [10]: ../features/production-mode.md
 [11]: ../guides/handling-issues.mdx#unused-dependencies
 [12]: ../features/compilers.md
+[13]: ../features/source-mapping.md

--- a/packages/knip/fixtures/resolution/conditions/knip.json
+++ b/packages/knip/fixtures/resolution/conditions/knip.json
@@ -1,0 +1,6 @@
+{
+  "entry": ["src/index.ts!"],
+  "project": ["**/*.ts!"],
+  "includeEntryExports": true,
+  "conditions": ["source", "require", "import", "node", "default"]
+}

--- a/packages/knip/fixtures/resolution/conditions/package.json
+++ b/packages/knip/fixtures/resolution/conditions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixtures/resolution-conditions",
+  "type": "module",
+  "imports": {
+    "#feature": {
+      "source": "./src/feature.ts",
+      "default": "./dist/feature.js"
+    }
+  }
+}

--- a/packages/knip/fixtures/resolution/conditions/src/feature.ts
+++ b/packages/knip/fixtures/resolution/conditions/src/feature.ts
@@ -1,0 +1,3 @@
+export const feature = () => 1;
+
+export const unusedFeature = () => 2;

--- a/packages/knip/fixtures/resolution/conditions/src/index.ts
+++ b/packages/knip/fixtures/resolution/conditions/src/index.ts
@@ -1,0 +1,3 @@
+import { feature } from '#feature';
+
+export const main = () => feature();

--- a/packages/knip/fixtures/resolution/conditions/tsconfig.json
+++ b/packages/knip/fixtures/resolution/conditions/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node16"
+  }
+}

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -21,6 +21,9 @@
     }
   ],
   "properties": {
+    "conditions": {
+      "$ref": "#/definitions/conditions"
+    },
     "ignoreBinaries": {
       "$ref": "#/definitions/ignoreBinaries"
     },
@@ -181,6 +184,12 @@
   },
   "unevaluatedProperties": false,
   "definitions": {
+    "conditions": {
+      "title": "Export/import map conditions to use during module resolution",
+      "description": "Replaces Knip's built-in condition names for all module resolvers. The node defaults are require, import, and node; the browser fallback uses require, import, and browser. Package map default targets remain fallbacks. Matching conditions follow map key order, not array order.",
+      "examples": [["source", "require", "import", "node", "default"]],
+      "$ref": "#/definitions/list"
+    },
     "list": {
       "type": "array",
       "items": {

--- a/packages/knip/src/ConfigurationChief.ts
+++ b/packages/knip/src/ConfigurationChief.ts
@@ -50,6 +50,7 @@ const getDefaultWorkspaceConfig = (extensions: string[] = []) => {
 const isPluginName = (name: string): name is PluginName => pluginNames.includes(name as PluginName);
 
 const defaultConfig: Configuration = {
+  conditions: undefined,
   ignore: [],
   ignoreBinaries: [],
   ignoreDependencies: [],
@@ -139,6 +140,7 @@ export class ConfigurationChief {
   }
 
   private normalize(rawConfig: RawConfiguration): Configuration {
+    const conditions = rawConfig.conditions ?? defaultConfig.conditions;
     const ignore = arrayify(rawConfig.ignore ?? defaultConfig.ignore);
     const ignoreFiles = arrayify(rawConfig.ignoreFiles ?? defaultConfig.ignoreFiles);
     const ignoreBinaries = rawConfig.ignoreBinaries ?? [];
@@ -162,6 +164,7 @@ export class ConfigurationChief {
     }
 
     return {
+      conditions,
       ignore,
       ignoreFiles,
       cycles,

--- a/packages/knip/src/ProjectPrincipal.ts
+++ b/packages/knip/src/ProjectPrincipal.ts
@@ -24,6 +24,7 @@ import { compact } from './util/array.ts';
 import type { MainOptions } from './util/create-options.ts';
 import { timerify } from './util/Performance.ts';
 import { extname, isInNodeModules, toAbsolute } from './util/path.ts';
+import type { Resolver } from './util/resolve.ts';
 import type { ToSourceFilePath, WorkspaceManifestHandler } from './util/to-source-path.ts';
 
 export class ProjectPrincipal {
@@ -56,6 +57,7 @@ export class ProjectPrincipal {
   private findWorkspaceManifestImports: WorkspaceManifestHandler | undefined;
 
   fileManager: SourceFileManager;
+  resolver: Resolver;
   private resolveModule: ResolveModule = () => undefined;
   resolveGlobPattern: ResolveGlobPattern = pattern => [pattern];
 
@@ -66,11 +68,13 @@ export class ProjectPrincipal {
   constructor(
     options: MainOptions,
     toSourceFilePath: ToSourceFilePath,
+    resolver: Resolver,
     findWorkspaceManifestImports?: WorkspaceManifestHandler
   ) {
     this.cache = new CacheConsultant('root', options);
     this.toSourceFilePath = toSourceFilePath;
     this.findWorkspaceManifestImports = findWorkspaceManifestImports;
+    this.resolver = resolver;
     this.tsConfigFile = options.tsConfigFile ? toAbsolute(options.tsConfigFile, options.cwd) : undefined;
     this.pluginVisitorObjects.push(createBunShellVisitor(this.pluginCtx));
     this.fileManager = new SourceFileManager({
@@ -121,6 +125,7 @@ export class ProjectPrincipal {
     const scopedRootDirs =
       this.rootDirs.size > 0 ? Array.from(this.rootDirs, ([scope, rootDirs]) => ({ scope, rootDirs })) : undefined;
     this.resolveModule = createCustomModuleResolver(
+      this.resolver,
       { scopedPaths, scopedRootDirs },
       customCompilerExtensions,
       this.toSourceFilePath,

--- a/packages/knip/src/WorkspaceWorker.ts
+++ b/packages/knip/src/WorkspaceWorker.ts
@@ -12,6 +12,7 @@ import type {
   Plugin,
   RegisterCompiler,
   RegisterVisitorsOptions,
+  ResolveFile,
   SourceMap,
   WorkspaceConfiguration,
 } from './types/config.ts';
@@ -58,6 +59,7 @@ type WorkspaceManagerOptions = {
   findWorkspaceByFilePath: (filePath: string) => Workspace | undefined;
   getManifest: (dir: string) => Manifest | undefined;
   readFile: (filePath: string) => string;
+  resolve: ResolveFile;
   negatedWorkspacePatterns: string[];
   ignoredWorkspacePatterns: string[];
   enabledPluginsInAncestors: string[];
@@ -91,6 +93,7 @@ export class WorkspaceWorker {
   findWorkspaceByFilePath: (filePath: string) => Workspace | undefined;
   getManifest: (dir: string) => Manifest | undefined;
   readFile: (filePath: string) => string;
+  resolve: ResolveFile;
   negatedWorkspacePatterns: string[] = [];
   ignoredWorkspacePatterns: string[] = [];
 
@@ -118,6 +121,7 @@ export class WorkspaceWorker {
     findWorkspaceByFilePath,
     getManifest,
     readFile,
+    resolve,
     configFilesMap,
     options,
   }: WorkspaceManagerOptions) {
@@ -136,6 +140,7 @@ export class WorkspaceWorker {
     this.findWorkspaceByFilePath = findWorkspaceByFilePath;
     this.getManifest = getManifest;
     this.readFile = readFile;
+    this.resolve = resolve;
 
     this.options = options;
 
@@ -305,7 +310,16 @@ export class WorkspaceWorker {
 
     const rootManifest = this.rootManifest;
     const getManifest = this.getManifest;
-    const baseOptions = { manifest, rootManifest, cwd, rootCwd, containingFilePath, knownBinsOnly, getManifest };
+    const baseOptions = {
+      manifest,
+      rootManifest,
+      cwd,
+      rootCwd,
+      containingFilePath,
+      knownBinsOnly,
+      getManifest,
+      resolve: this.resolve,
+    };
 
     // Get dependencies from package.json#scripts
     const baseScriptOptions = { ...baseOptions, isProduction, enabledPlugins: this.enabledPlugins };

--- a/packages/knip/src/binaries/resolvers/bun.ts
+++ b/packages/knip/src/binaries/resolvers/bun.ts
@@ -2,7 +2,6 @@ import parseArgs from '../../util/parse-args.ts';
 import type { BinaryResolver } from '../../types/config.ts';
 import { toBinary, toEntry } from '../../util/input.ts';
 import { isAbsolute, join } from '../../util/path.ts';
-import { _resolveSync } from '../../util/resolve.ts';
 import { resolveX } from './bunx.ts';
 
 const commands = new Set([
@@ -72,7 +71,7 @@ export const resolve: BinaryResolver = (_binary, args, options) => {
   const filePath = command === 'run' ? script : command;
   if (!filePath) return [binary];
   const _cwd = parsed.cwd ? join(cwd, parsed.cwd) : cwd;
-  const resolved = _resolveSync(isAbsolute(filePath) ? filePath : join(_cwd, filePath), _cwd);
+  const resolved = options.resolve(isAbsolute(filePath) ? filePath : join(_cwd, filePath), _cwd);
   if (resolved) return [binary, toEntry(resolved)];
 
   const dir = parsed.cwd ? join(cwd, parsed.cwd) : undefined;

--- a/packages/knip/src/binaries/resolvers/nub.ts
+++ b/packages/knip/src/binaries/resolvers/nub.ts
@@ -2,7 +2,6 @@ import parseArgs from '../../util/parse-args.ts';
 import type { BinaryResolver } from '../../types/config.ts';
 import { toBinary, toEntry } from '../../util/input.ts';
 import { isAbsolute, join } from '../../util/path.ts';
-import { _resolveSync } from '../../util/resolve.ts';
 import { resolveX } from './bunx.ts';
 
 const runtimes = new Set(['x', 'dlx', 'exec']);
@@ -43,7 +42,7 @@ export const resolve: BinaryResolver = (_binary, args, options) => {
 
   if (runners.has(command)) {
     if (!script || manifest.scriptNames.has(script)) return [binary];
-    const resolved = _resolveSync(isAbsolute(script) ? script : join(cwd, script), cwd);
+    const resolved = options.resolve(isAbsolute(script) ? script : join(cwd, script), cwd);
     return resolved ? [binary, toEntry(resolved)] : [binary];
   }
 

--- a/packages/knip/src/graph/build.ts
+++ b/packages/knip/src/graph/build.ts
@@ -77,7 +77,15 @@ export async function build({
 
   const externalRefsFromInputs: ExternalRefsFromInputs | undefined = options.isSession ? new Map() : undefined;
 
-  const handleInput = createInputHandler(deputy, chief, isGitIgnored, addIssue, externalRefsFromInputs, options);
+  const handleInput = createInputHandler(
+    deputy,
+    chief,
+    isGitIgnored,
+    addIssue,
+    externalRefsFromInputs,
+    options,
+    principal.resolver
+  );
 
   const rawRootManifest = chief.getManifestForWorkspace('.');
   const rootManifest = rawRootManifest ? createManifest(rawRootManifest) : undefined;
@@ -157,6 +165,7 @@ export async function build({
       ignoredWorkspacePatterns: chief.getIgnoredWorkspacesFor(name),
       enabledPluginsInAncestors: ancestors.flatMap(ancestor => enabledPluginsStore.get(ancestor) ?? []),
       readFile: (filePath: string) => principal.readFile(filePath),
+      resolve: principal.resolver.resolveSync,
       configFilesMap,
       options,
     });
@@ -482,6 +491,7 @@ export async function build({
           manifest: createManifest(manifest),
           rootManifest,
           getManifest,
+          resolve: principal.resolver.resolveSync,
         };
         const inputs = _getInputsFromScripts(file.scripts, opts);
         for (const input of inputs) {

--- a/packages/knip/src/plugins/sst/resolveFromAST.ts
+++ b/packages/knip/src/plugins/sst/resolveFromAST.ts
@@ -4,7 +4,6 @@ import { collectPropertyValues, getImportMap } from '../../typescript/ast-helper
 import { _parseFile } from '../../typescript/ast-nodes.ts';
 import { toDeferResolveProductionEntry } from '../../util/input.ts';
 import { dirname } from '../../util/path.ts';
-import { _resolveSync } from '../../util/resolve.ts';
 
 export const resolveFromAST: ResolveFromAST = (program, options) => {
   const entries = new Set<string>();
@@ -27,7 +26,7 @@ export const resolveFromAST: ResolveFromAST = (program, options) => {
           if (arg?.type === 'Identifier') {
             const importPath = importMap.get(arg.name);
             if (importPath) {
-              const resolvedPath = _resolveSync(importPath, dirname(options.configFilePath));
+              const resolvedPath = options.resolve(importPath, dirname(options.configFilePath));
               if (resolvedPath) {
                 const stackText = options.readFile(resolvedPath);
                 if (stackText) {

--- a/packages/knip/src/run.ts
+++ b/packages/knip/src/run.ts
@@ -13,6 +13,7 @@ import { debugLogObject } from './util/debug.ts';
 import { flushGitignoreCache, initGitignoreCache } from './util/gitignore-cache.ts';
 import { flushGlobCache, initGlobCache } from './util/glob-cache.ts';
 import { getGitIgnoredHandler } from './util/glob-core.ts';
+import { createResolver } from './util/resolve.ts';
 import { getModuleSourcePathHandler, getWorkspaceManifestHandler } from './util/to-source-path.ts';
 import { getSessionHandler, type OnFileChange, type SessionHandler } from './util/watch.ts';
 
@@ -40,7 +41,8 @@ export const run = async (options: MainOptions) => {
 
   const toSourceFilePath = getModuleSourcePathHandler(chief);
   const findWorkspaceManifestImports = getWorkspaceManifestHandler(chief);
-  const principal = new ProjectPrincipal(options, toSourceFilePath, findWorkspaceManifestImports);
+  const resolver = createResolver(chief.config.conditions);
+  const principal = new ProjectPrincipal(options, toSourceFilePath, resolver, findWorkspaceManifestImports);
 
   collector.setWorkspaceFilter(chief.workspaceFilePathFilter);
   collector.setSelectedWorkspaces(chief.selectedWorkspaces);

--- a/packages/knip/src/schema/configuration.ts
+++ b/packages/knip/src/schema/configuration.ts
@@ -78,6 +78,40 @@ const rootConfigurationSchema = z.object({
    */
   $schema: z.optional(z.string()),
   /**
+   * Export/import map conditions to use during module resolution.
+   *
+   * Replaces Knip's built-in condition names for all module resolvers. The default
+   * node conditions are `require`, `import`, and `node`; the browser fallback uses
+   * `require`, `import`, and `browser`. Package map `default` targets remain
+   * fallbacks. The order of keys in the `exports` or `imports` object determines
+   * which matching condition wins; the order of this array does not.
+   *
+   * @default undefined
+   *
+   * @example
+   * ```json title="knip.json"
+   * {
+   *   "conditions": ["source", "require", "import", "node", "default"]
+   * }
+   * ```
+   *
+   * With a workspace package exposing its sources through a custom condition:
+   *
+   * ```json title="package.json"
+   * {
+   *   "exports": {
+   *     ".": {
+   *       "source": "./src/index.ts",
+   *       "default": "./dist/index.js"
+   *     }
+   *   }
+   * }
+   * ```
+   *
+   * @see {@link https://knip.dev/features/source-mapping | Source Mapping}
+   */
+  conditions: z.optional(z.array(z.string())),
+  /**
    * @default {}
    *
    * @see {@link https://knip.dev/features/rules-and-filters | Rules & Filters}

--- a/packages/knip/src/types/config.ts
+++ b/packages/knip/src/types/config.ts
@@ -28,6 +28,7 @@ export type GetInputsFromScriptsPartial = (
 ) => Input[];
 
 export type FromArgs = (args: string[], options?: Partial<GetInputsFromScriptsOptions>) => Input[];
+export type ResolveFile = (specifier: string, baseDir: string) => string | undefined;
 
 export interface BinaryResolverOptions extends GetInputsFromScriptsOptions {
   fromArgs: FromArgs;
@@ -67,6 +68,7 @@ export type GetImportsAndExportsOptions = {
 };
 
 export interface Configuration {
+  conditions?: string[];
   ignore: NormalizedGlob;
   ignoreBinaries: IgnorePatterns;
   ignoreDependencies: IgnorePatterns;
@@ -113,6 +115,7 @@ interface BaseOptions {
   manifest: Manifest;
   rootManifest: Manifest | undefined;
   getManifest: (dir: string) => Manifest | undefined;
+  resolve: ResolveFile;
 }
 
 type IsPluginEnabledOptions = {

--- a/packages/knip/src/typescript/resolve-module-names.ts
+++ b/packages/knip/src/typescript/resolve-module-names.ts
@@ -4,7 +4,7 @@ import { DEFAULT_EXTENSIONS, DTS_EXTENSIONS } from '../constants.ts';
 import { sanitizeSpecifier } from '../util/modules.ts';
 import { timerify } from '../util/Performance.ts';
 import { dirname, extname, isAbsolute, isInNodeModules, join, toPosix } from '../util/path.ts';
-import { _createSyncModuleResolver, _resolveModuleSync } from '../util/resolve.ts';
+import type { Resolver } from '../util/resolve.ts';
 import type { ToSourceFilePath, WorkspaceManifestHandler } from '../util/to-source-path.ts';
 import type { ResolveModule, ResolvedModule } from './ast-nodes.ts';
 
@@ -102,6 +102,7 @@ export function createGlobAliasResolver(scopedPaths: ScopedPaths | undefined): R
 }
 
 export function createCustomModuleResolver(
+  resolver: Resolver,
   compilerOptions: { scopedPaths?: ScopedPaths; scopedRootDirs?: ScopedRootDirs },
   customCompilerExtensions: string[],
   toSourceFilePath: ToSourceFilePath,
@@ -112,7 +113,9 @@ export function createCustomModuleResolver(
   const hasCustomExts = customCompilerExtensionsSet.size > 0;
   const extensions = [...DEFAULT_EXTENSIONS, ...customCompilerExtensions, ...DTS_EXTENSIONS, '.json', '.jsonc'];
   const resolveSync =
-    hasCustomExts || tsConfigFile ? _createSyncModuleResolver(extensions, tsConfigFile) : _resolveModuleSync;
+    hasCustomExts || tsConfigFile
+      ? resolver.createModuleResolver(extensions, tsConfigFile)
+      : resolver.resolveModuleSync;
   const pathMappings = compilePathMappings(compilerOptions.scopedPaths);
   const rootDirMappings = compileRootDirs(compilerOptions.scopedRootDirs);
 

--- a/packages/knip/src/util/create-input-handler.ts
+++ b/packages/knip/src/util/create-input-handler.ts
@@ -17,7 +17,7 @@ import {
 } from './input.ts';
 import { getPackageNameFromSpecifier } from './modules.ts';
 import { dirname, isAbsolute, isInNodeModules, isInternal, join } from './path.ts';
-import { _resolveModuleSync, _resolveSync } from './resolve.ts';
+import type { Resolver } from './resolve.ts';
 
 export type ExternalRefsFromInputs = Map<string, Set<ExternalRef>>;
 
@@ -44,7 +44,8 @@ export const createInputHandler =
     isGitIgnored: (filePath: string) => boolean,
     addIssue: (issue: Issue) => void,
     externalRefs: ExternalRefsFromInputs | undefined,
-    options: MainOptions
+    options: MainOptions,
+    resolver: Resolver
   ) =>
   (input: Input, workspace: Workspace) => {
     const { specifier, containingFilePath } = input;
@@ -122,7 +123,7 @@ export const createInputHandler =
           }
 
           // Return resolved path for refs to internal workspaces
-          const internalPath = _resolveSync(specifier, dirname(containingFilePath));
+          const internalPath = resolver.resolveSync(specifier, dirname(containingFilePath));
           if (internalPath && isInternal(internalPath) && !isGitIgnored(internalPath)) return internalPath;
         }
 
@@ -137,7 +138,7 @@ export const createInputHandler =
     // oxc-resolver does not resolve "file" or "file.ts" without "./" so we best-guess-absolutify
     const filePath = isJoinable(specifier) ? join(input.dir ?? dirname(containingFilePath), specifier) : specifier;
     const basePath = input.dir ? join(input.dir, 'file.ts') : containingFilePath;
-    const resolvedFilePath = _resolveModuleSync(filePath, basePath);
+    const resolvedFilePath = resolver.resolveModuleSync(filePath, basePath);
 
     if (resolvedFilePath && isInternal(resolvedFilePath)) {
       return isGitIgnored(resolvedFilePath) ? undefined : resolvedFilePath;

--- a/packages/knip/src/util/resolve.ts
+++ b/packages/knip/src/util/resolve.ts
@@ -10,70 +10,70 @@ const extensionAlias = {
   '.cjs': ['.cjs', '.cts', '.d.cts'],
 };
 
-const resolverInstances: ResolverFactory[] = [];
+const defaultConditionNames = ['require', 'import', 'node', 'default'];
+const browserConditionNames = ['require', 'import', 'browser', 'default'];
 
-const createSyncModuleResolver = (extensions: string[], tsConfigFile?: string) => {
-  const baseOptions = {
-    extensions,
-    extensionAlias,
-    conditionNames: ['require', 'import', 'node', 'default'],
-    nodePath: false,
+export const createResolver = (conditions?: string[]) => {
+  const resolverInstances: ResolverFactory[] = [];
+  const getConditionNames = (conditionNames: string[]) => conditions ?? conditionNames;
+
+  const createSyncModuleResolver = (extensions: string[], tsConfigFile?: string) => {
+    const baseOptions = {
+      extensions,
+      extensionAlias,
+      conditionNames: getConditionNames(defaultConditionNames),
+      nodePath: false,
+    };
+    const resolver = new ResolverFactory({
+      tsconfig: tsConfigFile ? { configFile: tsConfigFile, references: 'auto' } : 'auto',
+      ...baseOptions,
+    });
+    const fallbackResolver = new ResolverFactory({
+      ...baseOptions,
+      conditionNames: getConditionNames(browserConditionNames),
+    });
+
+    resolverInstances.push(resolver, fallbackResolver);
+
+    return function resolveSync(specifier: string, basePath: string) {
+      const resolved = resolver.resolveFileSync(basePath, specifier);
+      if (resolved.path) return toPosix(resolved.path);
+      if (resolved.error) {
+        const fallback = fallbackResolver.resolveFileSync(basePath, specifier);
+        if (fallback.path) return toPosix(fallback.path);
+      }
+    };
   };
-  const resolver = new ResolverFactory({
-    tsconfig: tsConfigFile ? { configFile: tsConfigFile, references: 'auto' } : 'auto',
-    ...baseOptions,
-  });
-  const fallbackResolver = new ResolverFactory({
-    ...baseOptions,
-    conditionNames: ['require', 'import', 'browser', 'default'],
-  });
 
-  resolverInstances.push(resolver, fallbackResolver);
+  const resolveModuleSync = timerify(
+    createSyncModuleResolver([...DEFAULT_EXTENSIONS, ...DTS_EXTENSIONS, '.json', '.jsonc']),
+    'resolveModuleSync'
+  );
 
-  return function resolveSync(specifier: string, basePath: string) {
-    const resolved = resolver.resolveFileSync(basePath, specifier);
-    if (resolved.path) return toPosix(resolved.path);
-    if (resolved.error) {
-      const fallback = fallbackResolver.resolveFileSync(basePath, specifier);
-      if (fallback.path) return toPosix(fallback.path);
-    }
+  const createModuleResolver = (extensions: string[], tsConfigFile?: string) =>
+    timerify(createSyncModuleResolver(extensions, tsConfigFile), 'resolveModuleSync');
+
+  const createSyncResolver = (extensions: string[]) => {
+    const resolver = new ResolverFactory({
+      extensions,
+      conditionNames: getConditionNames(defaultConditionNames),
+      nodePath: false,
+    });
+
+    resolverInstances.push(resolver);
+
+    return function resolveSync(specifier: string, baseDir: string) {
+      const resolved = resolver.sync(baseDir, specifier);
+      if (resolved.path) return toPosix(resolved.path);
+    };
   };
+
+  const resolveSync = timerify(createSyncResolver([...DEFAULT_EXTENSIONS, '.json', '.jsonc']));
+  const clearCache = () => {
+    for (const resolver of resolverInstances) resolver.clearCache();
+  };
+
+  return { resolveModuleSync, createModuleResolver, resolveSync, clearCache };
 };
 
-const resolveModuleSync = createSyncModuleResolver([...DEFAULT_EXTENSIONS, ...DTS_EXTENSIONS, '.json', '.jsonc']);
-
-/**
- * Default module resolver (no custom extensions or path aliases).
- */
-export const _resolveModuleSync = timerify(resolveModuleSync, 'resolveModuleSync');
-
-export const _createSyncModuleResolver = (extensions: string[], tsConfigFile?: string) =>
-  timerify(createSyncModuleResolver(extensions, tsConfigFile), 'resolveModuleSync');
-
-const createSyncResolver = (extensions: string[]) => {
-  const resolver = new ResolverFactory({
-    extensions,
-    conditionNames: ['require', 'import', 'node', 'default'],
-    nodePath: false,
-  });
-
-  resolverInstances.push(resolver);
-
-  return function resolveSync(specifier: string, baseDir: string) {
-    const resolved = resolver.sync(baseDir, specifier);
-    if (resolved.path) return toPosix(resolved.path);
-  };
-};
-
-export function clearResolverCache() {
-  for (const resolver of resolverInstances) resolver.clearCache();
-}
-
-const resolveSync = createSyncResolver([...DEFAULT_EXTENSIONS, '.json', '.jsonc']);
-
-/**
- * Resolver for everything outside the realm of TS module resolution.
- * That's everything coming directly from package.json, scripts and plugins
- * that's an `Input` except those of type `entry` or `project`.
- */
-export const _resolveSync = timerify(resolveSync);
+export type Resolver = ReturnType<typeof createResolver>;

--- a/packages/knip/src/util/watch.ts
+++ b/packages/knip/src/util/watch.ts
@@ -13,7 +13,6 @@ import { updateImportMap } from './module-graph.ts';
 import { toAbsolute, toPosix, toRelative } from './path.ts';
 import { clearModuleResolutionCaches } from '../typescript/resolve-module-names.ts';
 import { clearGlobCache } from './glob-cache.ts';
-import { clearResolverCache } from './resolve.ts';
 
 export type OnFileChange = (options: { issues: Issues; duration?: number; mem?: number }) => void;
 
@@ -109,7 +108,7 @@ export const getSessionHandler = async (
 
     if (added.size === 0 && deleted.size === 0 && modified.size === 0) return;
 
-    clearResolverCache();
+    principal.resolver.clearCache();
     clearModuleResolutionCaches();
     clearGlobCache();
     invalidateCache(graph);

--- a/packages/knip/test/resolution/conditions.test.ts
+++ b/packages/knip/test/resolution/conditions.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/resolution/conditions');
+
+test('Resolve a subpath import using a custom condition', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert.deepEqual(issues.unresolved, {});
+  assert.equal(issues.exports['src/feature.ts'].unusedFeature.symbol, 'unusedFeature');
+  assert.equal(issues.exports['src/feature.ts'].feature, undefined);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
+    exports: 2,
+  });
+});

--- a/packages/knip/test/util/get-inputs-from-scripts.test.ts
+++ b/packages/knip/test/util/get-inputs-from-scripts.test.ts
@@ -6,10 +6,12 @@ import { _getInputsFromScripts } from '../../src/binaries/index.ts';
 import { type Input, toBinary, toConfig, toDeferResolve, toDeferResolveEntry, toDependency, toEntry } from '../../src/util/input.ts';
 import { createManifest } from '../../src/util/package-json.ts';
 import { join } from '../../src/util/path.ts';
+import { createResolver } from '../../src/util/resolve.ts';
 import { resolve } from '../helpers/resolve.ts';
 
 const cwd = resolve('fixtures/binaries');
 const containingFilePath = join(cwd, 'package.json');
+const resolver = createResolver();
 const toManifest = (scriptNames: string[] = []) => createManifest({ scripts: Object.fromEntries(scriptNames.map(name => [name, ''])) });
 const pkgScripts = { cwd, manifest: toManifest(['program', 'spl:t']) };
 const knownOnly = { cwd, knownBinsOnly: true };
@@ -26,6 +28,7 @@ const t: T = (script, dependencies = [], options = { cwd }) =>
       rootCwd: cwd,
       manifest: toManifest(),
       getManifest: () => undefined,
+      resolve: resolver.resolveSync,
       containingFilePath,
       ...options,
     }),


### PR DESCRIPTION
Adds a top-level `conditions` option that replaces the condition names passed to Knip's module resolvers. Existing node and browser defaults are preserved when the option is omitted.

This follows up on #1873 and #1877, whose browser fallback handles built-in conditions but cannot activate project-defined conditions such as `source` or `monorepo`.

- Add the option to the configuration types and schemas.
- Create an isolated resolver per run and pass it through module, script, plugin, and watch paths.
- Document the option and cover custom-condition resolution with a fixture.