### PR TITLE
Mark Babel config as entry file in Expo plugin

### DIFF
--- a/packages/knip/fixtures/plugins/expo5/app.json
+++ b/packages/knip/fixtures/plugins/expo5/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "Knip",
+    "slug": "knip",
+    "platforms": ["ios", "android"],
+    "updates": {
+      "enabled": false
+    }
+  }
+}

--- a/packages/knip/fixtures/plugins/expo5/app/index.tsx
+++ b/packages/knip/fixtures/plugins/expo5/app/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export default function App() {
+  return <View />;
+}

--- a/packages/knip/fixtures/plugins/expo5/babel.config.js
+++ b/packages/knip/fixtures/plugins/expo5/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = api => {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/packages/knip/fixtures/plugins/expo5/node_modules/expo/package.json
+++ b/packages/knip/fixtures/plugins/expo5/node_modules/expo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "expo",
+  "bin": "bin/cli",
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/expo5/package.json
+++ b/packages/knip/fixtures/plugins/expo5/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@plugins/expo5",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
+  }
+}

--- a/packages/knip/src/plugins/expo/index.ts
+++ b/packages/knip/src/plugins/expo/index.ts
@@ -1,5 +1,5 @@
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
-import { toProductionEntry } from '../../util/input.ts';
+import { toEntry, toProductionEntry } from '../../util/input.ts';
 import { join } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
 import { getConfig, getDependencies } from './helpers.ts';
@@ -15,11 +15,14 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 
 const config = ['app.json', 'app.config.{ts,js}'];
 
+const entry = ['babel.config.{js,cjs,mjs,cts}'];
+
 const production = ['app/**/*.{js,jsx,ts,tsx}', 'src/app/**/*.{js,jsx,ts,tsx}'];
 
 const resolveConfig: ResolveConfig<ExpoConfig> = async (localConfig, options) => {
   const { manifest } = options;
   const config = getConfig(localConfig, options);
+  const entries = entry.map(id => toEntry(id));
 
   // https://docs.expo.dev/router/installation/#setup-entry-point
   if (manifest.main === 'expo-router/entry') {
@@ -37,10 +40,10 @@ const resolveConfig: ResolveConfig<ExpoConfig> = async (localConfig, options) =>
       }
     }
 
-    return patterns.map(entry => toProductionEntry(entry)).concat(await getDependencies(localConfig, options));
+    return patterns.map(id => toProductionEntry(id)).concat(entries, await getDependencies(localConfig, options));
   }
 
-  return production.map(entry => toProductionEntry(entry)).concat(await getDependencies(localConfig, options));
+  return production.map(id => toProductionEntry(id)).concat(entries, await getDependencies(localConfig, options));
 };
 
 const plugin: Plugin = {
@@ -48,6 +51,7 @@ const plugin: Plugin = {
   enablers,
   isEnabled,
   config,
+  entry,
   production,
   resolveConfig,
 };

--- a/packages/knip/test/plugins/expo5.test.ts
+++ b/packages/knip/test/plugins/expo5.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/expo5');
+
+test('Find Babel config in Expo project without direct Babel dependency', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #1931.

Expo supports `babel.config.js` out of the box, so a generated Expo app has a
`babel.config.js` but no `@babel/*` dependency of its own. The Babel plugin is
gated on `enablers = [/^@babel\//]`, so it never enables, and the Expo plugin
didn't claim the file — knip reported `babel.config.js` as an unused file.

This mirrors the Docusaurus plugin, which declares the same `entry` for the same
reason (Docusaurus ships Babel too).

## Changes

- Expo plugin: add `entry = ['babel.config.{js,cjs,mjs,cts}']`, both on the
  plugin export and spread into the two `resolveConfig` return paths.
- Renamed the two `.map(entry => …)` arrow params to `id` so they no longer
  shadow the new `entry` — no behavior change.
- New fixture and test (`expo5`), mirroring the reproduction in the issue.

Both halves are needed. With `entry` only on the plugin export, a project
*without* `app.json` is fixed, but as soon as `app.json` is present
`resolveConfig` runs and its return replaces the defaults, so the file is
reported unused again — and the reproduction in the issue has an `app.json`.

## Testing

- `node --test test/plugins/expo5.test.ts` — fails before the change
  (`files: 1`), passes after
- `node ./src/cli.ts --directory fixtures/plugins/expo5` — reports
  `Unused files (1) babel.config.js` before, clean after
- `pnpm test` — 1069/1069 passing
- `pnpm build`, `pnpm knip`, `pnpm knip:production`, and `pnpm run ci` from the
  root all pass