### PR TITLE
fix: attribute wildcard subpath-import aliases as dependency usage

### DIFF
--- a/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/node_modules/@scope/fruit
+++ b/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/node_modules/@scope/fruit
@@ -1,0 +1,1 @@
+../../packages/fruit

--- a/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/package.json
+++ b/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixtures/subpath-import-alias-workspace",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/packages/consumer/index.ts
+++ b/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/packages/consumer/index.ts
@@ -1,0 +1,3 @@
+import { apple } from '#fruit/index.js';
+
+apple;

--- a/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/packages/consumer/package.json
+++ b/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/packages/consumer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@scope/consumer",
+  "private": true,
+  "imports": {
+    "#fruit/*": "@scope/fruit/*"
+  },
+  "dependencies": {
+    "@scope/fruit": "*"
+  }
+}

--- a/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/packages/fruit/index.ts
+++ b/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/packages/fruit/index.ts
@@ -1,0 +1,1 @@
+export const apple = 'apple';

--- a/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/packages/fruit/package.json
+++ b/packages/knip/fixtures/dependencies/subpath-import-wildcard-workspace/packages/fruit/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scope/fruit",
+  "private": true,
+  "main": "index.ts"
+}

--- a/packages/knip/src/util/package-json.ts
+++ b/packages/knip/src/util/package-json.ts
@@ -2,6 +2,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { IS_DTS } from '../constants.ts';
 import type { PackageJson } from '../types/package-json.ts';
+import { getPackageNameFromModuleSpecifier } from './modules.ts';
 
 const INDENT = Symbol.for('indent');
 const NEWLINE = Symbol.for('newline');
@@ -262,7 +263,9 @@ export const getManifestImportDependencies = (manifest: PackageJson) => {
   for (const [entry, exportValue] of Object.entries(manifest.imports)) {
     if (!entry.startsWith('#')) continue;
     for (const item of getEntriesFromExports(exportValue)) {
-      if (!item.startsWith('.') && !item.startsWith('!')) dependencies.add(item);
+      if (item.startsWith('.') || item.startsWith('!')) continue;
+      const packageName = getPackageNameFromModuleSpecifier(item);
+      if (packageName) dependencies.add(packageName);
     }
   }
   return dependencies;

--- a/packages/knip/test/dependencies/subpath-import-wildcard-workspace.test.ts
+++ b/packages/knip/test/dependencies/subpath-import-wildcard-workspace.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/dependencies/subpath-import-wildcard-workspace');
+
+test('Attribute a wildcard subpath-import target pointing to a sibling workspace package as dependency usage', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert.deepEqual(issues.unlisted, {});
+  assert.deepEqual(issues.dependencies, {});
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
+  });
+});


### PR DESCRIPTION
### Problem

A `package.json` [subpath import](https://nodejs.org/api/packages.html#subpath-imports) can alias to another package rather than a relative path, e.g.:

```jsonc
{
  "name": "app",
  "imports": {
    "#shared/*": "@scope/shared/*"
  },
  "dependencies": {
    "@scope/shared": "*"
  }
}
```

Knip already has a mechanism for this (`getManifestImportDependencies` in `src/util/package-json.ts`): it scans a workspace's own `imports` field and marks any bare-package-specifier target as a referenced dependency, independent of whether any file actually imports through the alias. This works correctly for exact targets like `"#shared": "@scope/shared"`.

It breaks for wildcard targets. For `"#shared/*": "@scope/shared/*"`, the collected value is the literal string `"@scope/shared/*"`, not `"@scope/shared"`. That string is then marked as the referenced dependency, which never matches the real dependency name (`@scope/shared`) in `dependencies`. `@scope/shared` is therefore reported as unused, even though it's the only reason the subpath import resolves.

I ran into this in a real npm-workspaces monorepo where a package's `imports` field points at a sibling workspace package via a wildcard subpath. The resolution itself (following the alias to the correct file) works fine — this is purely a dependency-usage attribution bug.

### Fix

Normalize each collected target to its package name with the existing `getPackageNameFromModuleSpecifier` helper before adding it to the dependency set. `getPackageNameFromModuleSpecifier('@scope/shared/*')` returns `'@scope/shared'`, so this is a pure normalization fix with no behavior change for the already-working exact-target case.

### Test

New fixture at `fixtures/dependencies/subpath-import-wildcard-workspace/`: two real npm workspaces (`fruit`, `consumer`), with `consumer` declaring `"imports": {"#fruit/*": "@scope/fruit/*"}` and `"dependencies": {"@scope/fruit": "*"}`, plus a real symlink at `node_modules/@scope/fruit` (simulating an actual workspace install, since that's what actually exercises the resolver's realpath behavior — a monorepo fixture without an install doesn't hit the same code path). `test/dependencies/subpath-import-wildcard-workspace.test.ts` asserts `@scope/fruit` is not reported unused.

Verified test-driven: fails against unmodified Knip with the exact predicted symptom, passes with the fix. Also verified against a real-world reproduction of the original bug (removing an `ignoreDependencies` workaround and confirming the false positive disappears with the fix, with no change to any other reported issue).