### PR TITLE
feat: markdownlint-cli2

### DIFF
--- a/packages/knip/fixtures/plugins/markdownlint-cli2/.markdownlint-cli2.jsonc
+++ b/packages/knip/fixtures/plugins/markdownlint-cli2/.markdownlint-cli2.jsonc
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "extends": "markdownlint-config-prettier"
+  },
+  "customRules": ["markdownlint-rule-titlecase"],
+  "markdownItPlugins": [["markdown-it-anchor", { "permalink": true }]],
+  "outputFormatters": [["markdownlint-cli2-formatter-summarize"]]
+}

--- a/packages/knip/fixtures/plugins/markdownlint-cli2/.markdownlint-cli2.jsonc
+++ b/packages/knip/fixtures/plugins/markdownlint-cli2/.markdownlint-cli2.jsonc
@@ -1,9 +1,8 @@
 {
-  "extends": "markdownlint/style/prettier",
   "config": {
     "extends": "markdownlint-config-prettier"
   },
   "customRules": ["markdownlint-rule-titlecase"],
   "markdownItPlugins": [["markdown-it-anchor", { "permalink": true }]],
-  "outputFormatters": [["markdownlint-cli2-formatter-summarize"]]
+  "outputFormatters": [["markdownlint-cli2-formatter-summarize"], ["markdownlint-cli2-formatter-default"]]
 }

--- a/packages/knip/fixtures/plugins/markdownlint-cli2/.markdownlint-cli2.jsonc
+++ b/packages/knip/fixtures/plugins/markdownlint-cli2/.markdownlint-cli2.jsonc
@@ -1,4 +1,5 @@
 {
+  "extends": "markdownlint/style/prettier",
   "config": {
     "extends": "markdownlint-config-prettier"
   },

--- a/packages/knip/fixtures/plugins/markdownlint-cli2/.markdownlint.yml
+++ b/packages/knip/fixtures/plugins/markdownlint-cli2/.markdownlint.yml
@@ -1,0 +1,1 @@
+extends: markdownlint/style/prettier

--- a/packages/knip/fixtures/plugins/markdownlint-cli2/package.json
+++ b/packages/knip/fixtures/plugins/markdownlint-cli2/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@plugins/markdownlint-cli2",
+  "scripts": {
+    "md": "markdownlint-cli2 \"**/*.md\""
+  },
+  "devDependencies": {
+    "markdown-it-anchor": "*",
+    "markdownlint-cli2": "*",
+    "markdownlint-cli2-formatter-summarize": "*",
+    "markdownlint-config-prettier": "*",
+    "markdownlint-rule-titlecase": "*"
+  }
+}

