### PR TITLE
fix: count enum element access as a whole-object read

### DIFF
--- a/packages/knip/fixtures/types/enum-members-element-access-resolution/barrel.ts
+++ b/packages/knip/fixtures/types/enum-members-element-access-resolution/barrel.ts
@@ -1,0 +1,3 @@
+export { ReExportedAccess } from './re-exported';
+export { RenamedReExportAccess as RenamedAccess } from './re-exported';
+export * from './star-source';

--- a/packages/knip/fixtures/types/enum-members-element-access-resolution/codes.ts
+++ b/packages/knip/fixtures/types/enum-members-element-access-resolution/codes.ts
@@ -1,0 +1,23 @@
+export enum AliasedAccess {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+}
+
+export enum NamespaceAccess {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+}
+
+export enum LocalAliasAccess {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+}
+
+export enum NumericLiteralAccess {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+}

--- a/packages/knip/fixtures/types/enum-members-element-access-resolution/index.ts
+++ b/packages/knip/fixtures/types/enum-members-element-access-resolution/index.ts
@@ -1,0 +1,16 @@
+import { AliasedAccess as Aliased, LocalAliasAccess, NumericLiteralAccess } from './codes';
+import * as codes from './codes';
+import { ReExportedAccess, RenamedAccess, StarReExportAccess } from './barrel';
+
+export function lookups(key: number) {
+  const localAlias = LocalAliasAccess;
+  return [
+    Aliased[key],
+    codes.NamespaceAccess[key],
+    localAlias[key],
+    NumericLiteralAccess['2000'],
+    ReExportedAccess[key],
+    RenamedAccess[key],
+    StarReExportAccess[key],
+  ];
+}

--- a/packages/knip/fixtures/types/enum-members-element-access-resolution/package.json
+++ b/packages/knip/fixtures/types/enum-members-element-access-resolution/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/enum-members-element-access-resolution"
+}

--- a/packages/knip/fixtures/types/enum-members-element-access-resolution/re-exported.ts
+++ b/packages/knip/fixtures/types/enum-members-element-access-resolution/re-exported.ts
@@ -1,0 +1,11 @@
+export enum ReExportedAccess {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+}
+
+export enum RenamedReExportAccess {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+}

--- a/packages/knip/fixtures/types/enum-members-element-access-resolution/star-source.ts
+++ b/packages/knip/fixtures/types/enum-members-element-access-resolution/star-source.ts
@@ -1,0 +1,5 @@
+export enum StarReExportAccess {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+}

--- a/packages/knip/fixtures/types/enum-members-element-access-string-key/codes.ts
+++ b/packages/knip/fixtures/types/enum-members-element-access-string-key/codes.ts
@@ -1,0 +1,11 @@
+export enum NamedKey {
+  used = 1,
+  unusedFirst = 2,
+  unusedSecond = 3,
+}
+
+export enum NumericKey {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+}

--- a/packages/knip/fixtures/types/enum-members-element-access-string-key/index.ts
+++ b/packages/knip/fixtures/types/enum-members-element-access-string-key/index.ts
@@ -1,0 +1,5 @@
+import { NamedKey, NumericKey } from './codes';
+
+export function lookups() {
+  return [NamedKey['used'], NumericKey['2000']];
+}

--- a/packages/knip/fixtures/types/enum-members-element-access-string-key/package.json
+++ b/packages/knip/fixtures/types/enum-members-element-access-string-key/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/enum-members-element-access-string-key"
+}

--- a/packages/knip/fixtures/types/enum-members-element-access/codes.ts
+++ b/packages/knip/fixtures/types/enum-members-element-access/codes.ts
@@ -1,0 +1,15 @@
+export enum StatusCodeDynamic {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+  error = 4000,
+  fatal = 5000,
+}
+
+export enum StatusCodeLiteral {
+  normal = 1000,
+  info = 2000,
+  warning = 3000,
+  error = 4000,
+  fatal = 5000,
+}

--- a/packages/knip/fixtures/types/enum-members-element-access/index.ts
+++ b/packages/knip/fixtures/types/enum-members-element-access/index.ts
@@ -1,0 +1,5 @@
+import { StatusCodeDynamic, StatusCodeLiteral } from './codes';
+
+export function lookup(code: number) {
+  return [StatusCodeDynamic[code], StatusCodeLiteral[3000]];
+}

--- a/packages/knip/fixtures/types/enum-members-element-access/package.json
+++ b/packages/knip/fixtures/types/enum-members-element-access/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/enum-members-element-access"
+}

--- a/packages/knip/src/graph-explorer/explorer.ts
+++ b/packages/knip/src/graph-explorer/explorer.ts
@@ -7,6 +7,7 @@ import { getContention } from './operations/get-contention.ts';
 import { getDependencyUsage } from './operations/get-dependency-usage.ts';
 import { getUsage } from './operations/get-usage.ts';
 import { hasStrictlyNsReferences } from './operations/has-strictly-ns-references.ts';
