### PR TITLE
Fix Supported `lint-staged` Configs

### DIFF
--- a/packages/knip/src/plugins/lint-staged/index.ts
+++ b/packages/knip/src/plugins/lint-staged/index.ts
@@ -13,9 +13,9 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 
 const config = [
   'package.{json,yaml,yml}',
-  ".lintstagedrc",
-  ".lintstagedrc.{json,yaml,yml,mjs,mts,js,ts,cjs,cts}",
-  "lint-staged.config.{mjs,mts,js,ts,cjs,cts}",
+  '.lintstagedrc',
+  '.lintstagedrc.{json,yaml,yml,mjs,mts,js,ts,cjs,cts}',
+  'lint-staged.config.{mjs,mts,js,ts,cjs,cts}',
 ];
 
 const resolveEntry = async (value: Entry): Promise<string[]> => {

--- a/packages/knip/src/plugins/lint-staged/index.ts
+++ b/packages/knip/src/plugins/lint-staged/index.ts
@@ -1,7 +1,6 @@
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
 import type { Input } from '../../util/input.ts';
 import { hasDependency } from '../../util/plugin.ts';
-import { toLilconfig } from '../../util/plugin-config.ts';
 import type { Entry, LintStagedConfig } from './types.ts';
 
 // https://github.com/okonet/lint-staged
@@ -13,11 +12,10 @@ const enablers = ['lint-staged'];
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
 const config = [
-  'package.json',
-  'package.yaml',
-  'package.yml',
-  ...toLilconfig('lint-staged'),
-  ...toLilconfig('lintstaged'),
+  'package.{json,yaml,yml}',
+  ".lintstagedrc",
+  ".lintstagedrc.{json,yaml,yml,mjs,mts,js,ts,cjs,cts}",
+  "lint-staged.config.{mjs,mts,js,ts,cjs,cts}",
 ];
 
 const resolveEntry = async (value: Entry): Promise<string[]> => {


### PR DESCRIPTION
`lint-staged` doesn't use `lilconfig` (anymore?), and it's config file support list is different from it.

Derived from https://github.com/lint-staged/lint-staged/blob/main/lib/configFiles.js

Aside: I don't think `lilconfig` supports TS (https://github.com/antonk52/lilconfig/issues/61) - so I'm not sure `toLilconfig` should?