### PR TITLE
Resolve oxlint/vite-plus import resolvers from `settings`

### DIFF
--- a/packages/knip/fixtures/plugins/oxlint-js-plugins/.oxlintrc-0.json
+++ b/packages/knip/fixtures/plugins/oxlint-js-plugins/.oxlintrc-0.json
@@ -9,5 +9,12 @@
     {
       "jsPlugins": ["eslint-plugin-import"]
     }
-  ]
+  ],
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "project": "tsconfig.json"
+      }
+    }
+  }
 }

--- a/packages/knip/fixtures/plugins/oxlint-js-plugins/package.json
+++ b/packages/knip/fixtures/plugins/oxlint-js-plugins/package.json
@@ -8,6 +8,7 @@
     "eslint-plugin-security": "*",
     "eslint-plugin-unused-imports": "*",
     "eslint-plugin-jsdoc": "*",
-    "eslint-plugin-import": "*"
+    "eslint-plugin-import": "*",
+    "eslint-import-resolver-typescript": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/oxlint-vite-config/package.json
+++ b/packages/knip/fixtures/plugins/oxlint-vite-config/package.json
@@ -3,6 +3,8 @@
   "devDependencies": {
     "vite-plus": "*",
     "eslint-plugin-regexp": "*",
-    "@e18e/eslint-plugin": "*"
+    "@e18e/eslint-plugin": "*",
+    "eslint-import-resolver-typescript": "*",
+    "@typescript-eslint/parser": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/oxlint-vite-config/vite.config.ts
+++ b/packages/knip/fixtures/plugins/oxlint-vite-config/vite.config.ts
@@ -4,5 +4,9 @@ export default defineConfig({
   lint: {
     plugins: ['unicorn', 'typescript'],
     jsPlugins: ['eslint-plugin-regexp', { name: 'e18e', specifier: '@e18e/eslint-plugin' }],
+    settings: {
+      'import/resolver': { typescript: { project: 'tsconfig.json' } },
+      'import/parsers': { '@typescript-eslint/parser': ['.ts', '.tsx'] },
+    },
   },
 });

--- a/packages/knip/src/plugins/eslint/helpers.ts
+++ b/packages/knip/src/plugins/eslint/helpers.ts
@@ -5,7 +5,7 @@ import { getPackageNameFromFilePath, getPackageNameFromModuleSpecifier } from '.
 import { extname, isAbsolute, isInternal } from '../../util/path.ts';
 import { substringBefore } from '../../util/string.ts';
 import { getDependenciesFromConfig } from '../babel/index.ts';
-import type { ESLintConfig, ESLintConfigDeprecated, OverrideConfigDeprecated } from './types.ts';
+import type { ESLintConfig, ESLintConfigDeprecated, OverrideConfigDeprecated, Settings } from './types.ts';
 
 export const isFlatConfig = (fileName: string) => /eslint\.config/.test(fileName);
 
@@ -110,6 +110,9 @@ const getDependenciesFromSettings = (settings: ESLintConfigDeprecated['settings'
     }
   });
 };
+
+export const getInputsFromSettings = (settings?: Settings) =>
+  compact(getDependenciesFromSettings(settings)).map(id => toDeferResolve(id, { optional: true }));
 
 const builtinFormatters = new Set(['html', 'json-with-metadata', 'json', 'stylish']);
 export const resolveFormatters = (formatters: string | string[]) => {

--- a/packages/knip/src/plugins/eslint/resolveFromAST.ts
+++ b/packages/knip/src/plugins/eslint/resolveFromAST.ts
@@ -5,7 +5,7 @@ import { findProperty, getPropertyKey } from '../../typescript/ast-helpers.ts';
 import { getStringValue } from '../../typescript/ast-nodes.ts';
 import { isInternal } from '../../util/path.ts';
 
-export const getInputsFromFlatConfigAST = (program: Program): Input[] => {
+export const getInputsFromSettingsAST = (program: Program): Input[] => {
   const inputs: Input[] = [];
 
   const addResolver = (key: string, resolver: string | undefined) => {
@@ -35,7 +35,10 @@ export const getInputsFromFlatConfigAST = (program: Program): Input[] => {
   });
   visitor.visit(program);
 
-  inputs.push(toDeferResolve('eslint-import-resolver-typescript', { optional: true }));
-
   return inputs;
 };
+
+export const getInputsFromFlatConfigAST = (program: Program): Input[] => [
+  ...getInputsFromSettingsAST(program),
+  toDeferResolve('eslint-import-resolver-typescript', { optional: true }),
+];

--- a/packages/knip/src/plugins/eslint/types.ts
+++ b/packages/knip/src/plugins/eslint/types.ts
@@ -7,7 +7,7 @@ type ParserOptions = {
   };
 };
 
-type Settings = Record<string, Record<string, unknown> | string>;
+export type Settings = Record<string, Record<string, unknown> | string>;
 
 type Rules = Record<string, string | number>;
 

--- a/packages/knip/src/plugins/oxlint/index.ts
+++ b/packages/knip/src/plugins/oxlint/index.ts
@@ -4,6 +4,8 @@ import { findProperty, getPropertyValues } from '../../typescript/ast-helpers.ts
 import { type Input, toDependency, toEntry } from '../../util/input.ts';
 import { isInternal } from '../../util/path.ts';
 import { hasDependency } from '../../util/plugin.ts';
+import { getInputsFromSettings } from '../eslint/helpers.ts';
+import { getInputsFromSettingsAST } from '../eslint/resolveFromAST.ts';
 import type { OxlintConfig } from './types.ts';
 
 // https://oxc.rs/docs/guide/usage/linter/config.html
@@ -39,6 +41,7 @@ const resolveConfig: ResolveConfig<OxlintConfig> = config => {
   for (const override of config.overrides ?? []) {
     for (const input of resolveJsPlugins(override.jsPlugins)) inputs.push(input);
   }
+  for (const input of getInputsFromSettings(config.settings)) inputs.push(input);
   return inputs;
 };
 
@@ -57,7 +60,7 @@ const resolveFromAST: ResolveFromAST = (program, options) => {
     },
   });
   visitor.visit(program);
-  return resolveJsPlugins([...jsPlugins]);
+  return [...resolveJsPlugins([...jsPlugins]), ...getInputsFromSettingsAST(program)];
 };
 
 const plugin: Plugin = {

--- a/packages/knip/src/plugins/oxlint/types.ts
+++ b/packages/knip/src/plugins/oxlint/types.ts
@@ -1,3 +1,5 @@
+import type { Settings } from '../eslint/types.ts';
+
 type JsPlugin =
   | string
   | {
@@ -12,4 +14,5 @@ type Override = {
 export type OxlintConfig = {
   jsPlugins?: JsPlugin[];
   overrides?: Override[];
+  settings?: Settings;
 };


### PR DESCRIPTION
Oxlint's `settings` behaves the same as in ESLint. A plugin like `eslint-plugin-boundaries` resolves specifiers by name from `settings['import/resolver']` and requires `eslint-import-resolver-<name>` to be installed. Those resolvers are currently reported as unused. The same problem and solution applies to the vite-plus plugin.