### PR TITLE
fix(compilers): ignore @import inside CSS block comments

### DIFF
--- a/packages/knip/fixtures/compilers/tailwind/package.json
+++ b/packages/knip/fixtures/compilers/tailwind/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@fixtures/compilers-tailwind",
+  "exports": {
+    "./tailwind-theme.css": "./styles.css"
+  },
   "dependencies": {
     "tailwindcss": "*"
   },

--- a/packages/knip/fixtures/compilers/tailwind/styles.css
+++ b/packages/knip/fixtures/compilers/tailwind/styles.css
@@ -1,6 +1,11 @@
 @import "tailwindcss";
 @import "./components.css";
 
+/**
+ * Usage:
+ * @import "@fixtures/compilers-tailwind/tailwind-theme.css";
+ */
+
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/typography";
 

--- a/packages/knip/src/compilers/less.ts
+++ b/packages/knip/src/compilers/less.ts
@@ -1,3 +1,4 @@
+import { blockCommentMatcher } from './compilers.ts';
 import { isScopedPackage, isTildePackage, splitSpec } from './shared.ts';
 import type { CompilerSync } from './types.ts';
 
@@ -18,11 +19,12 @@ const candidates = (specifier: string): string[] => {
 
 export const compiler: CompilerSync = text => {
   if (!text.includes('@import')) return '';
+  const body = text.replace(blockCommentMatcher, '');
   const out: string[] = [];
   let i = 0;
   let match: RegExpExecArray | null;
   importMatcher.lastIndex = 0;
-  while ((match = importMatcher.exec(text))) {
+  while ((match = importMatcher.exec(body))) {
     let spec = match[1] ?? match[2];
     if (!spec || isExternalUrl(spec)) continue;
     let isBare = isScopedPackage(spec);

--- a/packages/knip/src/compilers/scss.ts
+++ b/packages/knip/src/compilers/scss.ts
@@ -1,3 +1,4 @@
+import { blockCommentMatcher } from './compilers.ts';
 import { isScopedPackage, isTildePackage, splitSpec } from './shared.ts';
 import type { CompilerSync } from './types.ts';
 
@@ -21,11 +22,12 @@ const candidates = (specifier: string): string[] => {
 
 export const compiler: CompilerSync = text => {
   if (!text.includes('@use') && !text.includes('@import') && !text.includes('@forward')) return '';
+  const body = text.replace(blockCommentMatcher, '');
   const out: string[] = [];
   let i = 0;
   let match: RegExpExecArray | null;
   importMatcher.lastIndex = 0;
-  while ((match = importMatcher.exec(text))) {
+  while ((match = importMatcher.exec(body))) {
     let spec = match[2];
     if (!spec || spec.startsWith('sass:')) continue;
     let isBare = Boolean(match[1]) || isScopedPackage(spec);

--- a/packages/knip/src/compilers/stylus.ts
+++ b/packages/knip/src/compilers/stylus.ts
@@ -1,3 +1,4 @@
+import { blockCommentMatcher } from './compilers.ts';
 import { isScopedPackage, isTildePackage, splitSpec } from './shared.ts';
 import type { CompilerSync } from './types.ts';
 
@@ -15,11 +16,12 @@ const candidates = (specifier: string): string[] => {
 
 export const compiler: CompilerSync = text => {
   if (!text.includes('@import') && !text.includes('@require')) return '';
+  const body = text.replace(blockCommentMatcher, '');
   const out: string[] = [];
   let i = 0;
   let match: RegExpExecArray | null;
   importMatcher.lastIndex = 0;
-  while ((match = importMatcher.exec(text))) {
+  while ((match = importMatcher.exec(body))) {
     let spec = match[1];
     if (!spec || spec.includes('*')) continue;
     let isBare = isScopedPackage(spec);

--- a/packages/knip/src/plugins/tailwind/compiler.ts
+++ b/packages/knip/src/plugins/tailwind/compiler.ts
@@ -1,13 +1,16 @@
+import { blockCommentMatcher } from '../../compilers/compilers.ts';
+
 const directiveMatcher = /@(?:import|config|plugin)\s+['"]([^'"]+)['"][^;]*;/g;
 
 const compiler = (text: string) => {
   if (!text.includes('@import') && !text.includes('@config') && !text.includes('@plugin')) return '';
+  const body = text.replace(blockCommentMatcher, '');
   const imports = [];
   let match: RegExpExecArray | null;
   let index = 0;
 
   directiveMatcher.lastIndex = 0;
-  while ((match = directiveMatcher.exec(text))) if (match[1]) imports.push(`import _$${index++} from '${match[1]}';`);
+  while ((match = directiveMatcher.exec(body))) if (match[1]) imports.push(`import _$${index++} from '${match[1]}';`);
 
   return imports.join('\n');
 };

--- a/packages/knip/test/compilers/less.test.ts
+++ b/packages/knip/test/compilers/less.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { compiler } from '../../src/compilers/less.ts';
 import { main } from '../../src/index.ts';
 import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
@@ -8,6 +9,8 @@ import { resolve } from '../helpers/resolve.ts';
 const cwd = resolve('fixtures/compilers/less');
 
 test('Built-in compiler for Less', async () => {
+  assert.equal(compiler('/* @import "./missing-commented"; */'), '');
+
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 

--- a/packages/knip/test/compilers/scss.test.ts
+++ b/packages/knip/test/compilers/scss.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { compiler } from '../../src/compilers/scss.ts';
 import { main } from '../../src/index.ts';
 import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
@@ -8,6 +9,8 @@ import { resolve } from '../helpers/resolve.ts';
 const cwd = resolve('fixtures/compilers/scss');
 
 test('Built-in compiler for SCSS', async () => {
+  assert.equal(compiler('/* @import "./missing-commented"; */'), '');
+
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 

--- a/packages/knip/test/compilers/stylus.test.ts
+++ b/packages/knip/test/compilers/stylus.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { compiler } from '../../src/compilers/stylus.ts';
 import { main } from '../../src/index.ts';
 import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
@@ -8,6 +9,8 @@ import { resolve } from '../helpers/resolve.ts';
 const cwd = resolve('fixtures/compilers/stylus');
 
 test('Built-in compiler for Stylus', async () => {
+  assert.equal(compiler("/* @import './missing-commented' */"), '');
+
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 

--- a/packages/knip/test/compilers/tailwind.test.ts
+++ b/packages/knip/test/compilers/tailwind.test.ts
@@ -17,4 +17,10 @@ test('Built-in compiler for Tailwind CSS', async () => {
     processed: 6,
     total: 6,
   });
+
+  const cycleOptions = await createOptions({ cwd, includedIssueTypes: ['cycles'] });
+  const cycleResult = await main(cycleOptions);
+
+  assert.equal(Object.keys(cycleResult.issues.cycles).length, 0);
+  assert.deepEqual(cycleResult.counters, { ...baseCounters, processed: 6, total: 6 });
 });


### PR DESCRIPTION
## Summary

Fixes #1880.

CSS/SCSS/Less/Stylus import scanners treated `@import` (and related directives) inside `/* ... */` block comments as real dependency edges. When a commented specifier resolves back to the same file via package `exports`, that produced a false self-cycle.

## Changes

- Strip block comments with the existing `blockCommentMatcher` before regex import scanning in:
  - `packages/knip/src/plugins/tailwind/compiler.ts`
  - `packages/knip/src/compilers/scss.ts`
  - `packages/knip/src/compilers/less.ts`
  - `packages/knip/src/compilers/stylus.ts`
- Extend the Tailwind compiler fixture with a package `exports` self-map and a commented `@import` that would previously self-cycle.
- Add lightweight compiler-unit assertions for SCSS/Less/Stylus and a cycles assertion for the Tailwind fixture.

## Verification

- `cd packages/knip && bun test test/compilers/tailwind.test.ts test/compilers/scss.test.ts test/compilers/less.test.ts test/compilers/stylus.test.ts` (4 pass)
- Tailwind compiler unit smoke: commented self-resolving `@import` is omitted; real `@import 'tailwindcss'` remains

## Backwards compatibility

No intentional public API change. Only ignored comment text is dropped before import extraction.
