### PR TITLE
Recognize catalog entries referenced through dlx scripts

### DIFF
--- a/packages/knip/fixtures/dependencies/catalog-pnpm-dlx/package.json
+++ b/packages/knip/fixtures/dependencies/catalog-pnpm-dlx/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixtures/catalog-pnpm-dlx",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "lint:packages": "pnpm dlx sherif@catalog:"
+  }
+}

--- a/packages/knip/fixtures/dependencies/catalog-pnpm-dlx/packages/app/index.ts
+++ b/packages/knip/fixtures/dependencies/catalog-pnpm-dlx/packages/app/index.ts
@@ -1,0 +1,1 @@
+export const app = () => 'app';

--- a/packages/knip/fixtures/dependencies/catalog-pnpm-dlx/packages/app/package.json
+++ b/packages/knip/fixtures/dependencies/catalog-pnpm-dlx/packages/app/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/catalog-pnpm-dlx__app"
+}

--- a/packages/knip/fixtures/dependencies/catalog-pnpm-dlx/pnpm-workspace.yaml
+++ b/packages/knip/fixtures/dependencies/catalog-pnpm-dlx/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - 'packages/*'
+
+catalog:
+  sherif: ^1.0.0
+  lodash: ^4.17.21

--- a/packages/knip/src/util/catalog.ts
+++ b/packages/knip/src/util/catalog.ts
@@ -70,12 +70,27 @@ export const extractCatalogReferences = (manifest: PackageJson): Set<string> => 
     }
   };
 
+  // Package managers (pnpm, yarn) allow referencing a catalog entry directly from a script through
+  // the `catalog:` protocol, e.g. `pnpm dlx sherif@catalog:` or `yarn dlx pkg@catalog:frontend`.
+  const catalogSpecifier = /(@?[\w.-]+(?:\/[\w.-]+)?)@catalog:([\w.-]*)/g;
+  const checkScripts = (scripts: Record<string, string> | undefined) => {
+    if (!scripts) return;
+
+    for (const script of Object.values(scripts)) {
+      if (typeof script !== 'string') continue;
+      for (const [, name, catalogName] of script.matchAll(catalogSpecifier)) {
+        catalogReferences.add([catalogName || DEFAULT_CATALOG, name].join(':'));
+      }
+    }
+  };
+
   checkDependencies(manifest.dependencies);
   checkDependencies(manifest.devDependencies);
   checkDependencies(manifest.peerDependencies);
   checkDependencies(manifest.optionalDependencies);
   checkDependencies(manifest.resolutions);
   checkDependencies(manifest.pnpm?.overrides);
+  checkScripts(manifest.scripts);
 
   return catalogReferences;
 };

--- a/packages/knip/test/dependencies/catalog.pnpm-dlx.test.ts
+++ b/packages/knip/test/dependencies/catalog.pnpm-dlx.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+test('Should track catalog entries referenced through pnpm dlx scripts', async () => {
+  const cwd = resolve('fixtures/dependencies/catalog-pnpm-dlx');
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  // `sherif` is referenced through `pnpm dlx sherif@catalog:` and must not be reported.
+  assert.equal(issues.catalog['pnpm-workspace.yaml']?.['default.sherif'], undefined);
+
+  // `lodash` is not referenced anywhere and must still be reported as unused.
+  assert(issues.catalog['pnpm-workspace.yaml']['default.lodash']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    catalog: 1,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
## What

Catalog references are currently extracted only from dependency-like manifest fields (`dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`, `resolutions`, `pnpm.overrides`). A catalog entry used solely from a package script through the `catalog:` protocol — e.g. `pnpm dlx <pkg>@catalog:` — is not recognized, so Knip reports it under **Unused catalog entries**.

This adds a scan of `package.json` scripts for `<pkg>@catalog:<name>?` specifiers and registers the corresponding catalog reference, matching pnpm/yarn `dlx` (and `exec`) usage.

## Why

pnpm supports referencing catalog-managed versions directly from scripts:

```json
{
  "scripts": {
    "tool:sherif": "pnpm dlx sherif@catalog:"
  }
}
```

with the catalog defined in `pnpm-workspace.yaml`:

```yaml
catalog:
  sherif: ^1.0.0
```

Before this change the `sherif` catalog entry was flagged as unused even though the script references it. The default and named (`@catalog:<name>`) forms as well as scoped packages (`@scope/pkg@catalog:`) are handled.

Fixes #1885

## Test evidence

Added `test/dependencies/catalog.pnpm-dlx.test.ts` with a fixture (`fixtures/dependencies/catalog-pnpm-dlx`) whose script uses `pnpm dlx sherif@catalog:`. The test asserts `sherif` is no longer reported while the genuinely unused `lodash` catalog entry still is.

- Before the fix the new test fails (`default.sherif` reported as unused).
- After the fix it passes.

```
$ node --test test/dependencies/catalog.pnpm-dlx.test.ts
✔ Should track catalog entries referenced through pnpm dlx scripts
# tests 1 / pass 1

$ node --test 'test/dependencies/*.test.ts'
# tests 34 / pass 34
```

`oxlint` and `oxfmt` are clean on the touched files.