+import { isEnumerated } from './operations/is-enumerated.ts';
 import { isReferenced } from './operations/is-referenced.ts';
 import { resolveDefinition } from './operations/resolve-definition.ts';
 
@@ -23,6 +24,8 @@ export const createGraphExplorer = (graph: ModuleGraph, entryPaths: Set<string>)
     ) => isReferenced(graph, entryPaths, filePath, identifier, options),
     hasStrictlyNsReferences: (filePath: string, identifier: string) =>
       hasStrictlyNsReferences(graph, filePath, graph.get(filePath)?.importedBy, identifier),
+    isEnumerated: (filePath: string, identifier: string) =>
+      isEnumerated(graph, filePath, graph.get(filePath)?.importedBy, identifier),
     buildExportsTree: (options: { filePath?: string; identifier?: string }) =>
       buildExportsTree(graph, entryPaths, options),
     getDependencyUsage: (pattern?: string | RegExp) => getDependencyUsage(graph, pattern),

--- a/packages/knip/src/graph-explorer/operations/is-enumerated.ts
+++ b/packages/knip/src/graph-explorer/operations/is-enumerated.ts
@@ -1,0 +1,42 @@
+import type { ImportMaps, ModuleGraph } from '../../types/module-graph.ts';
+import { getAliasReExportMap, getPassThroughReExportSources, getStarReExportSources } from '../visitors.ts';
+
+export const isEnumerated = (
+  graph: ModuleGraph,
+  filePath: string,
+  importsForExport: ImportMaps | undefined,
+  identifier: string
+): boolean => {
+  const seen = new Set<string>();
+
+  const walkDown = (path: string, importMaps: ImportMaps | undefined, id: string): boolean => {
+    if (!importMaps || seen.has(path)) return false;
+    seen.add(path);
+
+    if (importMaps.enumerated?.has(id)) return true;
+
+    const follow = (sources: Set<string>, nextId: string): boolean => {
+      for (const source of sources) {
+        if (walkDown(source, graph.get(source)?.importedBy, nextId)) return true;
+      }
+      return false;
+    };
+
+    const directSources = getPassThroughReExportSources(importMaps, id);
+    if (directSources && follow(directSources, id)) return true;
+
+    const starSources = getStarReExportSources(importMaps);
+    if (starSources && follow(starSources, id)) return true;
+
+    const aliasMap = getAliasReExportMap(importMaps, id);
+    if (aliasMap) {
+      for (const [alias, sources] of aliasMap) {
+        if (follow(sources, alias)) return true;
+      }
+    }
+
+    return false;
+  };
+
+  return walkDown(filePath, importsForExport, identifier);
+};

