### PR TITLE
Don't report a tag as unused when it suppresses member issues (resolve #1957)

### DIFF
--- a/packages/knip/fixtures/tags-hints/tag-suppresses-enum-members/index.ts
+++ b/packages/knip/fixtures/tags-hints/tag-suppresses-enum-members/index.ts
@@ -1,0 +1,3 @@
+import { labelFor } from './utils';
+
+console.log(labelFor('3000'));

--- a/packages/knip/fixtures/tags-hints/tag-suppresses-enum-members/package.json
+++ b/packages/knip/fixtures/tags-hints/tag-suppresses-enum-members/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/tag-suppresses-enum-members"
+}

--- a/packages/knip/fixtures/tags-hints/tag-suppresses-enum-members/status.ts
+++ b/packages/knip/fixtures/tags-hints/tag-suppresses-enum-members/status.ts
@@ -1,0 +1,12 @@
+/**
+ * Members are looked up by reverse numeric index, so they have no static references.
+ *
+ * @knipignore
+ */
+export enum StatusCode {
+  normal = 1000,
+  unknown = 2000,
+  warning = 3000,
+  critical = 4000,
+  nostatus = 5000,
+}

--- a/packages/knip/fixtures/tags-hints/tag-suppresses-enum-members/utils.ts
+++ b/packages/knip/fixtures/tags-hints/tag-suppresses-enum-members/utils.ts
@@ -1,0 +1,5 @@
+import { StatusCode } from './status';
+
+export function labelFor(code: string): string {
+  return StatusCode[Number.parseInt(code)] ?? 'unrecognized';
+}

--- a/packages/knip/src/graph/analyze.ts
+++ b/packages/knip/src/graph/analyze.ts
@@ -135,8 +135,18 @@ export const analyze = async ({
                 traverseEntries: isIncludeEntryExports,
               });
 
+              // On an export with members the tag also gates the member analysis below, which the
+              // `continue` on `isIgnored` skips. A referenced export is then not on its own
+              // evidence that the tag is unused, since removing it can surface member issues.
+              const gatesMemberAnalysis =
+                exportedItem.members.length > 0 &&
+                (exportedItem.type === 'enum'
+                  ? options.includedIssueTypes.enumMembers
+                  : options.includedIssueTypes.namespaceMembers);
+
               if (
                 isIgnored &&
+                !gatesMemberAnalysis &&
                 (isReferenced ||
                   isReferencedInUsedExport(exportedItem, filePath, isIncludeEntryExports, ignoreExportsUsedInFile))
               ) {

--- a/packages/knip/test/tags-hints/tag-suppresses-enum-members.test.ts
+++ b/packages/knip/test/tags-hints/tag-suppresses-enum-members.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/tags-hints/tag-suppresses-enum-members');
+
+test('Do not flag a tag that suppresses enum member issues', async () => {
+  const options = await createOptions({ cwd, tags: ['-knipignore'] });
+  const { issues, tagHints, counters } = await main(options);
+
+  assert.equal(tagHints.size, 0);
+  assert.equal(Object.keys(issues.enumMembers).length, 0);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 3,
+    total: 3,
+  });
+});
+
+test('The same enum members are reported when the tag is not excluded', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.enumMembers['status.ts']['StatusCode.normal']);
+  assert(issues.enumMembers['status.ts']['StatusCode.unknown']);
+  assert(issues.enumMembers['status.ts']['StatusCode.warning']);
+  assert(issues.enumMembers['status.ts']['StatusCode.critical']);
+  assert(issues.enumMembers['status.ts']['StatusCode.nostatus']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    enumMembers: 5,
+    processed: 3,
+    total: 3,
+  });
+});


### PR DESCRIPTION
Resolves #1957.

A tag that excludes an export also skips the enum/namespace member analysis, since that block sits behind the `continue` on `isIgnored`. The hint only checked whether the export itself was referenced, so `@knipignore` on a referenced enum was reported as unused while it was still suppressing five member issues. Removing the tag brought those five back, so neither keeping nor removing it gave a clean run.

This skips the hint when the export has members the tag gates.

Added `fixtures/tags-hints/tag-suppresses-enum-members` with a test for both sides: no hint when the tag is excluded, and the same five members reported when it isn't. The second one fails without the source change.

One thing worth your call: the guard is deliberately blunt, so a tag on an export whose members are all referenced no longer gets a hint either. Narrowing that needs the member walk to run before the hint is decided — happy to do it that way if you prefer.
