### PR TITLE
fix: report types used only in non-exported function signatures

### DIFF
--- a/packages/knip/fixtures/types/private-fn-signature/package.json
+++ b/packages/knip/fixtures/types/private-fn-signature/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/private-fn-signature"
+}

--- a/packages/knip/fixtures/types/private-fn-signature/src/index.ts
+++ b/packages/knip/fixtures/types/private-fn-signature/src/index.ts
@@ -1,0 +1,3 @@
+import { fnParam, fnReturn, fnGeneric, fnLocal } from './lib.js';
+
+console.log(fnParam({ a: 'a' }), fnReturn(), fnGeneric([]), fnLocal());

--- a/packages/knip/fixtures/types/private-fn-signature/src/lib.ts
+++ b/packages/knip/fixtures/types/private-fn-signature/src/lib.ts
@@ -1,0 +1,17 @@
+export type AsParam = { a: string };
+export type AsReturn = { b: string };
+export type AsGenericArg = { c: string };
+export type AsPrivateParam = { d: string };
+export type AsLocalAnnotation = { e: string };
+export type Unused = { f: string };
+
+export const fnParam = (x: AsParam) => x.a;
+export const fnReturn = (): AsReturn => ({ b: 'b' });
+export const fnGeneric = (xs: Array<AsGenericArg>) => xs.length;
+
+const privateFn = (y: AsPrivateParam) => y.d;
+
+export const fnLocal = () => {
+  const t: AsLocalAnnotation = { e: 'e' };
+  return privateFn({ d: t.e });
+};

--- a/packages/knip/src/typescript/visitors/walk.ts
+++ b/packages/knip/src/typescript/visitors/walk.ts
@@ -184,7 +184,8 @@ const _collectRefsInType = (
   exportName: string,
   signatureOnly: boolean,
   seen = new Set<string>(),
-  inBody = false
+  inBody = false,
+  skipParams = false
 ): void => {
   if (!node) return;
   const type = node.type;
@@ -235,13 +236,13 @@ const _collectRefsInType = (
     case 'TSTypeAssertion':
     case 'TSSatisfiesExpression':
       if (inBody) {
-        if (node.expression) _collectRefsInType(node.expression, exportName, signatureOnly, seen, inBody);
+        if (node.expression) _collectRefsInType(node.expression, exportName, signatureOnly, seen, inBody, skipParams);
         return;
       }
       break;
     case 'VariableDeclarator':
       if (inBody) {
-        if (node.init) _collectRefsInType(node.init, exportName, signatureOnly, seen, inBody);
+        if (node.init) _collectRefsInType(node.init, exportName, signatureOnly, seen, inBody, skipParams);
         return;
       }
       break;
@@ -250,15 +251,19 @@ const _collectRefsInType = (
   const keys = visitorKeys[type];
   if (!keys) return;
   const childInBody = inBody || type === 'FunctionBody' || type === 'BlockStatement';
+  const skipFnParams =
+    skipParams &&
+    (type === 'ArrowFunctionExpression' || type === 'FunctionExpression' || type === 'FunctionDeclaration');
   for (const key of keys) {
+    if (skipFnParams && key === 'params') continue;
     const val = node[key];
     if (!val) continue;
     if (Array.isArray(val)) {
       for (const item of val) {
-        if (item) _collectRefsInType(item, exportName, signatureOnly, seen, childInBody);
+        if (item) _collectRefsInType(item, exportName, signatureOnly, seen, childInBody, skipParams);
       }
     } else {
-      _collectRefsInType(val, exportName, signatureOnly, seen, childInBody);
+      _collectRefsInType(val, exportName, signatureOnly, seen, childInBody, skipParams);
     }
   }
 };
@@ -830,7 +835,7 @@ function walkAST(program: Program, sourceText: string, filePath: string, hasModu
       const decl = state.localDeclarations.get(name);
       if (!decl) continue;
       seen.add(name);
-      _collectRefsInType(decl, exportName, true, seen);
+      _collectRefsInType(decl, exportName, true, seen, false, true);
     }
     while (state.pendingMemberCallRefs.length > 0) {
       const { objectName, propertyName, exportName, seen } = state.pendingMemberCallRefs.pop()!;
@@ -845,7 +850,7 @@ function walkAST(program: Program, sourceText: string, filePath: string, hasModu
       const fn = prop.value;
       if (fn.type !== 'ArrowFunctionExpression' && fn.type !== 'FunctionExpression') continue;
       seen.add(key);
-      _collectRefsInType(fn, exportName, true, seen);
+      _collectRefsInType(fn, exportName, true, seen, false, true);
     }
   }
 

--- a/packages/knip/test/types/private-fn-signature.test.ts
+++ b/packages/knip/test/types/private-fn-signature.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/types/private-fn-signature');
+
+test('Report types used only in a non-exported function signature (issue #1950)', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.types['src/lib.ts']['AsPrivateParam']);
+  assert(issues.types['src/lib.ts']['AsLocalAnnotation']);
+  assert(issues.types['src/lib.ts']['Unused']);
+
+  assert.equal(issues.types['src/lib.ts']['AsParam'], undefined);
+  assert.equal(issues.types['src/lib.ts']['AsReturn'], undefined);
+  assert.equal(issues.types['src/lib.ts']['AsGenericArg'], undefined);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    types: 3,
+    processed: 2,
+    total: 2,
+  });
+});


### PR DESCRIPTION
Resolves #1950

### What

Since v6.12.0, exported types that are referenced only in the signature of a
**non-exported** function are wrongly kept alive and never reported as unused.

Example:

```ts
// src/lib.ts
export type AsPrivateParam = { d: string };

const privateFn = (y: AsPrivateParam) => y.d; // non-exported

export const fnLocal = () => privateFn({ d: 'x' }); // used elsewhere → walks body → calls privateFn
```

`AsPrivateParam` should be reported as unused (only referenced by a non-exported
function), but currently isn't.

### Why

Regression from `4dcd756f` ("Fix inferred declaration export references", v6.12.1).
When a used export has no explicit return type and is walked (body traversal),
followed call refs (`pendingCallRefs` / `pendingMemberCallRefs`) walk the callee's
declaration including its **parameters**, wrongly crediting the callee's param type
to the used export.

### How

`_collectRefsInType` gained a `skipParams` flag (default `false`, so normal
collection is unchanged). The call-following loops now pass `skipParams = true`,
so a followed callee's function **parameters** are skipped while its **return type**
is still collected.

- Keeps declaration-safety: types in **exported** signature positions
  (`AsParam`, `AsReturn`, `AsGenericArg`) are still kept, per `.agents/EXPORTS.md`.
- No false-positive regressions (guarded by `test/e2e/fix-tsc.test.ts`, 27 tests).

### Tests

New regression fixture + test:
- `fixtures/types/private-fn-signature/`
- `test/types/private-fn-signature.test.ts`

Verified: regression test passes; `test/exports`, `test/types`, `test/fix`,
`test/ignore-exports-used-in-file` (62 tests), `test/re-exports`, `test/namespaces`,
`test/imports`, `test/e2e` (86 tests) all pass; `tsc` typecheck, `oxlint`, `oxfmt` clean.

I hope this helps! Thanks in advance!