### PR TITLE
Add support for TypeScript content mappers

### DIFF
--- a/packages/knip/fixtures/plugins/typescript/package.json
+++ b/packages/knip/fixtures/plugins/typescript/package.json
@@ -2,12 +2,14 @@
   "name": "@plugins/typescript",
   "scripts": {
     "build-base": "tsc -p tsconfig.base.json",
+    "build-content-mapper": "tsc -p tsconfig.content-mapper.json",
     "build-ext": "tsc -p tsconfig.ext.json",
     "build-preact": "tsc -p tsconfig.jsx-import-source-preact.json",
     "build-react": "tsc -p tsconfig.jsx-import-source-react.json",
     "build-jsx": "tsc -p tsconfig.jsx-preserve.json"
   },
   "devDependencies": {
+    "ember-content-mapper": "*",
     "@tsconfig/node16": "*",
     "@tsconfig/node20": "*",
     "@tsconfig/node22": "*",

--- a/packages/knip/fixtures/plugins/typescript/tsconfig.content-mapper.json
+++ b/packages/knip/fixtures/plugins/typescript/tsconfig.content-mapper.json
@@ -1,0 +1,12 @@
+{
+  "contentMappers": [
+    {
+      "package": "@mdx-js/content-mapper",
+      "extensions": [".mdx"]
+    },
+    {
+      "package": "ember-content-mapper",
+      "extensions": [".gjs", ".gts"]
+    }
+  ]
+}

--- a/packages/knip/src/plugins/typescript/index.ts
+++ b/packages/knip/src/plugins/typescript/index.ts
@@ -30,7 +30,12 @@ const resolveConfig: ResolveConfig<TsConfigJson> = async (localConfig, options) 
       ?.filter(reference => reference.path.endsWith('.json'))
       .map(reference => toConfig('typescript', reference.path, { containingFilePath: options.configFilePath })) ?? [];
 
-  if (!(compilerOptions && localConfig)) return compact([...extend, ...references]);
+  const contentMappers =
+    localConfig.contentMappers?.map(contentMapper =>
+      toConfig('typescript', contentMapper.package, { containingFilePath: options.configFilePath })
+    ) ?? [];
+
+  if (!(compilerOptions && localConfig)) return compact([...contentMappers, ...extend, ...references]);
 
   const jsx = (compilerOptions?.jsxImportSource ? [compilerOptions.jsxImportSource] : []).map(toProductionDependency);
 
@@ -41,6 +46,7 @@ const resolveConfig: ResolveConfig<TsConfigJson> = async (localConfig, options) 
   const importHelpers = compilerOptions?.importHelpers ? ['tslib'] : [];
 
   return compact([
+    ...contentMappers,
     ...extend,
     ...references,
     ...types.map(id => toDeferResolve(id, { isTypeOnly: true, dir: options.cwd })),

--- a/packages/knip/src/plugins/typescript/index.ts
+++ b/packages/knip/src/plugins/typescript/index.ts
@@ -2,7 +2,7 @@ import type { ConfigArg } from '../../types/args.ts';
 import type { IsPluginEnabled, Plugin, ResolveConfig } from '../../types/config.ts';
 import type { TsConfigJson } from '../../types/tsconfig-json.ts';
 import { compact } from '../../util/array.ts';
-import { toConfig, toDeferResolve, toProductionDependency } from '../../util/input.ts';
+import { toConfig, toDeferResolve, toDependency, toProductionDependency } from '../../util/input.ts';
 import { join } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
 
@@ -30,10 +30,7 @@ const resolveConfig: ResolveConfig<TsConfigJson> = async (localConfig, options) 
       ?.filter(reference => reference.path.endsWith('.json'))
       .map(reference => toConfig('typescript', reference.path, { containingFilePath: options.configFilePath })) ?? [];
 
-  const contentMappers =
-    localConfig.contentMappers?.map(contentMapper =>
-      toConfig('typescript', contentMapper.package, { containingFilePath: options.configFilePath })
-    ) ?? [];
+  const contentMappers = localConfig.contentMappers?.map(contentMapper => toDependency(contentMapper.package)) ?? [];
 
   if (!(compilerOptions && localConfig)) return compact([...contentMappers, ...extend, ...references]);
 

--- a/packages/knip/src/types/tsconfig-json.ts
+++ b/packages/knip/src/types/tsconfig-json.ts
@@ -6,5 +6,8 @@ export interface TsConfigJson {
     plugins?: Array<string | { name: string }>;
     [key: string]: unknown;
   };
+  contentMappers?: {
+    package: string;
+  }[];
   references?: Array<{ path: string }>;
 }

--- a/packages/knip/test/plugins/typescript.test.ts
+++ b/packages/knip/test/plugins/typescript.test.ts
@@ -14,6 +14,7 @@ test('Find dependencies with the TypeScript plugin', async () => {
   assert(issues.unresolved['tsconfig.json']['typescript-eslint-language-service']);
   assert(issues.unresolved['tsconfig.json']['ts-graphql-plugin']);
   assert(issues.unresolved['tsconfig.json']['tslib']); // resolved up to dep of knip itself
+  assert(issues.unlisted['tsconfig.content-mapper.json']['@mdx-js/content-mapper']);
   assert(issues.unlisted['tsconfig.jsx-import-source-preact.json']['preact']);
   assert(issues.unresolved['tsconfig.jsx-import-source-preact.json']['preact']);
   assert(issues.unresolved['tsconfig.jsx-import-source-react.json']['vitest/globals']);
@@ -22,7 +23,7 @@ test('Find dependencies with the TypeScript plugin', async () => {
   assert.deepEqual(counters, {
     ...baseCounters,
     binaries: 1,
-    unlisted: 2,
+    unlisted: 3,
     unresolved: 5,
     processed: 0,
     total: 0,
@@ -38,7 +39,7 @@ test('Find dependencies with the TypeScript plugin (production)', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    unlisted: 2,
+    unlisted: 3,
     processed: 0,
     total: 0,
   });

--- a/packages/knip/test/plugins/typescript.test.ts
+++ b/packages/knip/test/plugins/typescript.test.ts
@@ -39,7 +39,7 @@ test('Find dependencies with the TypeScript plugin (production)', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    unlisted: 3,
+    unlisted: 2,
     processed: 0,
     total: 0,
   });


### PR DESCRIPTION
Hello from the future :wave: 

TypeScript 7.1 will add support for content mappers, allowing you to check files other than TypeScript, such as MDX, Vue, Ember, etc.

This change makes Knip understand the the `package` field in the `contentMappers` entries refers to an npm package name.

This feature is still experimental. The configuration might change before the TypeScript 7.1 releases, but I don’t expect any changes.