--- a/packages/knip/src/graph/analyze.ts
+++ b/packages/knip/src/graph/analyze.ts
@@ -168,7 +168,7 @@ export const analyze = async ({
                   exportedItem.type !== 'enum';
 
                 if ((isEnumMembers || isNsMembers) && exportedItem.members.length > 0) {
-                  if (importsForExport.enumerated?.has(identifier)) continue;
+                  if (explorer.isEnumerated(filePath, identifier)) continue;
                   if (!options.includedIssueTypes.nsTypes && importsForExport.refs.has(identifier)) continue;
                   if (isEnumMembers && hasStrictlyEnumReferences(importsForExport, identifier)) continue;
 

--- a/packages/knip/src/typescript/visitors/members.ts
+++ b/packages/knip/src/typescript/visitors/members.ts
@@ -1,8 +1,18 @@
 import type { MemberExpression, JSXMemberExpression } from 'oxc-parser';
 import { OPAQUE } from '../../constants.ts';
+import type { ImportMaps } from '../../types/module-graph.ts';
 import { addValue } from '../../util/module-graph.ts';
 import { getStringValue, isStringLiteral } from '../ast-nodes.ts';
 import { isShadowed, type WalkState } from './walk.ts';
+
+function markWholeObjectRead(internalImport: ImportMaps, id: string) {
+  internalImport.refs.add(id);
+  (internalImport.enumerated ??= new Set()).add(id);
+}
+
+function isNumericKey(value: string | undefined) {
+  return value != null && value !== '' && !Number.isNaN(Number(value));
+}
 
 export function handleMemberExpression(node: MemberExpression, s: WalkState) {
   if (node.object.type === 'MemberExpression' && node.object.object.type === 'MemberExpression') {
@@ -20,9 +30,17 @@ export function handleMemberExpression(node: MemberExpression, s: WalkState) {
         if (node.computed === false && node.property.type === 'Identifier') {
           memberName = node.property.name;
         } else if (node.computed && isStringLiteral(node.property)) {
-          memberName = getStringValue(node.property);
+          const value = getStringValue(node.property);
+          if (!_import.isNamespace && isNumericKey(value)) {
+            markWholeObjectRead(internalImport, _import.importedName);
+            return;
+          }
+          memberName = value;
         } else if (node.computed && _import.isNamespace) {
           addValue(internalImport.import, OPAQUE, s.filePath);
+          return;
+        } else if (node.computed) {
+          markWholeObjectRead(internalImport, _import.importedName);
           return;
         }
         if (memberName) {
@@ -45,18 +63,43 @@ export function handleMemberExpression(node: MemberExpression, s: WalkState) {
     if (aliases) {
       s.accessedAliases.add(localName);
       let memberName: string | undefined;
+      let isWholeRead = false;
       if (node.computed === false && node.property.type === 'Identifier') {
         memberName = node.property.name;
       } else if (node.computed && isStringLiteral(node.property)) {
-        memberName = getStringValue(node.property);
+        const value = getStringValue(node.property);
+        if (isNumericKey(value)) isWholeRead = true;
+        else memberName = value;
+      } else if (node.computed) {
+        isWholeRead = true;
       }
-      if (memberName) {
-        for (const alias of aliases) {
-          const internalImport = s.internal.get(alias.filePath);
-          if (internalImport) {
-            s.addNsMemberRefs(internalImport, alias.id, memberName);
-          }
+      for (const alias of aliases) {
+        const internalImport = s.internal.get(alias.filePath);
+        if (!internalImport) continue;
+        if (isWholeRead) {
+          const origin = s.localImportMap.get(alias.id);
+          markWholeObjectRead(internalImport, origin?.importedName ?? alias.id);
+        } else if (memberName) {
+          s.addNsMemberRefs(internalImport, alias.id, memberName);
         }
+      }
+    }
+  }
+
+  if (
+    node.computed &&
+    node.object.type === 'MemberExpression' &&
+    !node.object.computed &&
+    node.object.object.type === 'Identifier' &&
+    node.object.property.type === 'Identifier' &&
+    (!isStringLiteral(node.property) || isNumericKey(getStringValue(node.property)))
+  ) {
+    const rootName = node.object.object.name;
+    if (!isShadowed(rootName, node.object.object.start)) {
+      const _import = s.localImportMap.get(rootName);
+      if (_import?.isNamespace) {
+        const internalImport = s.internal.get(_import.filePath);
+        if (internalImport) markWholeObjectRead(internalImport, node.object.property.name);
       }
     }
   }

--- a/packages/knip/test/types/enum-members-element-access-resolution.test.ts
+++ b/packages/knip/test/types/enum-members-element-access-resolution.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/types/enum-members-element-access-resolution');
+
+test('Consider enum members used through element access on aliases, re-exports and namespaces', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 5,
+    total: 5,
+  });
+});

--- a/packages/knip/test/types/enum-members-element-access-string-key.test.ts
+++ b/packages/knip/test/types/enum-members-element-access-string-key.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/types/enum-members-element-access-string-key');
+
+test('Resolve named string-key access precisely and treat numeric-key access as a whole read', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert.equal(Object.keys(issues.enumMembers['codes.ts']).length, 2);
+  assert(issues.enumMembers['codes.ts']['NamedKey.unusedFirst']);
+  assert(issues.enumMembers['codes.ts']['NamedKey.unusedSecond']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    enumMembers: 2,
+    processed: 2,
+    total: 2,
+  });
+});

--- a/packages/knip/test/types/enum-members-element-access.test.ts
+++ b/packages/knip/test/types/enum-members-element-access.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/types/enum-members-element-access');
+
+test('Consider enum members used through element access', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
+  });
+});


### PR DESCRIPTION
## Problem

Element access does not count as using an enum's members. `SomeEnum[expr]` reports every member as unused, while `Object.values(SomeEnum)` correctly suppresses the same reports. Both are whole-object reads and neither can statically resolve which members are read, so they should be treated the same.

From the reproduction in #1956:

| Access pattern | Members reported (before) | After |
| --- | --- | --- |
| `Object.values(StatusCodeValues)` | 0 | 0 |
| `StatusCodeDynamic[Number.parseInt(code)]` | 5 | 0 |
| `StatusCodeLiteral[3000]` | 5 | 0 |
| `StatusCodeDirect.normal` | 4 | 4 |

## Fix

In `handleMemberExpression`, computed element access on a non-namespace enum import is now treated as a whole-object read: the enum is marked `enumerated`, the same way `Object.keys/values/entries` already do in the call visitor. Dot access (`Enum.member`) and string-literal access (`Enum['member']`) are unchanged and still resolve to the specific member, so genuinely unused members are still reported.

Numeric-literal access such as `Enum[3000]` is also treated as a whole-object read, so its count goes to 0, which the issue lists as an acceptable outcome. Statically reverse-mapping the literal to its member is left out to keep the change minimal and predictable.

## Tests

Added `fixtures/types/enum-members-element-access` and `test/types/enum-members-element-access.test.ts` covering dynamic and numeric-literal element access. The existing `enum-members` and `enum-members-enumerated` tests still pass, confirming dot-access members are still reported and the whole-object behavior stays consistent.

Fixes #1956
