### PR TITLE
fix(remark): support all types of dependency names

### DIFF
--- a/packages/knip/fixtures/plugins/remark-fallback-scoped/package.json
+++ b/packages/knip/fixtures/plugins/remark-fallback-scoped/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fixtures/remark-fallback-scoped",
+  "scripts": {
+    "format": "remark README.md -o"
+  },
+  "devDependencies": {
+    "remark-cli": "*",
+    "@scope/pkg-b": "*"
+  },
+  "remarkConfig": {
+    "plugins": [
+      "@scope/pkg-b"
+    ]
+  }
+}

--- a/packages/knip/fixtures/plugins/remark-fallback-unscoped/package.json
+++ b/packages/knip/fixtures/plugins/remark-fallback-unscoped/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fixtures/remark-fallback-unscoped",
+  "scripts": {
+    "format": "remark README.md -o"
+  },
+  "devDependencies": {
+    "remark-cli": "*",
+    "pkg-a": "*"
+  },
+  "remarkConfig": {
+    "plugins": [
+      "pkg-a"
+    ]
+  }
+}

--- a/packages/knip/fixtures/plugins/remark-local-path/index.js
+++ b/packages/knip/fixtures/plugins/remark-local-path/index.js
@@ -1,0 +1,1 @@
+export default function localRemarkPlugin() {}

--- a/packages/knip/fixtures/plugins/remark-local-path/package.json
+++ b/packages/knip/fixtures/plugins/remark-local-path/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@fixtures/remark-local-path",
+  "scripts": {
+    "format": "remark README.md -o"
+  },
+  "devDependencies": {
+    "remark-cli": "*"
+  },
+  "remarkConfig": {
+    "plugins": [
+      "./index.js"
+    ]
+  }
+}

--- a/packages/knip/fixtures/plugins/remark-missing-placeholder/package.json
+++ b/packages/knip/fixtures/plugins/remark-missing-placeholder/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@fixtures/remark-missing-placeholder",
+  "scripts": {
+    "format": "remark README.md -o"
+  },
+  "devDependencies": {
+    "remark-cli": "*"
+  },
+  "remarkConfig": {
+    "plugins": [
+      "pkg-c"
+    ]
+  }
+}

--- a/packages/knip/fixtures/plugins/remark-primary-scoped/package.json
+++ b/packages/knip/fixtures/plugins/remark-primary-scoped/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fixtures/remark-primary-scoped",
+  "scripts": {
+    "format": "remark README.md -o"
+  },
+  "devDependencies": {
+    "remark-cli": "*",
+    "@scope/remark-pkg-b": "*"
+  },
+  "remarkConfig": {
+    "plugins": [
+      "@scope/pkg-b"
+    ]
+  }
+}

--- a/packages/knip/fixtures/plugins/remark-primary-unscoped/package.json
+++ b/packages/knip/fixtures/plugins/remark-primary-unscoped/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fixtures/remark-primary-unscoped",
+  "scripts": {
+    "format": "remark README.md -o"
+  },
+  "devDependencies": {
+    "remark-cli": "*",
+    "remark-pkg-a": "*"
+  },
+  "remarkConfig": {
+    "plugins": [
+      "pkg-a"
+    ]
+  }
+}

--- a/packages/knip/src/plugins/remark/helpers.ts
+++ b/packages/knip/src/plugins/remark/helpers.ts
@@ -1,0 +1,48 @@
+import { type Input, toDeferResolve, toDependency } from '../../util/input.ts';
+import type { Manifest } from '../../util/package-json.ts';
+import { isInternal } from '../../util/path.ts';
+
+const getCandidates = (prefix: string, identifier: string): string[] => {
+  if (isInternal(identifier)) return [identifier];
+
+  if (identifier.startsWith('@')) {
+    const [scope, name, ...rest] = identifier.split('/');
+    if (rest.length > 0) return [identifier];
+    if (scope) {
+      if (!name) return [[scope, prefix].join('/')];
+      if (name.startsWith(prefix)) return [identifier];
+      return [[scope, prefix + name].join('/'), identifier];
+    }
+  }
+
+  const [name, ...rest] = identifier.split('/');
+  if (rest.length > 0) return [identifier];
+  if (name.startsWith(prefix)) return [identifier];
+  return [prefix + name, name];
+};
+
+const getDeclaredDependencies = (manifest: Manifest) =>
+  new Set([
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.devDependencies ?? {}),
+    ...Object.keys(manifest.optionalDependencies ?? {}),
+    ...Object.keys(manifest.peerDependencies ?? {}),
+  ]);
+
+const pickCandidate = (prefix: string, identifier: string, manifest: Manifest) => {
+  const candidates = getCandidates(prefix, identifier);
+  if (candidates.length === 1 || isInternal(candidates[0])) return candidates[0];
+
+  const dependencies = getDeclaredDependencies(manifest);
+  return candidates.find(candidate => dependencies.has(candidate)) ?? candidates[0];
+};
+
+// Resolve plugins for https://github.com/wooorm/load-plugin
+export const resolveLoadPluginStylePluginName = (prefix: string, identifier: string, manifest: Manifest): Input => {
+  // https://github.com/wooorm/load-plugin/blob/4a1b7231e20f64be52625ff3469bbf111dda5949/lib/index.js#L104
+  prefix = prefix + (prefix.at(-1) === '-' ? '' : '-');
+
+  const candidate = pickCandidate(prefix, identifier, manifest);
+
+  return isInternal(candidate) ? toDeferResolve(candidate) : toDependency(candidate);
+};

