### PR TITLE
fix(nuxt): resolve nuxt module paths

### DIFF
--- a/packages/knip/fixtures/plugins/nuxt-no-root-tsconfig/extra-modules/analytics.ts
+++ b/packages/knip/fixtures/plugins/nuxt-no-root-tsconfig/extra-modules/analytics.ts
@@ -1,0 +1,1 @@
+export default function analytics() {}

--- a/packages/knip/fixtures/plugins/nuxt-no-root-tsconfig/extra-modules/telemetry.ts
+++ b/packages/knip/fixtures/plugins/nuxt-no-root-tsconfig/extra-modules/telemetry.ts
@@ -1,0 +1,1 @@
+export default function telemetry() {}

--- a/packages/knip/fixtures/plugins/nuxt-no-root-tsconfig/nuxt.config.ts
+++ b/packages/knip/fixtures/plugins/nuxt-no-root-tsconfig/nuxt.config.ts
@@ -1,3 +1,5 @@
 import { defineNuxtConfig } from 'nuxt/config';
 
-export default defineNuxtConfig({});
+export default defineNuxtConfig({
+  modules: ['~~/extra-modules/analytics', ['~~/extra-modules/telemetry', {}]],
+});

--- a/packages/knip/src/plugins/nuxt/index.ts
+++ b/packages/knip/src/plugins/nuxt/index.ts
@@ -114,8 +114,8 @@ const resolveConfig: ResolveConfig<NuxtConfig> = async (localConfig, options) =>
   const inputs: Input[] = [];
 
   for (const id of localConfig.modules ?? []) {
-    if (Array.isArray(id) && typeof id[0] === 'string') inputs.push(toDependency(id[0]));
-    if (typeof id === 'string') inputs.push(toDependency(id));
+    if (Array.isArray(id) && typeof id[0] === 'string') inputs.push(toDependency(resolveAlias(id[0], srcDir, cwd)));
+    if (typeof id === 'string') inputs.push(toDependency(resolveAlias(id, srcDir, cwd)));
   }
 
   addAppEntries(inputs, srcDir, serverDir, localConfig, cwd);

--- a/packages/knip/src/plugins/nuxt/index.ts
+++ b/packages/knip/src/plugins/nuxt/index.ts
@@ -12,7 +12,7 @@ import {
   toProductionEntry,
 } from '../../util/input.ts';
 import { loadTSConfig } from '../../util/load-tsconfig.ts';
-import { join } from '../../util/path.ts';
+import { isInternal, join } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
 import {
   buildAutoImportMap,
@@ -113,9 +113,16 @@ const resolveConfig: ResolveConfig<NuxtConfig> = async (localConfig, options) =>
   const serverDir = localConfig.serverDir ?? 'server';
   const inputs: Input[] = [];
 
+  const addModule = (id: string) => {
+    const specifier = resolveAlias(id, srcDir, cwd);
+    inputs.push(
+      isInternal(id) || specifier !== id ? toDeferResolveProductionEntry(specifier) : toDependency(specifier)
+    );
+  };
+
   for (const id of localConfig.modules ?? []) {
-    if (Array.isArray(id) && typeof id[0] === 'string') inputs.push(toDependency(resolveAlias(id[0], srcDir, cwd)));
-    if (typeof id === 'string') inputs.push(toDependency(resolveAlias(id, srcDir, cwd)));
+    if (Array.isArray(id) && typeof id[0] === 'string') addModule(id[0]);
+    if (typeof id === 'string') addModule(id);
   }
 
   addAppEntries(inputs, srcDir, serverDir, localConfig, cwd);

--- a/packages/knip/test/plugins/nuxt-no-root-tsconfig.test.ts
+++ b/packages/knip/test/plugins/nuxt-no-root-tsconfig.test.ts
@@ -13,7 +13,7 @@ test('Resolve nuxt aliases without a root tsconfig.json', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 3,
-    total: 3,
+    processed: 5,
+    total: 5,
   });
 });


### PR DESCRIPTION
spotted this in when enabling knip to run automatically - https://github.com/nuxt/nuxt/pull/35742

a nuxt module can be specified by local path, e.g. `~~/modules/thing.ts`, so this applies the same resolution logic for other paths to nuxt modules