### PR TITLE
fix(lefthook): match all config file names and extensions

### DIFF
--- a/packages/knip/fixtures/plugins/lefthook-yaml/lefthook.yaml
+++ b/packages/knip/fixtures/plugins/lefthook-yaml/lefthook.yaml
@@ -1,0 +1,6 @@
+pre-commit:
+  commands:
+    lint:
+      files: git diff --name-only HEAD @{push}
+      glob: '*.{ts,tsx}'
+      run: npx --no eslint {files}

--- a/packages/knip/fixtures/plugins/lefthook-yaml/node_modules/eslint/package.json
+++ b/packages/knip/fixtures/plugins/lefthook-yaml/node_modules/eslint/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "eslint",
+  "bin": "index.js"
+}

--- a/packages/knip/fixtures/plugins/lefthook-yaml/node_modules/lefthook/package.json
+++ b/packages/knip/fixtures/plugins/lefthook-yaml/node_modules/lefthook/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "lefthook",
+  "bin": "index.js"
+}

--- a/packages/knip/fixtures/plugins/lefthook-yaml/package.json
+++ b/packages/knip/fixtures/plugins/lefthook-yaml/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@plugins/lefthook-yaml",
+  "devDependencies": {
+    "eslint": "*",
+    "lefthook": "*"
+  }
+}

--- a/packages/knip/src/plugins/lefthook/index.ts
+++ b/packages/knip/src/plugins/lefthook/index.ts
@@ -6,12 +6,22 @@ import { extname } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
 
 // https://github.com/evilmartians/lefthook
+// https://lefthook.dev/configuration/#config-file-name
 
 const title = 'Lefthook';
 
 const enablers = ['lefthook', '@arkweid/lefthook', '@evilmartians/lefthook'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+
+const configFiles = [
+  'lefthook.{yml,yaml,json,jsonc,toml}',
+  '.lefthook.{yml,yaml,json,jsonc,toml}',
+  '.config/lefthook.{yml,yaml,json,jsonc,toml}',
+  'lefthook-local.{yml,yaml,json,jsonc,toml}',
+  '.lefthook-local.{yml,yaml,json,jsonc,toml}',
+  '.config/lefthook-local.{yml,yaml,json,jsonc,toml}',
+];
 
 type Command = {
   run: string;
@@ -25,7 +35,7 @@ const resolveConfig: ResolveConfig = async (localConfig, options) => {
 
   const inputs = manifest.devDependencies ? Object.keys(manifest.devDependencies).map(id => toDependency(id)) : [];
 
-  if (extname(configFileName) === '.yml') {
+  if (extname(configFileName) !== '') {
     const scripts = findByKeyDeep<Command>(localConfig, 'run').flatMap(command => {
       const deps = getInputsFromScripts([command.run], { ...options, knownBinsOnly: true });
       const dir = command.root ?? cwd;
@@ -52,7 +62,7 @@ const plugin: Plugin = {
   title,
   enablers,
   isEnabled,
-  config: options => ['lefthook.yml', ...getGitHookPaths('.git/hooks', true, options.cwd)],
+  config: options => [...configFiles, ...getGitHookPaths('.git/hooks', true, options.cwd)],
   resolveConfig,
 };
 

--- a/packages/knip/test/plugins/lefthook-yaml.test.ts
+++ b/packages/knip/test/plugins/lefthook-yaml.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/lefthook-yaml');
+
+test('Find dependencies with the Lefthook plugin (lefthook.yaml)', async () => {
+  const CI = process.env.CI;
+  process.env.CI = '1';
+
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 0,
+    total: 0,
+  });
+
+  process.env.CI = CI;
+});


### PR DESCRIPTION
Fixes #1939

## What

`packages/knip/src/plugins/lefthook/index.ts` registered a single config file
name out of the 30 locations lefthook accepts:

```diff
-  config: options => ['lefthook.yml', ...getGitHookPaths('.git/hooks', true, options.cwd)],
+  config: options => [...configFiles, ...getGitHookPaths('.git/hooks', true, options.cwd)],
```

with `configFiles` covering the official 6 names × 5 extensions:

```ts
const configFiles = [
  'lefthook.{yml,yaml,json,jsonc,toml}',
  '.lefthook.{yml,yaml,json,jsonc,toml}',
  '.config/lefthook.{yml,yaml,json,jsonc,toml}',
  'lefthook-local.{yml,yaml,json,jsonc,toml}',
  '.lefthook-local.{yml,yaml,json,jsonc,toml}',
  '.config/lefthook-local.{yml,yaml,json,jsonc,toml}',
];
```

The `extname(configFileName) === '.yml'` check in `resolveConfig` — which
separates named config files from the extensionless git hook scripts also
listed in `config` — became `extname(configFileName) !== ''` so the other
config extensions take the same branch.

## Why

Lefthook resolves its config against these names and extensions, per the table
in [its configuration docs](https://lefthook.dev/configuration/#config-file-name)
and [`internal/config/loader.go`](https://github.com/evilmartians/lefthook/blob/master/internal/config/loader.go):

```go
LocalConfigNames = []string{"lefthook-local", ".lefthook-local", filepath.Join(".config", "lefthook-local")}
MainConfigNames  = []string{"lefthook", ".lefthook", filepath.Join(".config", "lefthook")}
Extensions       = []string{".yml", ".yaml", ".json", ".jsonc", ".toml"}
```

A project on `lefthook.yaml` (or any other non-`lefthook.yml` location) never
had its config parsed, so dependencies only used in its `run` commands were
reported as unused. Same class of gap as #1935 (lint-staged), #1919
(playwright) and #525 (eslint).

Unlike #1285, this PR only completes the config file list — no `isEnabled`
changes — and includes the `.jsonc` extension lefthook added since. Knip's
loader already handles all five extensions, and the git hook scripts from
`getGitHookPaths` are extensionless, so no loader changes are needed.

## Reproduction

New fixture `fixtures/plugins/lefthook-yaml` — `eslint` and `lefthook` in
`devDependencies`, a `lefthook.yaml` whose `pre-commit` command runs
`npx --no eslint`. Before the change, running knip in that fixture:

```
Unused devDependencies (2)
eslint    package.json:4:6
lefthook  package.json:5:6
```

After the change the same command reports nothing.
`test/plugins/lefthook-yaml.test.ts` asserts this (mirroring
`lefthook-ci.test.ts`); it fails without the fix and passes with it.

## Tests

Ran from `packages/knip`:

- `bun test test/plugins/lefthook-yaml.test.ts test/plugins/lefthook.test.ts test/plugins/lefthook-ci.test.ts test/plugins/lefthook-v1.test.ts` — 4/4 pass
- `pnpm test --runtime bun --smoke` — 951 pass, 0 fail
- `pnpm build` (tsc) — pass
- root `pnpm run ci` (oxlint + oxfmt --check + installed-check) — pass

## Note

Written with AI assistance; I reproduced the false positive locally and
reviewed every change.
