### PR TITLE
fix: resolve pnpm catalogs above project root

### DIFF
--- a/packages/knip/fixtures/dependencies/catalog-subdirectory/package.json
+++ b/packages/knip/fixtures/dependencies/catalog-subdirectory/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixtures/catalog-subdirectory",
+  "private": true
+}

--- a/packages/knip/fixtures/dependencies/catalog-subdirectory/pkg/index.ts
+++ b/packages/knip/fixtures/dependencies/catalog-subdirectory/pkg/index.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const schema = z.string();

--- a/packages/knip/fixtures/dependencies/catalog-subdirectory/pkg/package.json
+++ b/packages/knip/fixtures/dependencies/catalog-subdirectory/pkg/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/catalog-subdirectory__pkg",
+  "dependencies": {
+    "zod": "catalog:"
+  }
+}

--- a/packages/knip/fixtures/dependencies/catalog-subdirectory/pnpm-workspace.yaml
+++ b/packages/knip/fixtures/dependencies/catalog-subdirectory/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - 'pkg'
+
+catalog:
+  lodash: 4.17.23
+  zod: 4.4.3

--- a/packages/knip/src/CatalogCounselor.ts
+++ b/packages/knip/src/CatalogCounselor.ts
@@ -7,13 +7,14 @@ import type { Issue } from './types/issues.ts';
 import type { Catalog, Catalogs, WorkspacePackage } from './types/package-json.ts';
 import { type CatalogReference, extractCatalogReferences, parseCatalog } from './util/catalog.ts';
 import type { MainOptions } from './util/create-options.ts';