--- a/packages/knip/src/plugins/markdownlint/index.ts
+++ b/packages/knip/src/plugins/markdownlint/index.ts
@@ -13,13 +13,16 @@ const enablers = ['markdownlint-cli', 'markdownlint-cli2'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
+const isBundled = (specifier: string) =>
+  specifier.startsWith('markdownlint/style/') || specifier === 'markdownlint-cli2-formatter-default';
+
 const config = ['.markdownlint-cli2.{jsonc,yaml,cjs,mjs}', '.markdownlint.{json,jsonc,yaml,yml,cjs,mjs}'];
 
 const resolveConfig: ResolveConfig<MarkdownlintConfig> = (config, options) => {
   const { manifest } = options;
   const dependencies: string[] = [];
   for (const extend of [config?.extends, config?.config?.extends]) {
-    if (extend && !extend.startsWith('markdownlint/style/')) dependencies.push(extend);
+    if (extend) dependencies.push(extend);
   }
   for (const customRule of config?.customRules ?? []) {
     if (typeof customRule === 'string') dependencies.push(customRule);
@@ -40,7 +43,7 @@ const resolveConfig: ResolveConfig<MarkdownlintConfig> = (config, options) => {
   const uses = scripts
     .filter(script => script.includes('markdownlint ') || script.includes('markdownlint-cli2 '))
     .flatMap(script => getArgumentValues(script, / (--rules|-r)[ =]([^ ]+)/g));
-  return [...dependencies, ...uses].map(id => toDependency(id));
+  return [...dependencies, ...uses].filter(id => !isBundled(id)).map(id => toDependency(id));
 };
 
 const plugin: Plugin = {

--- a/packages/knip/src/plugins/markdownlint/index.ts
+++ b/packages/knip/src/plugins/markdownlint/index.ts
@@ -5,25 +5,41 @@ import { getArgumentValues } from './helpers.ts';
 import type { MarkdownlintConfig } from './types.ts';
 
 // https://github.com/igorshubovych/markdownlint-cli
+// https://github.com/DavidAnson/markdownlint-cli2
 
 const title = 'markdownlint';
 
-const enablers = ['markdownlint-cli'];
+const enablers = ['markdownlint-cli', 'markdownlint-cli2'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['.markdownlint.{json,jsonc}', '.markdownlint.{yml,yaml}'];
+const config = ['.markdownlint-cli2.{jsonc,yaml,cjs,mjs}', '.markdownlint.{json,jsonc,yaml,yml,cjs,mjs}'];
 
 const resolveConfig: ResolveConfig<MarkdownlintConfig> = (config, options) => {
   const { manifest } = options;
-  const extend = config?.extends ? [config.extends] : [];
+  const dependencies: string[] = [];
+  if (config?.extends) dependencies.push(config.extends);
+  if (config?.config?.extends) dependencies.push(config.config.extends);
+  for (const customRule of config?.customRules ?? []) {
+    if (typeof customRule === 'string') dependencies.push(customRule);
+    else if (Array.isArray(customRule)) {
+      for (const rule of customRule) {
+        if (typeof rule === 'string') dependencies.push(rule);
+      }
+    }
+  }
+  for (const modules of [config?.markdownItPlugins, config?.outputFormatters]) {
+    for (const module of modules ?? []) {
+      if (Array.isArray(module) && typeof module[0] === 'string') dependencies.push(module[0]);
+    }
+  }
   const scripts = manifest?.scripts
     ? Object.values(manifest.scripts).filter((script): script is string => typeof script === 'string')
     : [];
   const uses = scripts
     .filter(script => script.includes('markdownlint '))
     .flatMap(script => getArgumentValues(script, / (--rules|-r)[ =]([^ ]+)/g));
-  return [...extend, ...uses].map(id => toDependency(id));
+  return [...dependencies, ...uses].map(id => toDependency(id));
 };
 
 const plugin: Plugin = {

--- a/packages/knip/src/plugins/markdownlint/index.ts
+++ b/packages/knip/src/plugins/markdownlint/index.ts
@@ -18,8 +18,9 @@ const config = ['.markdownlint-cli2.{jsonc,yaml,cjs,mjs}', '.markdownlint.{json,
 const resolveConfig: ResolveConfig<MarkdownlintConfig> = (config, options) => {
   const { manifest } = options;
   const dependencies: string[] = [];
-  if (config?.extends) dependencies.push(config.extends);
-  if (config?.config?.extends) dependencies.push(config.config.extends);
+  for (const extend of [config?.extends, config?.config?.extends]) {
+    if (extend && !extend.startsWith('markdownlint/style/')) dependencies.push(extend);
+  }
   for (const customRule of config?.customRules ?? []) {
     if (typeof customRule === 'string') dependencies.push(customRule);
     else if (Array.isArray(customRule)) {

--- a/packages/knip/src/plugins/markdownlint/index.ts
+++ b/packages/knip/src/plugins/markdownlint/index.ts
@@ -37,7 +37,7 @@ const resolveConfig: ResolveConfig<MarkdownlintConfig> = (config, options) => {
     ? Object.values(manifest.scripts).filter((script): script is string => typeof script === 'string')
     : [];
   const uses = scripts
-    .filter(script => script.includes('markdownlint '))
+    .filter(script => script.includes('markdownlint ') || script.includes('markdownlint-cli2 '))
     .flatMap(script => getArgumentValues(script, / (--rules|-r)[ =]([^ ]+)/g));
   return [...dependencies, ...uses].map(id => toDependency(id));
 };

--- a/packages/knip/src/plugins/markdownlint/types.ts
+++ b/packages/knip/src/plugins/markdownlint/types.ts
@@ -1,3 +1,9 @@
 export type MarkdownlintConfig = {
+  config?: {
+    extends?: string;
+  };
+  customRules?: unknown[];
   extends?: string;
+  markdownItPlugins?: unknown[];
+  outputFormatters?: unknown[];
 };

--- a/packages/knip/test/plugins/markdownlint-cli2.test.ts
+++ b/packages/knip/test/plugins/markdownlint-cli2.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/markdownlint-cli2');
+
+test('Find dependencies with the markdownlint-cli2 plugin', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.binaries['package.json']['markdownlint-cli2']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    binaries: 1,
+    devDependencies: 1,
+  });
+});


### PR DESCRIPTION
This PR adds support for markdownlint-cli2, which is considered better than markdownlint-cli.

I had 5.6 Sol help me out with this.