### PR TITLE
Resolve oxlint jsPlugins from .oxlintrc.jsonc

### DIFF
--- a/packages/knip/fixtures/plugins/oxlint/.oxlintrc.jsonc
+++ b/packages/knip/fixtures/plugins/oxlint/.oxlintrc.jsonc
@@ -1,0 +1,4 @@
+{
+  // Comments are valid in JSONC only
+  "jsPlugins": ["./oxlint-plugin-orchard.mjs"]
+}

--- a/packages/knip/fixtures/plugins/oxlint/oxlint-plugin-orchard.mjs
+++ b/packages/knip/fixtures/plugins/oxlint/oxlint-plugin-orchard.mjs
@@ -1,0 +1,1 @@
+export default { meta: { name: 'orchard' }, rules: {} };

--- a/packages/knip/src/plugins/oxlint/index.ts
+++ b/packages/knip/src/plugins/oxlint/index.ts
@@ -14,7 +14,7 @@ const enablers = ['oxlint', 'vite-plus'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config: string[] = ['.oxlintrc.json', 'oxlint.config.{ts,mts}', 'vite.config.{js,mjs,ts,cjs,mts,cts}'];
+const config: string[] = ['.oxlintrc.{json,jsonc}', 'oxlint.config.{ts,mts}', 'vite.config.{js,mjs,ts,cjs,mts,cts}'];
 
 const isViteConfig = (configFileName: string) => configFileName.startsWith('vite.config.');
 

--- a/packages/knip/test/plugins/oxlint.test.ts
+++ b/packages/knip/test/plugins/oxlint.test.ts
@@ -13,7 +13,7 @@ test('Find dependencies with the oxlint plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 1,
-    total: 1,
+    processed: 2,
+    total: 2,
   });
 });


### PR DESCRIPTION
Oxlint discovers both `.oxlintrc.json` and `.oxlintrc.jsonc`, but the plugin only globbed the former. A project using the JSONC variant had its config file skipped entirely, so every `jsPlugins` dependency was reported unused.