-import { extname } from './util/path.ts';
+import { dirname, extname, isSameDir } from './util/path.ts';
 import { YamlCatalogPeeker } from './YamlCatalogPeeker.ts';
 
 export type CatalogContainer = { filePath: string; catalog?: Catalog; catalogs?: Catalogs };
 
 export class CatalogCounselor {
   private filePath: string;
+  private isExternal: boolean;
   private entries = new Set<string>();
   private referencedEntries = new Set<string>();
   private referenceIssues: Issue[] = [];
@@ -21,6 +22,7 @@ export class CatalogCounselor {
 
   constructor(options: MainOptions) {
     this.filePath = options.catalog.filePath;
+    this.isExternal = !isSameDir(dirname(this.filePath), options.cwd);
     this.entries = parseCatalog(options.catalog);
   }
 
@@ -65,7 +67,7 @@ export class CatalogCounselor {
     const workspace = ROOT_WORKSPACE_NAME;
     const catalogIssues: Issue[] = [];
 
-    if (this.entries.size > 0) {
+    if (!this.isExternal && this.entries.size > 0) {
       this.fileContent = await readFile(filePath, 'utf-8');
       const isYaml = ['.yml', '.yaml'].includes(extname(filePath));
       const Peeker = isYaml ? YamlCatalogPeeker : JsonCatalogPeeker;

--- a/packages/knip/src/util/catalog.ts
+++ b/packages/knip/src/util/catalog.ts
@@ -1,9 +1,9 @@
 import type { CatalogContainer } from '../CatalogCounselor.ts';
 import type { PackageJson } from '../types/package-json.ts';
-import { isFile } from './fs.ts';
+import { findFileUp, isFile } from './fs.ts';
 import { _load } from './loader.ts';
 import { getPackageNameFromModuleSpecifier } from './modules.ts';
-import { basename, join } from './path.ts';
+import { basename, dirname, isSameDir, join } from './path.ts';
 
 export const DEFAULT_CATALOG = 'default';
 
@@ -34,18 +34,39 @@ export const getCatalogContainer = async (
   pnpmWorkspacePath?: string,
   pnpmWorkspace?: any
 ): Promise<CatalogContainer> => {
-  const filePath = pnpmWorkspacePath ?? (isFile(cwd, '.yarnrc.yml') ? join(cwd, '.yarnrc.yml') : manifestPath);
+  const localPnpmWorkspacePath =
+    pnpmWorkspacePath && isSameDir(dirname(pnpmWorkspacePath), cwd) ? pnpmWorkspacePath : undefined;
+  const yarnWorkspacePath = isFile(cwd, '.yarnrc.yml') ? join(cwd, '.yarnrc.yml') : undefined;
+  const manifestWorkspaces = !Array.isArray(manifest.workspaces) ? manifest.workspaces : undefined;
+  const hasManifestCatalog =
+    manifest.catalog !== undefined ||
+    manifest.catalogs !== undefined ||
+    manifestWorkspaces?.catalog !== undefined ||
+    manifestWorkspaces?.catalogs !== undefined;
+  const pnpmCatalogPath =
+    localPnpmWorkspacePath ??
+    (!yarnWorkspacePath && !hasManifestCatalog ? findFileUp(dirname(cwd), 'pnpm-workspace.yaml') : undefined);
+  const filePath =
+    localPnpmWorkspacePath ??
+    yarnWorkspacePath ??
+    (hasManifestCatalog ? manifestPath : (pnpmCatalogPath ?? manifestPath));
+  const activePnpmWorkspace =
+    filePath === pnpmWorkspacePath
+      ? pnpmWorkspace
+      : basename(filePath) === 'pnpm-workspace.yaml'
+        ? await _load(filePath)
+        : undefined;
 
   const yarnWorkspace = basename(filePath) === '.yarnrc.yml' ? await _load(filePath) : undefined;
 
   const catalog =
-    pnpmWorkspace?.catalog ??
+    activePnpmWorkspace?.catalog ??
     yarnWorkspace?.catalog ??
     manifest.catalog ??
     ((!Array.isArray(manifest.workspaces) && manifest.workspaces?.catalog) || {});
 
   const catalogs =
-    pnpmWorkspace?.catalogs ??
+    activePnpmWorkspace?.catalogs ??
     yarnWorkspace?.catalogs ??
     manifest.catalogs ??
     ((!Array.isArray(manifest.workspaces) && manifest.workspaces?.catalogs) || {});

--- a/packages/knip/src/util/fs.ts
+++ b/packages/knip/src/util/fs.ts
@@ -4,7 +4,7 @@ import { parse as parseYAMLContents } from 'yaml';
 import { parse as parseTOML } from 'smol-toml';
 import stripJsonComments from 'strip-json-comments';
 import { LoaderError } from './errors.ts';
-import { extname, join, toPosix } from './path.ts';
+import { dirname, extname, join, toPosix } from './path.ts';
 
 export const isDirectory = (cwdOrPath: string, name?: string) => {
   try {
@@ -25,6 +25,17 @@ export const isFile = (cwdOrPath: string, name?: string) => {
 export const findFile = (cwd: string, fileName: string) => {
   const filePath = join(cwd, fileName);
   return isFile(filePath) ? filePath : undefined;
+};
+
+export const findFileUp = (cwd: string, fileName: string) => {
+  let dir = cwd;
+  while (true) {
+    const filePath = findFile(dir, fileName);
+    if (filePath) return filePath;
+    const parent = dirname(dir);
+    if (parent === dir || parent === '.' || /^\/\/[^/]+\/[^/]+\/?$/.test(dir)) return;
+    dir = parent;
+  }
 };
 
 export const findFileWithExtensions = (basePath: string, extensions: string[]): string | undefined => {

--- a/packages/knip/src/util/path.ts
+++ b/packages/knip/src/util/path.ts
@@ -36,3 +36,5 @@ export const toRelative = (id: string, base: string) => (isAbsolute(id) ? relati
 export const isInternal = (id: string) => (id.startsWith('.') || isAbsolute(id)) && !isInNodeModules(id);
 
 export const normalize = path.posix.normalize;
+
+export const isSameDir = (left: string, right: string) => normalize(`${left}/`) === normalize(`${right}/`);

--- a/packages/knip/test/dependencies/catalog.subdirectory.test.ts
+++ b/packages/knip/test/dependencies/catalog.subdirectory.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { main } from '../../src/index.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+test('Should resolve catalog references from a workspace subdirectory', async () => {
+  const cwd = resolve('fixtures/dependencies/catalog-subdirectory/pkg');
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert.deepEqual(issues.catalog, {});
+  assert.deepEqual(issues.catalogReferences, {});
+  assert.equal(counters.catalog, 0);
+  assert.equal(counters.catalogReferences, 0);
+});

--- a/packages/knip/test/util/catalog.test.ts
+++ b/packages/knip/test/util/catalog.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getCatalogContainer } from '../../src/util/catalog.ts';
+
+test('Should load a pnpm catalog from a Windows drive root', async () => {
+  const catalog = { zod: '4.4.3' };
+  const container = await getCatalogContainer('Z:/', {}, 'Z:/package.json', 'Z:/pnpm-workspace.yaml', { catalog });
+
+  assert.equal(container.filePath, 'Z:/pnpm-workspace.yaml');
+  assert.equal(container.catalog, catalog);
+});

--- a/packages/knip/test/util/fs.test.ts
+++ b/packages/knip/test/util/fs.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { findFileUp } from '../../src/util/fs.ts';
+
+test('findFileUp should not traverse past a Windows drive root', () => {
+  assert.equal(findFileUp('Z:/__knip_missing__/pkg', 'package.json'), undefined);
+});
+
+test('findFileUp should not traverse past a UNC share root', () => {
+  assert.equal(findFileUp('//__knip_server__/__knip_share__/pkg', 'etc/hosts'), undefined);
+});


### PR DESCRIPTION
Fixes #1963.

When Knip runs from a package directory, it now uses the nearest parent `pnpm-workspace.yaml` as the catalog source without treating that file as the current project's workspace definition. Local pnpm, Yarn, and `package.json` catalog sources continue to take precedence. Parent catalog entries validate references, while unused entries outside the current project are not reported.

Regression coverage includes the child-directory invocation, an unrelated unused parent entry, local source precedence, Windows drive roots, and UNC share roots.

Validation:

- `node --test test/dependencies/catalog.*.test.ts test/util/catalog.test.ts test/util/fs.test.ts` (13 passed)
- `pnpm build`
- `pnpm run ci`
- direct CLI checks for cwd, `--directory`, and `--workspace` variants