### PR TITLE
Resolve vitest include patterns relative to test.dir

### DIFF
--- a/packages/knip/fixtures/plugins/vitest11/node_modules/vitest/config.js
+++ b/packages/knip/fixtures/plugins/vitest11/node_modules/vitest/config.js
@@ -1,0 +1,5 @@
+function defineConfig(config) {
+  return config;
+}
+
+export { defineConfig };

--- a/packages/knip/fixtures/plugins/vitest11/node_modules/vitest/package.json
+++ b/packages/knip/fixtures/plugins/vitest11/node_modules/vitest/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "vitest"
+}

--- a/packages/knip/fixtures/plugins/vitest11/package.json
+++ b/packages/knip/fixtures/plugins/vitest11/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@plugins/vitest11",
+  "devDependencies": {
+    "vitest": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/vitest11/setup.ts
+++ b/packages/knip/fixtures/plugins/vitest11/setup.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/knip/fixtures/plugins/vitest11/src/unused.test.ts
+++ b/packages/knip/fixtures/plugins/vitest11/src/unused.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('Unit A', () => {
+  expect(true).toBe(!false);
+});

--- a/packages/knip/fixtures/plugins/vitest11/tests/adder.test.ts
+++ b/packages/knip/fixtures/plugins/vitest11/tests/adder.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('Unit A', () => {
+  expect(true).toBe(!false);
+});

--- a/packages/knip/fixtures/plugins/vitest11/vitest.config.ts
+++ b/packages/knip/fixtures/plugins/vitest11/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    dir: 'tests',
+    include: ['*.test.ts'],
+    setupFiles: ['./setup.ts'],
+  },
+});

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -160,7 +160,8 @@ export const resolveConfig: ResolveConfig<ViteConfigOrFn | VitestWorkspaceConfig
       for (const entry of await getIndexHtmlEntries(viteRoot)) inputs.add(entry);
     }
 
-    const dir = toAbsolute(cfg.test?.root ?? '.', options.cwd);
+    const vitestRoot = toAbsolute(cfg.test?.root ?? '.', options.cwd);
+    const dir = cfg.test?.dir ? toAbsolute(cfg.test.dir, vitestRoot) : vitestRoot;
 
     if (cfg.test) {
       if (cfg.test?.include) {
@@ -197,10 +198,10 @@ export const resolveConfig: ResolveConfig<ViteConfigOrFn | VitestWorkspaceConfig
         inputs.add(toEntry(`src/**/*${ext}`));
       }
     }
-    for (const dependency of findConfigDependencies(cfg, options, dir)) inputs.add(dependency);
+    for (const dependency of findConfigDependencies(cfg, options, vitestRoot)) inputs.add(dependency);
     const _entry = cfg.build?.lib?.entry ?? [];
     const deps = (typeof _entry === 'string' ? [_entry] : Object.values(_entry))
-      .map(specifier => join(dir, specifier))
+      .map(specifier => join(vitestRoot, specifier))
       .map(id => toEntry(id));
     for (const dependency of deps) inputs.add(dependency);
   }

--- a/packages/knip/src/plugins/vitest/types.ts
+++ b/packages/knip/src/plugins/vitest/types.ts
@@ -17,6 +17,7 @@ interface VitestConfig {
       provider: string;
     };
     root?: string;
+    dir?: string;
     environment?: string;
     globalSetup?: string | string[];
     reporters?: (string | [string, unknown] | unknown)[];

--- a/packages/knip/test/plugins/vitest11.test.ts
+++ b/packages/knip/test/plugins/vitest11.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/vitest11');
+
+test('Find dependencies with the Vitest plugin (11)', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert('src/unused.test.ts' in issues.files);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    files: 1,
+    processed: 4,
+    total: 4,
+  });
+});


### PR DESCRIPTION
Fixes #1926

Vitest's `test.dir` option scopes where include patterns apply, but the plugin resolved include patterns from the vitest root only, so test files under a configured `test.dir` were reported as unused. This resolves the pattern base through `test.dir` when set (itself relative to `test.root`), while config dependencies and build lib entries keep resolving from the root as before.

Offering this since the thread invited a PR and the reporter mentioned being away for a bit. New fixture + test covering a config with `test.dir: 'tests'`: a test file under `tests/` is picked up, one outside it is reported unused. All 15 vitest plugin tests pass.