### PR TITLE
fix(cli): validate numeric options instead of passing NaN through

### DIFF
--- a/packages/knip/src/cli.ts
+++ b/packages/knip/src/cli.ts
@@ -2,7 +2,7 @@
 import { fix } from './IssueFixer.ts';
 import { run } from './run.ts';
 import type { IssueType, ReporterOptions } from './types/issues.ts';
-import parseArgs, { helpText } from './util/cli-arguments.ts';
+import parseArgs, { helpText, parseNumericOption } from './util/cli-arguments.ts';
 import { createOptions } from './util/create-options.ts';
 import {
   getKnownErrors,
@@ -75,7 +75,7 @@ const main = async () => {
       isShowProgress: options.isShowProgress,
       isTreatConfigHintsAsErrors: options.isTreatConfigHintsAsErrors,
       isTreatTagHintsAsErrors: options.isTreatTagHintsAsErrors,
-      maxShowIssues: args['max-show-issues'] ? Number(args['max-show-issues']) : undefined,
+      maxShowIssues: parseNumericOption(args['max-show-issues'], 'max-show-issues'),
       options: args['reporter-options'] ?? '',
       preprocessorOptions: args['preprocessor-options'] ?? '',
       selectedWorkspaces,
@@ -104,7 +104,7 @@ const main = async () => {
 
     if (
       !args['no-exit-code'] &&
-      (totalErrorCount > Number(args['max-issues'] ?? 0) ||
+      (totalErrorCount > (parseNumericOption(args['max-issues'], 'max-issues') ?? 0) ||
         (!options.isDisableConfigHints && options.isTreatConfigHintsAsErrors && configurationHints.length > 0) ||
         (!options.isDisableTagHints && options.isTreatTagHintsAsErrors && tagHints.size > 0))
     ) {

--- a/packages/knip/src/cli.ts
+++ b/packages/knip/src/cli.ts
@@ -2,7 +2,7 @@
 import { fix } from './IssueFixer.ts';
 import { run } from './run.ts';
 import type { IssueType, ReporterOptions } from './types/issues.ts';
-import parseArgs, { helpText, parseNumericOption } from './util/cli-arguments.ts';
+import parseArgs, { helpText } from './util/cli-arguments.ts';
 import { createOptions } from './util/create-options.ts';
 import {
   getKnownErrors,
@@ -75,7 +75,7 @@ const main = async () => {
       isShowProgress: options.isShowProgress,
       isTreatConfigHintsAsErrors: options.isTreatConfigHintsAsErrors,
       isTreatTagHintsAsErrors: options.isTreatTagHintsAsErrors,
-      maxShowIssues: parseNumericOption(args['max-show-issues'], 'max-show-issues'),
+      maxShowIssues: options.maxShowIssues,
       options: args['reporter-options'] ?? '',
       preprocessorOptions: args['preprocessor-options'] ?? '',
       selectedWorkspaces,
@@ -104,7 +104,7 @@ const main = async () => {
 
     if (
       !args['no-exit-code'] &&
-      (totalErrorCount > (parseNumericOption(args['max-issues'], 'max-issues') ?? 0) ||
+      (totalErrorCount > options.maxIssues ||
         (!options.isDisableConfigHints && options.isTreatConfigHintsAsErrors && configurationHints.length > 0) ||
         (!options.isDisableTagHints && options.isTreatTagHintsAsErrors && tagHints.size > 0))
     ) {

--- a/packages/knip/src/util/cli-arguments.ts
+++ b/packages/knip/src/util/cli-arguments.ts
@@ -86,11 +86,10 @@ export type ParsedCLIArgs = ReturnType<typeof parseCLIArgs>;
 
 export const parseNumericOption = (value: string | undefined, option: string) => {
   if (value === undefined) return undefined;
-  const parsed = Number(value);
-  if (value === '' || !Number.isInteger(parsed) || parsed < 0) {
+  if (!/^\d+$/.test(value)) {
     throw new ConfigurationError(`Option --${option} expects a non-negative integer, got: ${value}`);
   }
-  return parsed;
+  return Number(value);
 };
 
 export default function parseCLIArgs() {

--- a/packages/knip/src/util/cli-arguments.ts
+++ b/packages/knip/src/util/cli-arguments.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from 'node:util';
+import { ConfigurationError } from './errors.ts';
 
 export const helpText = `✂️  Find unused dependencies, exports and files in your JavaScript and TypeScript projects
 
@@ -82,6 +83,15 @@ $ knip --tags=-lintignore
 Website: https://knip.dev`;
 
 export type ParsedCLIArgs = ReturnType<typeof parseCLIArgs>;
+
+export const parseNumericOption = (value: string | undefined, option: string) => {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (value === '' || !Number.isInteger(parsed) || parsed < 0) {
+    throw new ConfigurationError(`Option --${option} expects a non-negative integer, got: ${value}`);
+  }
+  return parsed;
+};
 
 export default function parseCLIArgs() {
   return parseArgs({

--- a/packages/knip/src/util/create-options.ts
+++ b/packages/knip/src/util/create-options.ts
@@ -6,7 +6,7 @@ import type { IssueType } from '../types/issues.ts';
 import type { Options } from '../types/options.ts';
 import type { PackageJson } from '../types/package-json.ts';
 import { getCatalogContainer } from './catalog.ts';
-import type { ParsedCLIArgs } from './cli-arguments.ts';
+import { parseNumericOption, type ParsedCLIArgs } from './cli-arguments.ts';
 import { ConfigurationError } from './errors.ts';
 import { findFile, loadJSON } from './fs.ts';
 import {
@@ -193,7 +193,7 @@ export const createOptions = async (options: CreateOptions) => {
     isTreatTagHintsAsErrors: args['treat-tag-hints-as-errors'] ?? parsedConfig.treatTagHintsAsErrors ?? false,
     isUseTscFiles: options.isUseTscFiles ?? args['use-tsconfig-files'] ?? (options.isSession && !configFilePath),
     isWatch: args.watch ?? options.isWatch ?? false,
-    maxShowIssues: args['max-show-issues'] ? Number(args['max-show-issues']) : undefined,
+    maxShowIssues: parseNumericOption(args['max-show-issues'], 'max-show-issues'),
     parsedConfig,
     rules,
     tags,

--- a/packages/knip/src/util/create-options.ts
+++ b/packages/knip/src/util/create-options.ts
@@ -193,6 +193,7 @@ export const createOptions = async (options: CreateOptions) => {
     isTreatTagHintsAsErrors: args['treat-tag-hints-as-errors'] ?? parsedConfig.treatTagHintsAsErrors ?? false,
     isUseTscFiles: options.isUseTscFiles ?? args['use-tsconfig-files'] ?? (options.isSession && !configFilePath),
     isWatch: args.watch ?? options.isWatch ?? false,
+    maxIssues: parseNumericOption(args['max-issues'], 'max-issues') ?? 0,
     maxShowIssues: parseNumericOption(args['max-show-issues'], 'max-show-issues'),
     parsedConfig,
     rules,

--- a/packages/knip/test/cli/cli-max-issues.test.ts
+++ b/packages/knip/test/cli/cli-max-issues.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { exec } from '../helpers/exec.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+test('knip --max-issues=abc (invalid value does not disable the exit code)', () => {
+  const cwd = resolve('fixtures/compact-reporter');
+  const result = exec('knip --max-issues=abc', { cwd });
+  assert.equal(result.stderr, 'ERROR: Option --max-issues expects a non-negative integer, got: abc');
+  assert.equal(result.status, 2);
+});

--- a/packages/knip/test/util/cli-arguments.test.ts
+++ b/packages/knip/test/util/cli-arguments.test.ts
@@ -1,9 +1,7 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
 import test from 'node:test';
 import { parseNumericOption } from '../../src/util/cli-arguments.ts';
 import { ConfigurationError } from '../../src/util/errors.ts';
-import { resolve } from '../helpers/resolve.ts';
 
 test('parseNumericOption returns non-negative integers', () => {
   assert.equal(parseNumericOption('0', 'max-issues'), 0);
@@ -33,12 +31,6 @@ test('parseNumericOption rejects an empty value', () => {
   assert.throws(() => parseNumericOption('', 'max-issues'), ConfigurationError);
 });
 
-test('invalid --max-issues does not disable the exit-code gate', () => {
-  const result = spawnSync(process.execPath, [resolve('src/cli.ts'), '--max-issues=abc', '--reporter', 'compact'], {
-    cwd: resolve('fixtures/compact-reporter'),
-    env: { PATH: process.env.PATH, NO_COLOR: '1' },
-  });
-
-  assert.match(result.stderr.toString(), /Option --max-issues expects a non-negative integer, got: abc/);
-  assert.equal(result.status, 2);
+test('parseNumericOption rejects a whitespace-only value', () => {
+  assert.throws(() => parseNumericOption('  ', 'max-issues'), ConfigurationError);
 });

--- a/packages/knip/test/util/cli-arguments.test.ts
+++ b/packages/knip/test/util/cli-arguments.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { parseNumericOption } from '../../src/util/cli-arguments.ts';
+import { ConfigurationError } from '../../src/util/errors.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+test('parseNumericOption returns non-negative integers', () => {
+  assert.equal(parseNumericOption('0', 'max-issues'), 0);
+  assert.equal(parseNumericOption('10', 'max-issues'), 10);
+});
+
+test('parseNumericOption returns undefined for an absent value', () => {
+  assert.equal(parseNumericOption(undefined, 'max-issues'), undefined);
+});
+
+test('parseNumericOption rejects non-numeric values with the option name', () => {
+  assert.throws(
+    () => parseNumericOption('abc', 'max-show-issues'),
+    error => error instanceof ConfigurationError && error.message.includes('--max-show-issues')
+  );
+});
+
+test('parseNumericOption rejects negative integers', () => {
+  assert.throws(() => parseNumericOption('-1', 'max-issues'), ConfigurationError);
+});
+
+test('parseNumericOption rejects fractional values', () => {
+  assert.throws(() => parseNumericOption('3.5', 'max-issues'), ConfigurationError);
+});
+
+test('parseNumericOption rejects an empty value', () => {
+  assert.throws(() => parseNumericOption('', 'max-issues'), ConfigurationError);
+});
+
+test('invalid --max-issues does not disable the exit-code gate', () => {
+  const result = spawnSync(process.execPath, [resolve('src/cli.ts'), '--max-issues=abc', '--reporter', 'compact'], {
+    cwd: resolve('fixtures/compact-reporter'),
+    env: { PATH: process.env.PATH, NO_COLOR: '1' },
+  });
+
+  assert.match(result.stderr.toString(), /Option --max-issues expects a non-negative integer, got: abc/);
+  assert.equal(result.status, 2);
+});


### PR DESCRIPTION
## Problem

`--max-issues` and `--max-show-issues` are declared as strings in `cli-arguments.ts` and read with `Number()` at three call sites, with no validation in between.

`Number("abc")` is `NaN`, and every comparison against `NaN` is false. So this line never fires when the option is malformed:

```ts
totalErrorCount > Number(args['max-issues'] ?? 0)
```

`knip --max-issues=abc` exits 0 regardless of how many issues were found. The exit-code gate stops gating and reports success.

The realistic way to hit this is a CI variable that holds a non-numeric value. An unset variable gives `--max-issues=`, and `Number('')` is 0, so that case already failed closed.

```
--max-issues="abc"   Number() = NaN   (100 > NaN) = false
--max-issues="10"    Number() = 10    (100 > 10)  = true
```

Negative and fractional values are accepted today too, and neither is meaningful for a maximum.

## Change

One helper in `cli-arguments.ts`, called once in `createOptions`:

```ts
export const parseNumericOption = (value: string | undefined, option: string) => {
  if (value === undefined) return undefined;
  if (!/^\d+$/.test(value)) {
    throw new ConfigurationError(`Option --${option} expects a non-negative integer, got: ${value}`);
  }
  return Number(value);
};
```

`createOptions` returns `maxIssues` and `maxShowIssues`. `cli.ts` reads those values and does not parse. `createOptions` runs before `run()`, so an invalid value throws before the analysis starts.

The regex states the contract directly. It also rejects a whitespace-only value, which `Number('  ') === 0` accepted before.

It throws `ConfigurationError`, so the handler already in `cli.ts` prints the message and the `Run knip --help` hint.

## Tests

`packages/knip/test/util/cli-arguments.test.ts` holds seven unit tests. They cover valid values, an absent value, and rejection of non-numeric, negative, fractional, empty and whitespace-only input. One test asserts the message names the offending option.

`packages/knip/test/cli/cli-max-issues.test.ts` spawns the real CLI against a fixture with `--max-issues=abc` and asserts exit code 2. It uses the `exec` helper, so it runs `dist/cli.js` on Node and `src/cli.ts` on Bun. It sits in `test/cli/`, which the smoke set skips.

Result on Node 24.18.0:

```
node --test test/util/cli-arguments.test.ts test/cli/cli-max-issues.test.ts
pass 8, fail 0

pnpm test --runtime node --smoke
tests 971, pass 969, fail 2
```

The two smoke failures are the moonrepo and Nx plugin tests. They fail the same way on `main` without this branch.

Reverting the regex leaves the whitespace test failing and the other seven passing. `oxlint`, `oxfmt --check`, `check-line-endings.sh` and `tsc` pass.
