### PR TITLE
fix: keep gitignore negations scoped so sibling paths stay ignored

### DIFF
--- a/packages/knip/fixtures/infra/gitignore-scoped-negation/.gitignore
+++ b/packages/knip/fixtures/infra/gitignore-scoped-negation/.gitignore
@@ -1,0 +1,2 @@
+build/
+!tools/build/

--- a/packages/knip/fixtures/infra/gitignore-scoped-negation/build/reports/orphan.ts
+++ b/packages/knip/fixtures/infra/gitignore-scoped-negation/build/reports/orphan.ts
@@ -1,0 +1,1 @@
+export const orphan = 1;

--- a/packages/knip/fixtures/infra/gitignore-scoped-negation/index.ts
+++ b/packages/knip/fixtures/infra/gitignore-scoped-negation/index.ts
@@ -1,0 +1,3 @@
+import { codegen } from './tools/build/codegen.ts';
+
+codegen();

--- a/packages/knip/fixtures/infra/gitignore-scoped-negation/package.json
+++ b/packages/knip/fixtures/infra/gitignore-scoped-negation/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/gitignore-scoped-negation"
+}

--- a/packages/knip/fixtures/infra/gitignore-scoped-negation/tools/build/codegen.ts
+++ b/packages/knip/fixtures/infra/gitignore-scoped-negation/tools/build/codegen.ts
@@ -1,0 +1,1 @@
+export const codegen = () => {};

--- a/packages/knip/src/util/glob-core.ts
+++ b/packages/knip/src/util/glob-core.ts
@@ -11,7 +11,7 @@ import { isDirectory, isFile } from './fs.ts';
 import { getCachedGitignore, isGitignoreCacheEnabled, setCachedGitignore } from './gitignore-cache.ts';
 import { timerify } from './Performance.ts';
 import { expandIgnorePatterns, parseAndConvertGitignorePatterns } from './parse-and-convert-gitignores.ts';
-import { dirname, join, relative, toPosix } from './path.ts';
+import { dirname, isAbsolute, join, relative, toPosix } from './path.ts';
 
 type Options = { gitignore: boolean; cwd: string };
 
@@ -28,6 +28,10 @@ export type Gitignores = { ignores: Set<string>; unignores: Set<string> };
 const cachedGitIgnores = new Map<string, Gitignores>();
 // ignore patterns are cached per directory as a product of .gitignore in current and ancestor directories
 const cachedGlobIgnores = new Map<string, string[]>();
+
+// The flat ignore lists can't express unignores (`!pattern`), so shadowed ignore patterns are dropped from them and
+// glob results are filtered through this exact matcher instead (only set when unignores are present)
+let exactGitignoreMatcher: ((relativePath: string) => boolean) | undefined;
 
 // Check if directory is a git root (has .git directory or .git file for worktrees)
 const isGitRoot = (dir: string) => isDirectory(dir, '.git') || isFile(dir, '.git');
@@ -265,7 +269,16 @@ export async function glob(_patterns: string[], options: GlobOptions): Promise<s
 
   const { dir, label, ...fgOptions } = { ...options, ignore: ignorePatterns, expandDirectories: false };
 
-  const paths = await tinyGlob(patterns, fgOptions);
+  let paths = await tinyGlob(patterns, fgOptions);
+
+  if (options.gitignore && exactGitignoreMatcher && paths.length > 0) {
+    const matcher = exactGitignoreMatcher;
+    const filtered: string[] = [];
+    for (const path of paths) {
+      if (!matcher(isAbsolute(path) ? relative(options.cwd, path) : path)) filtered.push(path);
+    }
+    paths = filtered;
+  }
 
   debugLogObject(relative(options.cwd, dir), label ? `Finding ${label}` : 'Finding paths', () => ({
     patterns,
@@ -285,11 +298,14 @@ export async function getGitIgnoredHandler(
   workspaceDirs?: Set<string>
 ): Promise<(path: string) => boolean> {
   cachedGitIgnores.clear();
+  exactGitignoreMatcher = undefined;
 
   if (options.gitignore === false) return () => false;
 
   const { ignores, unignores } = await _parseFindGitignores(options.cwd, workspaceDirs);
   const matcher = picomatch(expandIgnorePatterns(ignores), { ignore: expandIgnorePatterns(unignores) });
+
+  if (unignores.size > 0) exactGitignoreMatcher = matcher;
 
   const cache = new Map<string, boolean>();
   const isGitIgnored = (filePath: string) => {

--- a/packages/knip/test/infra/gitignore-scoped-negation.test.ts
+++ b/packages/knip/test/infra/gitignore-scoped-negation.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/infra/gitignore-scoped-negation');
+
+test('Negation for one path does not un-ignore a sibling path globally', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert.deepEqual(issues.files, {});
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
+  });
+});


### PR DESCRIPTION
Closes #1891.

**Problem:** An unrelated `.gitignore` negation such as `!foo/build/` globally un-ignores sibling `build/` paths — files under e.g. `tools/build/` that should stay gitignored start showing up in results.

**Root cause:** glob-core drops ignore patterns that are "shadowed" by any unignore pattern. That drop is needed because tinyglobby cannot express unignores, and traversal must not prune directories that contain unignored paths (the yarn-berry `.gitignore` case depends on exactly this). But the glob results were never re-checked afterwards, so every path matched by the dropped pattern leaked through — not just the negated one.

**Fix:** Keeps the drop for traversal, and post-filters `glob()` results through the exact picomatch matcher that `getGitIgnoredHandler` already builds. The filter is gated on `unignores.size > 0`, so the common case (no negations) has no extra work.

**Testing:** New fixture `gitignore-scoped-negation` plus a regression test that was red before the fix and green after, under both bun and node. 16/16 related regression tests pass, full smoke suite 870/870, `tsgo`/oxlint/oxfmt clean.