--- a/packages/knip/src/plugins/remark/index.ts
+++ b/packages/knip/src/plugins/remark/index.ts
@@ -1,8 +1,7 @@
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
-import { toDeferResolve } from '../../util/input.ts';
-import { isInternal } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
 import type { RemarkConfig } from './types.ts';
+import { resolveLoadPluginStylePluginName } from './helpers.ts';
 
 // https://github.com/remarkjs/remark/blob/main/packages/remark-cli/readme.md
 
@@ -16,7 +15,7 @@ const packageJsonPath = 'remarkConfig';
 
 const config = ['package.json', '.remarkrc', '.remarkrc.json', '.remarkrc.{js,cjs,mjs}', '.remarkrc.{yml,yaml}'];
 
-const resolveConfig: ResolveConfig<RemarkConfig> = config => {
+const resolveConfig: ResolveConfig<RemarkConfig> = (config, options) => {
   const plugins =
     config.plugins
       ?.flatMap(plugin => {
@@ -24,8 +23,19 @@ const resolveConfig: ResolveConfig<RemarkConfig> = config => {
         if (Array.isArray(plugin) && typeof plugin[0] === 'string') return plugin[0];
         return [];
       })
-      .map(plugin => (isInternal(plugin) ? plugin : plugin.startsWith('remark-') ? plugin : `remark-${plugin}`)) ?? [];
-  return plugins.map(id => toDeferResolve(id));
+      .map(plugin =>
+        // Resolve a remark plugin specifier from all possible dependency name variations.
+        //
+        // remark-cli configures `pluginPrefix: 'remark'`; unified-engine forwards this
+        // to load-plugin, which prefers the prefixed name and falls back to the raw
+        // identifier + supports scoped modules.
+        //
+        // https://github.com/remarkjs/remark/blob/334415d7552f2ffa359a23efc100345e7ed7a9f7/packages/remark-cli/cli.js#L36
+        // https://github.com/unifiedjs/unified-engine/blob/6f35eaedc659e6edd5392f9ef0cf49bc51f3feab/lib/configuration.js#L423-L426
+        // https://github.com/wooorm/load-plugin/blob/4a1b7231e20f64be52625ff3469bbf111dda5949/lib/index.js#L91-L101
+        resolveLoadPluginStylePluginName('remark-', plugin, options.manifest)
+      ) ?? [];
+  return plugins;
 };
 
 const plugin: Plugin = {

--- a/packages/knip/test/plugins/remark-fallback-scoped.test.ts
+++ b/packages/knip/test/plugins/remark-fallback-scoped.test.ts
@@ -5,21 +5,23 @@ import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
-const cwd = resolve('fixtures/plugins/remark');
+const cwd = resolve('fixtures/plugins/remark-fallback-scoped');
 
-test('Find dependencies with the Remark plugin', async () => {
+test('Find dependencies with the Remark plugin (fallback scoped candidate)', async () => {
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 
   assert(issues.devDependencies['package.json']['remark-cli']);
-  assert(issues.unlisted['package.json']['remark-preset-webpro']);
   assert(issues.binaries['package.json']['remark']);
+  assert.equal(issues.unlisted['package.json']?.['@scope/remark-pkg-b'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['@scope/remark-pkg-b'], undefined);
+  assert.equal(issues.unlisted['package.json']?.['@scope/pkg-b'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['@scope/pkg-b'], undefined);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 1,
     devDependencies: 1,
-    unlisted: 1,
     processed: 0,
     total: 0,
   });

--- a/packages/knip/test/plugins/remark-fallback-unscoped.test.ts
+++ b/packages/knip/test/plugins/remark-fallback-unscoped.test.ts
@@ -5,21 +5,23 @@ import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
-const cwd = resolve('fixtures/plugins/remark');
+const cwd = resolve('fixtures/plugins/remark-fallback-unscoped');
 
-test('Find dependencies with the Remark plugin', async () => {
+test('Find dependencies with the Remark plugin (fallback unscoped candidate)', async () => {
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 
   assert(issues.devDependencies['package.json']['remark-cli']);
-  assert(issues.unlisted['package.json']['remark-preset-webpro']);
   assert(issues.binaries['package.json']['remark']);
+  assert.equal(issues.unlisted['package.json']?.['remark-pkg-a'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['remark-pkg-a'], undefined);
+  assert.equal(issues.unlisted['package.json']?.['pkg-a'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['pkg-a'], undefined);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 1,
     devDependencies: 1,
-    unlisted: 1,
     processed: 0,
     total: 0,
   });

--- a/packages/knip/test/plugins/remark-local-path.test.ts
+++ b/packages/knip/test/plugins/remark-local-path.test.ts
@@ -5,22 +5,23 @@ import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
-const cwd = resolve('fixtures/plugins/remark');
+const cwd = resolve('fixtures/plugins/remark-local-path');
 
-test('Find dependencies with the Remark plugin', async () => {
+test('Find dependencies with the Remark plugin (local plugin path)', async () => {
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 
   assert(issues.devDependencies['package.json']['remark-cli']);
-  assert(issues.unlisted['package.json']['remark-preset-webpro']);
   assert(issues.binaries['package.json']['remark']);
+  assert.equal(issues.unlisted['package.json']?.['./index.js'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['./index.js'], undefined);
+  assert.equal(issues.files['index.js'], undefined);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 1,
     devDependencies: 1,
-    unlisted: 1,
-    processed: 0,
-    total: 0,
+    processed: 1,
+    total: 1,
   });
 });

--- a/packages/knip/test/plugins/remark-missing-placeholder.test.ts
+++ b/packages/knip/test/plugins/remark-missing-placeholder.test.ts
@@ -5,15 +5,18 @@ import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
-const cwd = resolve('fixtures/plugins/remark');
+const cwd = resolve('fixtures/plugins/remark-missing-placeholder');
 
-test('Find dependencies with the Remark plugin', async () => {
+test('Find dependencies with the Remark plugin (missing placeholder candidate)', async () => {
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 
   assert(issues.devDependencies['package.json']['remark-cli']);
-  assert(issues.unlisted['package.json']['remark-preset-webpro']);
   assert(issues.binaries['package.json']['remark']);
+  assert(issues.unlisted['package.json']['remark-pkg-c']);
+  assert.equal(issues.unresolved['package.json']?.['remark-pkg-c'], undefined);
+  assert.equal(issues.unlisted['package.json']?.['pkg-c'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['pkg-c'], undefined);
 
   assert.deepEqual(counters, {
     ...baseCounters,

--- a/packages/knip/test/plugins/remark-primary-scoped.test.ts
+++ b/packages/knip/test/plugins/remark-primary-scoped.test.ts
@@ -5,21 +5,23 @@ import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
-const cwd = resolve('fixtures/plugins/remark');
+const cwd = resolve('fixtures/plugins/remark-primary-scoped');
 
-test('Find dependencies with the Remark plugin', async () => {
+test('Find dependencies with the Remark plugin (primary scoped candidate)', async () => {
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 
   assert(issues.devDependencies['package.json']['remark-cli']);
-  assert(issues.unlisted['package.json']['remark-preset-webpro']);
   assert(issues.binaries['package.json']['remark']);
+  assert.equal(issues.unlisted['package.json']?.['@scope/remark-pkg-b'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['@scope/remark-pkg-b'], undefined);
+  assert.equal(issues.unlisted['package.json']?.['@scope/pkg-b'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['@scope/pkg-b'], undefined);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 1,
     devDependencies: 1,
-    unlisted: 1,
     processed: 0,
     total: 0,
   });

--- a/packages/knip/test/plugins/remark-primary-unscoped.test.ts
+++ b/packages/knip/test/plugins/remark-primary-unscoped.test.ts
@@ -5,21 +5,23 @@ import baseCounters from '../helpers/baseCounters.ts';
 import { createOptions } from '../helpers/create-options.ts';
 import { resolve } from '../helpers/resolve.ts';
 
-const cwd = resolve('fixtures/plugins/remark');
+const cwd = resolve('fixtures/plugins/remark-primary-unscoped');
 
-test('Find dependencies with the Remark plugin', async () => {
+test('Find dependencies with the Remark plugin (primary unscoped candidate)', async () => {
   const options = await createOptions({ cwd });
   const { issues, counters } = await main(options);
 
   assert(issues.devDependencies['package.json']['remark-cli']);
-  assert(issues.unlisted['package.json']['remark-preset-webpro']);
   assert(issues.binaries['package.json']['remark']);
+  assert.equal(issues.unlisted['package.json']?.['remark-pkg-a'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['remark-pkg-a'], undefined);
+  assert.equal(issues.unlisted['package.json']?.['pkg-a'], undefined);
+  assert.equal(issues.unresolved['package.json']?.['pkg-a'], undefined);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 1,
     devDependencies: 1,
-    unlisted: 1,
     processed: 0,
     total: 0,
   });


### PR DESCRIPTION
When I tried using my newly published [`@voxpelli/remark-preset`](https://github.com/voxpelli/remark-preset) I got complaints from `knip` that I had:

```
Unused devDependencies (1)

@voxpelli/remark-preset  package.json:60:6

Unresolved imports (1)

remark-@voxpelli/remark-preset  package.json
```

This PR aims to support the full range of [`load-plugin`](https://github.com/wooorm/load-plugin) name resolution so that scoped and prefix-less dependencies will resolve as cleanly in knip as it does in `remark-cli`.

I worked with GitHub Copilot to generate a set of tests for it as well, to make sure the code actually solves what it intended + I ran the full test suite of this project + I tested it on my own local project to validate that it solved my issue.