### PR TITLE
Read object jsPlugin specifiers from Vite+ config

### DIFF
--- a/packages/knip/fixtures/plugins/oxlint-vite-config/package.json
+++ b/packages/knip/fixtures/plugins/oxlint-vite-config/package.json
@@ -2,7 +2,6 @@
   "name": "@plugins/oxlint-vite-config",
   "devDependencies": {
     "vite-plus": "*",
-    "eslint-plugin-regexp": "*",
-    "@e18e/eslint-plugin": "*"
+    "eslint-plugin-regexp": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/oxlint-vite-config/package.json
+++ b/packages/knip/fixtures/plugins/oxlint-vite-config/package.json
@@ -2,6 +2,7 @@
   "name": "@plugins/oxlint-vite-config",
   "devDependencies": {
     "vite-plus": "*",
-    "eslint-plugin-regexp": "*"
+    "eslint-plugin-regexp": "*",
+    "@e18e/eslint-plugin": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/oxlint-vite-config/vite.config.ts
+++ b/packages/knip/fixtures/plugins/oxlint-vite-config/vite.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vite-plus';
 export default defineConfig({
   lint: {
     plugins: ['unicorn', 'typescript'],
-    jsPlugins: ['eslint-plugin-regexp'],
+    jsPlugins: ['eslint-plugin-regexp', { name: 'e18e', specifier: '@e18e/eslint-plugin' }],
   },
 });

--- a/packages/knip/fixtures/plugins/oxlint-vite-config/vite.config.ts
+++ b/packages/knip/fixtures/plugins/oxlint-vite-config/vite.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vite-plus';
 export default defineConfig({
   lint: {
     plugins: ['unicorn', 'typescript'],
-    jsPlugins: ['eslint-plugin-regexp', { name: 'e18e', specifier: '@e18e/eslint-plugin' }],
+    jsPlugins: [{ name: 'regexp', specifier: 'eslint-plugin-regexp' }],
   },
 });

--- a/packages/knip/fixtures/plugins/oxlint-vite-config/vite.config.ts
+++ b/packages/knip/fixtures/plugins/oxlint-vite-config/vite.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vite-plus';
 export default defineConfig({
   lint: {
     plugins: ['unicorn', 'typescript'],
-    jsPlugins: [{ name: 'regexp', specifier: 'eslint-plugin-regexp' }],
+    jsPlugins: ['eslint-plugin-regexp', { name: 'e18e', specifier: '@e18e/eslint-plugin' }],
   },
 });

--- a/packages/knip/src/plugins/oxlint/index.ts
+++ b/packages/knip/src/plugins/oxlint/index.ts
@@ -48,8 +48,12 @@ const resolveFromAST: ResolveFromAST = (program, options) => {
   const visitor = new Visitor({
     ObjectExpression(node) {
       const lint = findProperty(node, 'lint');
-      if (lint?.type === 'ObjectExpression')
-        for (const specifier of getPropertyValues(lint, 'jsPlugins')) jsPlugins.add(specifier);
+      if (lint?.type !== 'ObjectExpression') return;
+      for (const specifier of getPropertyValues(lint, 'jsPlugins')) jsPlugins.add(specifier);
+      for (const plugin of findProperty(lint, 'jsPlugins')?.elements ?? []) {
+        if (plugin?.type !== 'ObjectExpression') continue;
+        for (const specifier of getPropertyValues(plugin, 'specifier')) jsPlugins.add(specifier);
+      }
     },
   });
   visitor.visit(program);


### PR DESCRIPTION
Reads `specifier` from object-form Vite+ `lint.jsPlugins` entries while retaining string entries.

```ts
export default defineConfig({
  lint: {
    jsPlugins: [{ name: "regexp", specifier: "eslint-plugin-regexp" }],
  },
});
```

Vite+ [documents JS plugin support](https://viteplus.dev/guide/lint#js-plugins) and refers to [the Oxlint object-form plugin aliases](https://oxc.rs/docs/guide/usage/linter/js-plugins#plugin-aliases).