### PR TITLE
Expose `defineConfig` on a `./config` entrypoint

### DIFF
--- a/packages/docs/src/content/docs/reference/dynamic-configuration.mdx
+++ b/packages/docs/src/content/docs/reference/dynamic-configuration.mdx
@@ -71,3 +71,29 @@ as well:
     ```
   </TabItem>
 </Tabs>
+
+## defineConfig
+
+Knip also exports a `defineConfig` helper. It returns the configuration
+unchanged, so its only purpose is to type what you pass in:
+
+```ts title="knip.ts"
+import { defineConfig } from 'knip/config';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  project: ['src/**/*.ts'],
+});
+```
+
+The same works in a JavaScript configuration file, without the JSDoc annotation.
+A function is accepted as well:
+
+```ts title="knip.ts"
+import { defineConfig } from 'knip/config';
+
+export default defineConfig(async () => ({
+  entry: ['src/index.ts', ...(await fetchRepoInfo())],
+  project: ['src/**/*.ts'],
+}));
+```

--- a/packages/knip/package.json
+++ b/packages/knip/package.json
@@ -71,6 +71,10 @@
       "types": "./dist/types.d.ts",
       "default": "./dist/index.js"
     },
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "default": "./dist/config.js"
+    },
     "./session": {
       "types": "./dist/session/index.d.ts",
       "default": "./dist/session/index.js"

--- a/packages/knip/src/config.ts
+++ b/packages/knip/src/config.ts
@@ -1,0 +1,3 @@
+import type { KnipConfig } from './types.ts';
+
+export const defineConfig = (config: KnipConfig) => config;


### PR DESCRIPTION
Closes #1941

Adds a `defineConfig` helper on a separate `./config` entrypoint, following @iiroj's suggestion in the issue.

A separate entrypoint keeps the helper and its type resolving through one specifier, so the existing `.` map stays as it is and nothing new gets pulled in from the index file when a config is loaded. `./session` was already the precedent for a second entrypoint, so the shape matches that.

The helper returns its argument unchanged, so it is types only at runtime. `KnipConfig` is `RawConfiguration | ((options: ParsedCLIArgs) => RawConfiguration | Promise<RawConfiguration>)`, so both the object form and the sync and async function forms already documented on the Dynamic Configuration page go through it without a second overload.

```ts
// knip.ts
import { defineConfig } from 'knip/config';

export default defineConfig({
  entry: ['src/index.ts'],
  project: ['src/**/*.ts'],
});
```

Checked before opening:

- `pnpm knip` and `pnpm knip:production --strict` both run clean on this repo, so the new export is picked up as an entry through the exports map rather than reported as unused
- 1069 tests pass
- typechecked a real consumer resolving `knip/config` under `moduleResolution: nodenext`. Object form and async function form both pass, `entry: 42` fails with the underlying `string | string[] | undefined`, so the type is coming through the emitted declaration and not being widened
- `npm pack` includes `dist/config.js` and `dist/config.d.ts`
- `pnpm run ci` clean

Docs section added to Dynamic Configuration. Happy to drop the docs or the whole thing if you would rather keep the config typed with `satisfies KnipConfig`.
