### PR TITLE
fix: don't treat [-]-c[heck] as config flag for prettier

### DIFF
--- a/packages/knip/fixtures/plugins/prettier-check-flag/.prettierrc
+++ b/packages/knip/fixtures/plugins/prettier-check-flag/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/packages/knip/fixtures/plugins/prettier-check-flag/node_modules/prettier-plugin-tailwindcss/package.json
+++ b/packages/knip/fixtures/plugins/prettier-check-flag/node_modules/prettier-plugin-tailwindcss/package.json
@@ -1,0 +1,1 @@
+{"name":"prettier-plugin-tailwindcss","version":"1.0.0"}

--- a/packages/knip/fixtures/plugins/prettier-check-flag/node_modules/prettier/package.json
+++ b/packages/knip/fixtures/plugins/prettier-check-flag/node_modules/prettier/package.json
@@ -1,0 +1,1 @@
+{"name":"prettier","version":"3.0.0","bin":{"prettier":"bin/prettier.cjs"}}

--- a/packages/knip/fixtures/plugins/prettier-check-flag/package.json
+++ b/packages/knip/fixtures/plugins/prettier-check-flag/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@plugins/prettier-check-flag",
+  "devDependencies": {
+    "prettier": "*"
+  },
+  "scripts": {
+    "lint": "prettier . --config .prettierrc -c",
+    "lint:fix": "prettier . --config .prettierrc -w"
+  }
+}

--- a/packages/knip/src/plugins/prettier/index.ts
+++ b/packages/knip/src/plugins/prettier/index.ts
@@ -48,7 +48,7 @@ const resolveConfig: ResolveConfig<PrettierConfig> = config => {
 };
 
 const args: Args = {
-  config: true,
+  config: ['config'],
 };
 
 const isFilterTransitiveDependencies = true;

--- a/packages/knip/test/plugins/prettier.test.ts
+++ b/packages/knip/test/plugins/prettier.test.ts
@@ -34,6 +34,22 @@ test('Find dependencies with the Prettier plugin (--config arg)', async () => {
   assert(issues.unlisted['my-prettier-settings.js']['my-custom-prettier-plugin']);
 });
 
+test('Find dependencies with the Prettier plugin (--config arg with -c check flag)', async () => {
+  const cwd = resolve('fixtures/plugins/prettier-check-flag');
+  const options = await createOptions({ cwd });
+  // Before #1902, -c was aliased to --config causing parsed.config to be
+  // ["path", ""] (an array), which crashed on specifier.charCodeAt().
+  const { issues, counters } = await main(options);
+
+  // .prettierrc was correctly resolved via --config and its plugin was found
+  assert(!issues.unlisted['.prettierrc']);
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 0,
+    total: 0,
+  });
+});
+
 test('Find dependencies with the Prettier plugin (.json5 config)', async () => {
   const cwd = resolve('fixtures/plugins/prettier-json5');
   const options = await createOptions({ cwd });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

For prettier, `-c` was incorrectly treated as a config flag.
