### PR TITLE
Report unused re-exports when ignoreExportsUsedInFile is set

### DIFF
--- a/.github/workflows/snapshots/sanity.txt
+++ b/.github/workflows/snapshots/sanity.txt
@@ -1,0 +1,9 @@
+Unused exported types (8)
+packages/@repo/debug-proxy/src/createDebugProxy.ts: ProxyHeaders, SSEEvent
+packages/sanity/src/core/canvas/i18n/index.ts: CanvasLocaleResourceKeys
+packages/sanity/src/core/comments/i18n/index.ts: CommentsLocaleResourceKeys
+packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/index.ts: FullscreenPTEContextValue
+packages/sanity/src/core/releases/i18n/index.ts: ReleasesLocaleResourceKeys
+packages/sanity/src/core/singleDocRelease/i18n/index.ts: SingleDocReleaseLocaleResourceKeys
+packages/sanity/src/core/tasks/i18n/index.ts: TasksLocaleResourceKeys
+packages/sanity/src/core/validation/index.ts: ValidationContext

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/barrel.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/barrel.ts
@@ -1,0 +1,5 @@
+import { grape } from './fruits';
+
+export { grape as raisin };
+
+export const juice = () => grape + 1;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/fruits.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/fruits.ts
@@ -1,0 +1,1 @@
+export const grape = 1;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/index.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/index.ts
@@ -1,0 +1,3 @@
+import { juice } from './barrel';
+
+juice();

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/knip.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/knip.json
@@ -1,0 +1,3 @@
+{
+  "ignoreExportsUsedInFile": true
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/package.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-alias/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/ignore-exports-used-in-file-re-export-local-alias"
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/barrel.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/barrel.ts
@@ -1,0 +1,5 @@
+import { grape, plum } from './fruits';
+
+export { grape, plum };
+
+export const juice = () => plum + 1;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/fruits.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/fruits.ts
@@ -1,0 +1,2 @@
+export const grape = 1;
+export const plum = 2;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/index.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/index.ts
@@ -1,0 +1,3 @@
+import { juice } from './barrel';
+
+juice();

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/knip.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/knip.json
@@ -1,0 +1,3 @@
+{
+  "ignoreExportsUsedInFile": true
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/package.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local-unused/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/ignore-exports-used-in-file-re-export-local-unused"
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/barrel.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/barrel.ts
@@ -1,0 +1,5 @@
+import { grape } from './fruits';
+
+export { grape };
+
+export const juice = () => grape + 1;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/fruits.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/fruits.ts
@@ -1,0 +1,1 @@
+export const grape = 1;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/index.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/index.ts
@@ -1,0 +1,3 @@
+import { juice } from './barrel';
+
+juice();

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/knip.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/knip.json
@@ -1,0 +1,3 @@
+{
+  "ignoreExportsUsedInFile": true
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/package.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-local/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/ignore-exports-used-in-file-re-export-local"
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/barrel.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/barrel.ts
@@ -1,0 +1,5 @@
+import { helper } from './util';
+
+export { compute as helper } from './math';
+
+export const run = () => helper();

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/index.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/index.ts
@@ -1,0 +1,3 @@
+import { run } from './barrel';
+
+run();

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/knip.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/knip.json
@@ -1,0 +1,3 @@
+{
+  "ignoreExportsUsedInFile": true
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/math.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/math.ts
@@ -1,0 +1,1 @@
+export const compute = () => 2;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/package.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/ignore-exports-used-in-file-re-export-name-collision"
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/util.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-name-collision/util.ts
@@ -1,0 +1,1 @@
+export const helper = () => 1;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/barrel.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/barrel.ts
@@ -1,0 +1,1 @@
+export type { Used, Dead } from './schemas';

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/index.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/index.ts
@@ -1,0 +1,3 @@
+import type { Used } from './barrel';
+
+export const value: Used = { a: 1 };

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/knip.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/knip.json
@@ -1,0 +1,5 @@
+{
+  "ignoreExportsUsedInFile": {
+    "type": true
+  }
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/package.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/ignore-exports-used-in-file-re-export-specifier"
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/schemas.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-specifier/schemas.ts
@@ -1,0 +1,2 @@
+export type Used = { a: number };
+export type Dead = { b: number };

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/barrel.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/barrel.ts
@@ -1,0 +1,1 @@
+export { grape, plum } from './fruits';

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/fruits.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/fruits.ts
@@ -1,0 +1,2 @@
+export const grape = 1;
+export const plum = 2;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/index.ts
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/index.ts
@@ -1,0 +1,3 @@
+import { grape } from './barrel';
+
+grape;

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/knip.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/knip.json
@@ -1,0 +1,3 @@
+{
+  "ignoreExportsUsedInFile": true
+}

--- a/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/package.json
+++ b/packages/knip/fixtures/ignore-exports-used-in-file/re-export-value/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/ignore-exports-used-in-file-re-export-value"
+}

--- a/packages/knip/src/typescript/get-imports-and-exports.ts
+++ b/packages/knip/src/typescript/get-imports-and-exports.ts
@@ -422,7 +422,7 @@ const getImportsAndExports = (
 
   for (const [id, item] of exports) {
     item.referencedIn = referencedInExport.get(id);
-    if (localRefs && shouldCountRefs(ignoreExportsUsedInFile, item.type) && (localRefs.has(id) || item.isReExport)) {
+    if (localRefs && shouldCountRefs(ignoreExportsUsedInFile, item.type) && localRefs.has(id)) {
       item.hasRefsInFile = true;
     }
   }

--- a/packages/knip/src/typescript/visitors/walk.ts
+++ b/packages/knip/src/typescript/visitors/walk.ts
@@ -97,6 +97,7 @@ export interface WalkState extends WalkContext {
   currentVarDeclStart: number;
   nsRanges: [number, number][];
   memberRefsInFile: string[];
+  importedRefs: Set<string> | undefined;
   scopeDepth: number;
   scopeStarts: number[];
   scopeEnds: number[];
@@ -283,7 +284,9 @@ export const isShadowed = (name: string, pos: number): boolean => {
 };
 
 const _addLocalRef = (name: string, pos: number) => {
-  if (!state.localImportMap.has(name) && !isShadowed(name, pos)) state.localRefs!.add(name);
+  if (isShadowed(name, pos)) return;
+  if (state.localImportMap.has(name)) (state.importedRefs ??= new Set()).add(name);
+  else state.localRefs!.add(name);
 };
 
 const _addShadowRange = (name: string, range: [number, number]) => {
@@ -798,6 +801,7 @@ function walkAST(program: Program, sourceText: string, filePath: string, hasModu
     currentVarDeclStart: -1,
     nsRanges: [],
     memberRefsInFile: [],
+    importedRefs: undefined,
     scopeDepth: 0,
     scopeStarts: [],
     scopeEnds: [],
@@ -899,6 +903,13 @@ function walkAST(program: Program, sourceText: string, filePath: string, hasModu
         const aliased = state.exports.get(exportName);
         if (aliased) aliased.isRegistered = true;
       }
+    }
+  }
+
+  if (state.localRefs && state.importedRefs) {
+    for (const name of state.importedRefs) {
+      const exportNames = state.localToExports.get(name);
+      if (exportNames) for (const exportName of exportNames) state.localRefs.add(exportName);
     }
   }
 

--- a/packages/knip/test/e2e/fix-tsgo.test.ts
+++ b/packages/knip/test/e2e/fix-tsgo.test.ts
@@ -38,6 +38,7 @@ const fixtures = [
   'types/type-visibility',
   'types/typeof-in-type-alias',
   'infra/zero-config',
+  'ignore-exports-used-in-file/re-export-specifier',
 ];
 
 for (const name of fixtures) {

--- a/packages/knip/test/ignore-exports-used-in-file/re-export-local-alias.test.ts
+++ b/packages/knip/test/ignore-exports-used-in-file/re-export-local-alias.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/ignore-exports-used-in-file/re-export-local-alias');
+
+test('Find unused exports respecting an ignoreExportsUsedInFile (aliased re-export of referenced import)', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 3,
+    total: 3,
+  });
+});

--- a/packages/knip/test/ignore-exports-used-in-file/re-export-local-unused.test.ts
+++ b/packages/knip/test/ignore-exports-used-in-file/re-export-local-unused.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/ignore-exports-used-in-file/re-export-local-unused');
+
+test('Find unused exports respecting an ignoreExportsUsedInFile (re-export of unreferenced import)', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert('grape' in issues.exports['barrel.ts']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    exports: 1,
+    processed: 3,
+    total: 3,
+  });
+});

--- a/packages/knip/test/ignore-exports-used-in-file/re-export-local.test.ts
+++ b/packages/knip/test/ignore-exports-used-in-file/re-export-local.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/ignore-exports-used-in-file/re-export-local');
+
+test('Find unused exports respecting an ignoreExportsUsedInFile (re-export of referenced import)', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 3,
+    total: 3,
+  });
+});

