### PR TITLE
fix(playwright): match config files with .cjs, .cts and .mts extensions

### DIFF
--- a/packages/knip/fixtures/plugins/playwright/commonjs-reporter.cjs
+++ b/packages/knip/fixtures/plugins/playwright/commonjs-reporter.cjs
@@ -1,0 +1,1 @@
+module.exports = class {};

--- a/packages/knip/fixtures/plugins/playwright/commonjs-typescript-reporter.cts
+++ b/packages/knip/fixtures/plugins/playwright/commonjs-typescript-reporter.cts
@@ -1,0 +1,3 @@
+import type { Reporter } from '@playwright/test/reporter';
+
+export default class implements Reporter {}

--- a/packages/knip/fixtures/plugins/playwright/esmodule-reporter.mts
+++ b/packages/knip/fixtures/plugins/playwright/esmodule-reporter.mts
@@ -1,0 +1,3 @@
+import type { Reporter } from '@playwright/test/reporter';
+
+export default class implements Reporter {}

--- a/packages/knip/fixtures/plugins/playwright/playwright.config.cjs
+++ b/packages/knip/fixtures/plugins/playwright/playwright.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  reporter: [['./commonjs-reporter.cjs']],
+};

--- a/packages/knip/fixtures/plugins/playwright/playwright.config.cts
+++ b/packages/knip/fixtures/plugins/playwright/playwright.config.cts
@@ -1,0 +1,7 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  reporter: [['./commonjs-typescript-reporter.cts']],
+};
+
+export default config;

--- a/packages/knip/fixtures/plugins/playwright/playwright.config.mts
+++ b/packages/knip/fixtures/plugins/playwright/playwright.config.mts
@@ -1,0 +1,7 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  reporter: [['./esmodule-reporter.mts']],
+};
+
+export default config;

--- a/packages/knip/src/plugins/playwright/index.ts
+++ b/packages/knip/src/plugins/playwright/index.ts
@@ -13,7 +13,7 @@ const enablers = ['@playwright/test'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['playwright.config.{js,ts,mjs}'];
+const config = ['playwright.config.{js,cjs,mjs,ts,cts,mts}'];
 
 export const entry = ['**/*.@(spec|test).?(c|m)[jt]s?(x)'];
 

--- a/packages/knip/test/plugins/playwright.test.ts
+++ b/packages/knip/test/plugins/playwright.test.ts
@@ -13,7 +13,7 @@ test('Find dependencies with the Playwright plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 3,
-    total: 3,
+    processed: 9,
+    total: 9,
   });
 });


### PR DESCRIPTION
## What

`packages/knip/src/plugins/playwright/index.ts` matched three of the six config
file extensions Playwright accepts:

```diff
-const config = ['playwright.config.{js,ts,mjs}'];
+const config = ['playwright.config.{js,cjs,mjs,ts,cts,mts}'];
```

## Why

Playwright resolves `playwright.config` against a fixed extension list in
`packages/playwright/src/common/configLoader.ts`
(https://github.com/microsoft/playwright/blob/main/packages/playwright/src/common/configLoader.ts):

```js
for (const ext of ['.ts', '.js', '.mts', '.mjs', '.cts', '.cjs']) {
  const configFile = resolveConfig(path.resolve(directory, 'playwright.config' + ext));
  ...
}
```

A project on `playwright.config.cjs`, `playwright.config.cts` or
`playwright.config.mts` therefore got a false positive on the config file
itself, and nothing referenced from it (reporters, `globalSetup`,
`globalTeardown`, `testDir`/`testMatch` entries) was resolved either.

## Reproduction

Extended `fixtures/plugins/playwright` with one config per missing extension,
each pointing at its own custom reporter. Before the change, running knip in
that fixture:

```
Unused files (6)
commonjs-reporter.cjs
commonjs-typescript-reporter.cts
esmodule-reporter.mts
playwright.config.cjs
playwright.config.cts
playwright.config.mts
```

After the change the same command reports nothing, which is what the updated
counters in `test/plugins/playwright.test.ts` assert (`processed`/`total` 3 → 9).

## Tests

Ran from `packages/knip` on Node 26.5.0 (no `bun` on this machine):

- `node --test test/plugins/playwright.test.ts test/plugins/playwright2.test.ts test/plugins/playwright-ct.test.ts test/plugins/playwright-ct2.test.ts` — 4/4 pass
- `node --test $(ls test/plugins/*.test.ts)` — 361/361 pass
- root `oxlint` — exit 0; root `oxfmt --check` — all files correctly formatted

## Note

Written with AI assistance. The reproduction above and the test runs are the
evidence behind it; happy to adjust the fixture shape or drop it to a single
extension if you prefer a smaller diff.
