### PR TITLE
Change GitHub stars badge style to flat

### DIFF
--- a/packages/knip/README.md
+++ b/packages/knip/README.md
@@ -51,7 +51,7 @@ following projects:
 [3]: https://img.shields.io/npm/dm/knip?color=f56e0f
 [4]: https://github.com/webpro-nl/knip
 [5]:
-  https://img.shields.io/github/stars/webpro-nl/knip?style=flat-square&color=f56e0f
+  https://img.shields.io/github/stars/webpro-nl/knip?style=flat&color=f56e0f
 [6]: https://knip.dev
 [7]: https://www.npmx.dev/package/@knip/create-config
 [8]: https://www.npmx.dev/package/@knip/language-server


### PR DESCRIPTION
Updated GitHub stars badge style in README because for some reason, 2 are flat and one is flat-square.

<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
