### PR TITLE
fix: add bun 1.4 dedupe subcommand

### DIFF
--- a/packages/knip/src/binaries/resolvers/bun.ts
+++ b/packages/knip/src/binaries/resolvers/bun.ts
@@ -17,6 +17,7 @@ const commands = new Set([
   'completions',
   'config',
   'create',
+  'dedupe',
   'deploy',
   'discord',
   'exec',

--- a/packages/knip/test/util/get-inputs-from-scripts.test.ts
+++ b/packages/knip/test/util/get-inputs-from-scripts.test.ts
@@ -187,6 +187,7 @@ test('getInputsFromScripts (bun)', () => {
   t('bun run --cwd packages/knip watch', [toBinary('bun'), toBinary('watch', { optional: true, dir: join(cwd, 'packages/knip') })]);
   t('bun test', [toBinary('bun')]);
   t('bun add zod', [toBinary('bun')]);
+  t('bun dedupe', [toBinary('bun')]);
   t('bun install', [toBinary('bun')]);
   t('bun remove webpack', [toBinary('bun')]);
   t('bun update lodash', [toBinary('bun')]);


### PR DESCRIPTION
Bun 1.4 introduced `bun dedupe`, which Knip incorrectly reported as an unlisted binary. Other subcommands, including `bun prune`, were already supported; reproduction: [NimmLor/knip-bun-dedupe-bug](https://github.com/NimmLor/knip-bun-dedupe-bug).

- **Resolver:** Recognize `dedupe` as a Bun command.
- **Coverage:** Add `bun dedupe` input-resolution coverage.
- **Reference:** [Bun 1.4 release notes](https://bun.sh/blog/bun-v1.4#bun-dedupe)

```sh
bun dedupe
```