--- a/packages/knip/test/ignore-exports-used-in-file/re-export-name-collision.test.ts
+++ b/packages/knip/test/ignore-exports-used-in-file/re-export-name-collision.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/ignore-exports-used-in-file/re-export-name-collision');
+
+test('Find unused exports respecting an ignoreExportsUsedInFile (re-export sharing an import name)', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert('helper' in issues.exports['barrel.ts']);
+  assert('compute' in issues.exports['math.ts']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    exports: 2,
+    processed: 4,
+    total: 4,
+  });
+});

--- a/packages/knip/test/ignore-exports-used-in-file/re-export-specifier.test.ts
+++ b/packages/knip/test/ignore-exports-used-in-file/re-export-specifier.test.ts
@@ -5,16 +5,19 @@ import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
-const cwd = resolve('fixtures/re-exports/ignore-exports-used-in-file');
+const cwd = resolve('fixtures/ignore-exports-used-in-file/re-export-specifier');
 
-test('Find unused export through re-export in entry file (includeEntryExports/ignoreExportsUsedInFile)', async () => {
+test('Find unused exports respecting an ignoreExportsUsedInFile (re-export specifier)', async () => {
   const options = await createOptions({ cwd });
-  const { counters } = await main(options);
+  const { issues, counters } = await main(options);
+
+  assert.equal(issues.types['schemas.ts']['Dead'].symbol, 'Dead');
+  assert.equal(issues.types['barrel.ts']['Dead'].symbol, 'Dead');
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    exports: 2,
     processed: 3,
     total: 3,
+    types: 2,
   });
 });

