### PR TITLE
feat(stryker): add ts extensions

### DIFF
--- a/packages/knip/fixtures/plugins/stryker/package.json
+++ b/packages/knip/fixtures/plugins/stryker/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@plugins/stryker",
   "scripts": {
-    "stryker": "stryker"
+    "stryker": "stryker",
+    "stryker:custom": "stryker run --incremental stryker.custom.conf.ts"
   },
   "type": "module",
   "dependencies": {

--- a/packages/knip/fixtures/plugins/stryker/stryker.custom.conf.ts
+++ b/packages/knip/fixtures/plugins/stryker/stryker.custom.conf.ts
@@ -1,0 +1,6 @@
+const config = {
+  testRunner: 'tap',
+  checkers: ['typescript'],
+};
+
+export default config;

--- a/packages/knip/src/plugins/stryker/index.ts
+++ b/packages/knip/src/plugins/stryker/index.ts
@@ -11,7 +11,7 @@ const enablers = ['@stryker-mutator/core'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['?(.)stryker.{conf,config}.{js,mjs,cjs,json}'];
+const config = ['?(.)stryker.{conf,config}.{js,mjs,cjs,json,mts,cts,ts}'];
 
 const resolveConfig: ResolveConfig<StrykerConfig> = localConfig => {
   const runners = localConfig.testRunner ? [`@stryker-mutator/${localConfig.testRunner}-runner`] : [];

--- a/packages/knip/src/plugins/stryker/index.ts
+++ b/packages/knip/src/plugins/stryker/index.ts
@@ -1,5 +1,6 @@
+import type { Args } from '../../types/args.ts';
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
-import { toDeferResolve } from '../../util/input.ts';
+import { toConfig, toDeferResolve } from '../../util/input.ts';
 import { hasDependency } from '../../util/plugin.ts';
 import type { StrykerConfig } from './types.ts';
 
@@ -11,7 +12,7 @@ const enablers = ['@stryker-mutator/core'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['?(.)stryker.{conf,config}.{js,mjs,cjs,json,mts,cts,ts}'];
+const config = ['?(.)stryker.{conf,config}.{js,mjs,cjs,json}'];
 
 const resolveConfig: ResolveConfig<StrykerConfig> = localConfig => {
   const runners = localConfig.testRunner ? [`@stryker-mutator/${localConfig.testRunner}-runner`] : [];
@@ -23,12 +24,18 @@ const resolveConfig: ResolveConfig<StrykerConfig> = localConfig => {
   return [...runners, ...checkers, ...plugins].map(id => toDeferResolve(id));
 };
 
+const args: Args = {
+  boolean: ['allowEmpty', 'disableBail', 'dryRunOnly', 'force', 'ignoreStatic', 'incremental', 'inPlace'],
+  resolveInputs: parsed => (parsed._[0] === 'run' && parsed._[1] ? [toConfig('stryker', parsed._[1])] : []),
+};
+
 const plugin: Plugin = {
   title,
   enablers,
   isEnabled,
   config,
   resolveConfig,
+  args,
 };
 
 export default plugin;

--- a/packages/knip/test/plugins/stryker.test.ts
+++ b/packages/knip/test/plugins/stryker.test.ts
@@ -26,6 +26,18 @@ test('Find dependencies with the Stryker plugin', async () => {
   assert(issues.unlisted['stryker.conf.mjs']['@stryker-mutator/typescript-checker']);
   assert(issues.unlisted['stryker.conf.mjs']['@stryker-mutator/jasmine-framework']);
   assert(issues.unlisted['stryker.conf.mjs']['@stryker-mutator/karma-runner']);
+  assert(issues.unlisted['.stryker.conf.ts']['@stryker-mutator/mocha-runner']);
+  assert(issues.unlisted['.stryker.conf.ts']['@stryker-mutator/typescript-checker']);
+  assert(issues.unlisted['.stryker.conf.ts']['@stryker-mutator/jasmine-framework']);
+  assert(issues.unlisted['.stryker.conf.ts']['@stryker-mutator/karma-runner']);
+  assert(issues.unlisted['.stryker.conf.mts']['@stryker-mutator/mocha-runner']);
+  assert(issues.unlisted['.stryker.conf.mts']['@stryker-mutator/typescript-checker']);
+  assert(issues.unlisted['.stryker.conf.mts']['@stryker-mutator/jasmine-framework']);
+  assert(issues.unlisted['.stryker.conf.mts']['@stryker-mutator/karma-runner']);
+  assert(issues.unlisted['.stryker.conf.cts']['@stryker-mutator/mocha-runner']);
+  assert(issues.unlisted['.stryker.conf.cts']['@stryker-mutator/typescript-checker']);
+  assert(issues.unlisted['.stryker.conf.cts']['@stryker-mutator/jasmine-framework']);
+  assert(issues.unlisted['.stryker.conf.cts']['@stryker-mutator/karma-runner']);
   assert(issues.binaries['package.json']['stryker']);
 
   assert.deepEqual(counters, {

--- a/packages/knip/test/plugins/stryker.test.ts
+++ b/packages/knip/test/plugins/stryker.test.ts
@@ -26,26 +26,16 @@ test('Find dependencies with the Stryker plugin', async () => {
   assert(issues.unlisted['stryker.conf.mjs']['@stryker-mutator/typescript-checker']);
   assert(issues.unlisted['stryker.conf.mjs']['@stryker-mutator/jasmine-framework']);
   assert(issues.unlisted['stryker.conf.mjs']['@stryker-mutator/karma-runner']);
-  assert(issues.unlisted['.stryker.conf.ts']['@stryker-mutator/mocha-runner']);
-  assert(issues.unlisted['.stryker.conf.ts']['@stryker-mutator/typescript-checker']);
-  assert(issues.unlisted['.stryker.conf.ts']['@stryker-mutator/jasmine-framework']);
-  assert(issues.unlisted['.stryker.conf.ts']['@stryker-mutator/karma-runner']);
-  assert(issues.unlisted['.stryker.conf.mts']['@stryker-mutator/mocha-runner']);
-  assert(issues.unlisted['.stryker.conf.mts']['@stryker-mutator/typescript-checker']);
-  assert(issues.unlisted['.stryker.conf.mts']['@stryker-mutator/jasmine-framework']);
-  assert(issues.unlisted['.stryker.conf.mts']['@stryker-mutator/karma-runner']);
-  assert(issues.unlisted['.stryker.conf.cts']['@stryker-mutator/mocha-runner']);
-  assert(issues.unlisted['.stryker.conf.cts']['@stryker-mutator/typescript-checker']);
-  assert(issues.unlisted['.stryker.conf.cts']['@stryker-mutator/jasmine-framework']);
-  assert(issues.unlisted['.stryker.conf.cts']['@stryker-mutator/karma-runner']);
+  assert(issues.unlisted['stryker.custom.conf.ts']['@stryker-mutator/tap-runner']);
+  assert(issues.unlisted['stryker.custom.conf.ts']['@stryker-mutator/typescript-checker']);
   assert(issues.binaries['package.json']['stryker']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 1,
     dependencies: 1,
-    unlisted: 14,
-    processed: 3,
-    total: 3,
+    unlisted: 16,
+    processed: 4,
+    total: 4,
   });
 });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->

Although by default Stryker [does not](https://stryker-mutator.io/docs/stryker-js/config-file/) support .ts files, you can use TS files by supplying the name directly (e.g. `"pnpm exec stryker run stryker.config.ts) - so I am hoping this PR is still acceptable!