### PR TITLE
fix(webdriver-io): match all supported config file extensions

### DIFF
--- a/packages/knip/fixtures/plugins/webdriver-io/package.json
+++ b/packages/knip/fixtures/plugins/webdriver-io/package.json
@@ -7,6 +7,11 @@
     "@wdio/cli": "*",
     "@wdio/mocha-framework": "*",
     "@wdio/concise-reporter": "*",
-    "@wdio/browser-runner": "*"
+    "@wdio/browser-runner": "*",
+    "@wdio/spec-reporter": "*",
+    "@wdio/dot-reporter": "*",
+    "@wdio/junit-reporter": "*",
+    "@wdio/allure-reporter": "*",
+    "@wdio/json-reporter": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.cjs
+++ b/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.cjs
@@ -1,0 +1,3 @@
+exports.config = {
+  reporters: ['spec'],
+};

--- a/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.cts
+++ b/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.cts
@@ -1,0 +1,3 @@
+export const config = {
+  reporters: ['allure'],
+};

--- a/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.mjs
+++ b/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.mjs
@@ -1,0 +1,3 @@
+export const config = {
+  reporters: ['dot'],
+};

--- a/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.mts
+++ b/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.mts
@@ -1,0 +1,3 @@
+export const config = {
+  reporters: ['json'],
+};

--- a/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.ts
+++ b/packages/knip/fixtures/plugins/webdriver-io/wdio.conf.ts
@@ -1,0 +1,3 @@
+export const config = {
+  reporters: ['junit'],
+};

--- a/packages/knip/src/plugins/webdriver-io/index.ts
+++ b/packages/knip/src/plugins/webdriver-io/index.ts
@@ -11,7 +11,7 @@ const enablers = ['@wdio/cli'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config = ['wdio.conf.{js,ts}'];
+const config = ['wdio.conf.{js,cjs,mjs,ts,cts,mts}'];
 
 const resolveConfig: ResolveConfig<WebdriverIOConfig> = async config => {
   const cfg = config?.config;

--- a/packages/knip/test/plugins/webdriver-io.test.ts
+++ b/packages/knip/test/plugins/webdriver-io.test.ts
@@ -13,7 +13,7 @@ test('Find dependencies with the webdriver-io plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 1,
-    total: 1,
+    processed: 6,
+    total: 6,
   });
 });


### PR DESCRIPTION
The WebdriverIO plugin matches `wdio.conf.{js,ts}`, but WebdriverIO resolves its config file across six extensions:

```ts
// packages/create-wdio/src/constants.ts
export const SUPPORTED_CONFIG_FILE_EXTENSION = ['js', 'ts', 'mjs', 'mts', 'cjs', 'cts']
```

`canAccessConfigPath` tries each of these against the config path, and `wdio-cli`'s `run` handler loads `tsx` for `.ts`, `.tsx`, `.mts` and `.cts` configs.

So `wdio.conf.{cjs,mjs,cts,mts}` are all valid, but Knip left them unanalyzed — reporting the config file itself as unused and the dependencies it references (framework, runner, reporters) as unused too. `.mts` is the extension [WebdriverIO recommends](https://webdriver.io/docs/typescript/) for ESM + TypeScript setups.

Extending the existing fixture reproduces it before the fix — 4 unused files and 4 unused dependencies, exactly the four unmatched configs and the reporters only they reference.

Each fixture config references a distinct reporter (`spec`, `dot`, `junit`, `allure`, `json`) rather than sharing one, so that a regression in any single extension surfaces as an unused dependency instead of being masked by the other configs.

Same shape as #1919 (playwright), #1933/#1934 (oxfmt/oxlint) and #1938 (tsup).

### Testing

- `node --test test/plugins/webdriver-io.test.ts` — passes (fails as described above without the plugin change)
- `node --test test/plugins/*.test.ts` — 368/368 pass
- `oxlint` and `oxfmt --check` clean