### PR TITLE
fix(binaries): resolve missing pnpm subcommands

### DIFF
--- a/packages/knip/src/binaries/resolvers/pnpm.ts
+++ b/packages/knip/src/binaries/resolvers/pnpm.ts
@@ -19,6 +19,7 @@ const commands = [
   'clean-install',
   'clean',
   'config',
+  'create',
   'dedupe',
   'deploy',
   'dlx',
@@ -32,6 +33,7 @@ const commands = [
   'ic',
   'ignored-builds',
   'import',
+  'info',
   'init',
   'install-clean',
   'install-test',
@@ -43,6 +45,8 @@ const commands = [
   'list',
   'll',
   'ln',
+  'login',
+  'logout',
   'ls',
   'outdated',
   'pack-app',
@@ -74,6 +78,7 @@ const commands = [
   'store',
   't',
   'test',
+  'token',
   'tst',
   'un',
   'uninstall',
@@ -82,9 +87,12 @@ const commands = [
   'update',
   'upgrade',
   'version',
+  'view',
   'why',
   'with',
 ];
+
+const recursiveCommands = ['recursive', 'multi', 'm'];
 
 export const resolve: BinaryResolver = (_binary, words, options) => {
   const parsed = parseArgs(words, {
@@ -97,6 +105,10 @@ export const resolve: BinaryResolver = (_binary, words, options) => {
   if (command === 'dlx') {
     const wordsForDlx = words.filter(word => word.value !== 'dlx');
     return resolveDlx(wordsForDlx, options);
+  }
+
+  if (recursiveCommands.includes(command)) {
+    return resolve(_binary, argsAfter(words, command), options);
   }
 
   const { manifest, fromArgs } = options;

--- a/packages/knip/test/util/get-inputs-from-scripts.test.ts
+++ b/packages/knip/test/util/get-inputs-from-scripts.test.ts
@@ -284,6 +284,15 @@ test('getInputsFromScripts (pnpm)', () => {
   t('pnpm home lodash', []);
   t('pnpm la', []);
   t('pnpm ll', []);
+  t('pnpm info knip', []);
+  t('pnpm view knip version', []);
+  t('pnpm create vite my-app', []);
+  t('pnpm login --registry https://registry.npmjs.org', []);
+  t('pnpm logout', []);
+  t('pnpm token list', []);
+  t('pnpm recursive run program', [], pkgScripts);
+  t('pnpm multi run program', [], pkgScripts);
+  t('pnpm m run program', [], pkgScripts);
 });
 
 test('getInputsFromScripts (pnpx/pnpm dlx)', () => {


### PR DESCRIPTION
- Fixes #1944

Valid pnpm subcommands not on the allowlist in `src/binaries/resolvers/pnpm.ts` fall through and are reported as binaries, so `pnpm info knip version` yields an unlisted `info`.

- Added to `commands`: `create`, `info`, `login`, `logout`, `token`, `view`.
- `recursive` / `multi` / `m` handled as a prefix rather than a list entry.

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