--- a/packages/knip/test/ignore-exports-used-in-file/re-export-value.test.ts
+++ b/packages/knip/test/ignore-exports-used-in-file/re-export-value.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/ignore-exports-used-in-file/re-export-value');
+
+test('Find unused exports respecting an ignoreExportsUsedInFile (re-export from source)', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert('plum' in issues.exports['barrel.ts']);
+  assert('plum' in issues.exports['fruits.ts']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    exports: 2,
+    processed: 3,
+    total: 3,
+  });
+});


### PR DESCRIPTION
Fixes #1894

With `ignoreExportsUsedInFile` set, re-exports were always treated as used in their own file and never reported. A re-export like `export type { Dead } from './schemas'` has no local binding, so it cannot actually be used in its own file. When the source export was unused, `--fix` removed the `export` keyword at the declaration but left the re-export behind, and the project no longer compiled.

This removes the blanket `isReExport` check, so re-exports get the same local reference check as other exports. The `import { X }` plus `export { X }` case keeps working, since usage of `X` in the file is picked up by that check (covered by the existing `re-export` fixture).

The expected count in `test/re-exports/ignore-exports-used-in-file.test.ts` goes from 1 to 2: the unused export is now also reported at the re-export site, same as without `ignoreExportsUsedInFile`. That test was added for #698 to make sure the export is reported at all, so this stays in line with its intent.
