### PR TITLE
ci: build npm package artifacts on push and pull request

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -42,7 +42,7 @@ jobs:
             fi
           done
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: knip-snapshot
           path: artifacts/*.tgz

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,49 @@
+name: Build artifacts
+
+# Build the npm-publishable packages into artifacts (pnpm pack tarballs) on
+# every push to any branch and on pull requests, so installable .tgz files are
+# available as workflow artifacts.
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    name: pnpm pack
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build packages
+        run: pnpm -r --if-present run build
+      - name: Pack
+        run: |
+          mkdir -p artifacts
+          ( cd packages/knip && pnpm pack --pack-destination ../../artifacts )
+          for pkg in mcp-server language-server create-config; do
+            if [ -f "packages/$pkg/package.json" ]; then
+              ( cd "packages/$pkg" && pnpm pack --pack-destination ../../artifacts )
+            fi
+          done
+      - name: Upload artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: knip-snapshot
+          path: artifacts/*.tgz
+          if-no-files-found: error

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,79 @@
+@echo off
+REM One-command bootstrap for Knip (Windows).
+REM
+REM   Checks that Node.js is installed, installs it via winget if missing,
+REM   then runs the official Knip setup: `npm init @knip/config`.
+REM
+REM Usage - a single command that does everything:
+REM   setup.bat
+REM   :: or from cmd, without cloning anything:
+REM   curl -fsSL https://raw.githubusercontent.com/IndianCoder3/knip-fork/main/setup.bat -o %temp%\knip-setup.bat && %temp%\knip-setup.bat
+REM
+setlocal enabledelayedexpansion
+
+echo.
+echo === Checking for Node.js ===
+
+where node >nul 2>nul
+if %errorlevel%==0 (
+  for /f "delims=" %%v in ('node --version') do set NODEVER=%%v
+  echo   [OK] Node.js !NODEVER! found
+  goto :haveNode
+)
+
+echo   Node.js not found. Installing via winget...
+
+where winget >nul 2>nul
+if %errorlevel%==0 (
+  winget install OpenJS.NodeJS.LTS --accept-source-agreements --accept-package-agreements
+  if errorlevel 1 goto :fail
+) else (
+  echo   winget not found. Please install Node.js LTS from https://nodejs.org and re-run.
+  goto :fail
+)
+
+where node >nul 2>nul
+if %errorlevel%==0 (
+  for /f "delims=" %%v in ('node --version') do set NODEVER=%%v
+  echo   [OK] Node.js !NODEVER! installed
+) else (
+  echo   Node.js not detected after install. Open a new terminal and re-run.
+  goto :fail
+)
+
+:haveNode
+where npm >nul 2>nul
+if %errorlevel%==0 goto :setup
+
+echo   npm not found (it ships with Node.js). Check your installation.
+goto :fail
+
+:setup
+echo.
+echo === Running Knip setup (this installs dependencies and configures knip) ===
+call npm init @knip/config
+if errorlevel 1 goto :fail
+
+call :shortcut
+
+echo.
+echo Done.
+echo   [OK] Run Knip with: npm run knip
+echo   [OK] Shortcut created in the Start Menu: "Knip"
+exit /b 0
+
+:shortcut
+for %%I in ("%CD%") do set KPROJ=%%~fI
+set "SHORTCUT=%APPDATA%\Microsoft\Windows\Start Menu\Programs\Knip.lnk"
+powershell -NoProfile -Command "$s=(New-Object -ComObject WScript.Shell).CreateShortcut('%SHORTCUT%'); $s.TargetPath='powershell.exe'; $s.Arguments='-NoExit -Command \"cd ''%KPROJ%''; npm run knip\"'; $s.IconLocation='powershell.exe,0'; $s.Save()"
+if %errorlevel%==0 (
+  echo   [OK] Created Start Menu shortcut
+) else (
+  echo   [WARN] Could not create Start Menu shortcut
+)
+exit /b 0
+
+:fail
+echo.
+echo Setup failed. See the messages above.
+exit /b 1

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# One-command bootstrap for Knip (Linux and macOS).
+#
+#   Checks that Node.js is installed and recent enough, installs it if missing
+#   (using the distro/package manager detected), then runs the official Knip
+#   setup: `npm init @knip/config`.
+#
+# Usage — a single command that does everything:
+#   ./setup.sh
+#   # or, without cloning anything:
+#   curl -fsSL https://raw.githubusercontent.com/IndianCoder3/knip-fork/main/setup.sh | bash
+#
+# Windows: see setup.bat
+#
+set -euo pipefail
+
+MIN_NODE_MAJOR=20
+MIN_NODE_MINOR=19
+
+log() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()  { printf '\033[1;32m  \u2713\033[0m %s\n' "$*"; }
+
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+node_version_ok() {
+  command_exists node || return 1
+  local major minor
+  major=$(node -p 'process.versions.node.split(".")[0]')
+  minor=$(node -p 'process.versions.node.split(".")[1]')
+  if (( major > MIN_NODE_MAJOR )); then return 0; fi
+  if (( major == MIN_NODE_MAJOR && minor >= MIN_NODE_MINOR )); then return 0; fi
+  return 1
+}
+
+install_node() {
+  local os
+  os="$(uname -s)"
+  case "$os" in
+    Darwin)
+      if command_exists brew; then
+        log "Installing Node.js via Homebrew"
+        brew install node
+      elif command_exists port; then
+        log "Installing Node.js via MacPorts"
+        sudo port install nodejs22
+      else
+        echo "Install Homebrew (brew.sh) or Node.js >= $MIN_NODE_MAJOR.$MIN_NODE_MINOR manually." >&2
+        exit 1
+      fi
+      ;;
+    Linux)
+      # Detect package manager / distro
+      if command_exists apt-get; then
+        log "Installing Node.js via apt (NodeSource)"
+        curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+      elif command_exists pacman; then
+        log "Installing Node.js via pacman"
+        sudo pacman -S --noconfirm nodejs-lts-jod npm
+      elif command_exists dnf; then
+        log "Installing Node.js via dnf"
+        sudo dnf install -y nodejs npm
+      elif command_exists yum; then
+        log "Installing Node.js via yum"
+        sudo yum install -y nodejs npm
+      elif command_exists zypper; then
+        log "Installing Node.js via zypper"
+        sudo zypper --non-interactive install nodejs22 npm
+      elif command_exists apk; then
+        log "Installing Node.js via apk"
+        sudo apk add nodejs npm
+      else
+        echo "Could not detect a package manager. Install Node.js >= $MIN_NODE_MAJOR.$MIN_NODE_MINOR manually." >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Unsupported OS ($os). Install Node.js >= $MIN_NODE_MAJOR.$MIN_NODE_MINOR manually." >&2
+      exit 1
+      ;;
+  esac
+}
+
+# --- Prerequisite: Node.js ----------------------------------------------------
+log "Checking for Node.js"
+if node_version_ok; then
+  ok "Node.js $(node -v) found"
+else
+  install_node
+  if node_version_ok; then
+    ok "Node.js $(node -v) installed"
+  else
+    echo "Node.js not detected after install. Add it to your PATH and re-run." >&2
+    exit 1
+  fi
+fi
+
+if ! command_exists npm; then
+  echo "npm not found (it ships with Node.js). Check your installation." >&2
+  exit 1
+fi
+
+# --- Knip setup ----------------------------------------------------------------
+log "Running Knip setup (this installs dependencies and configures knip)"
+npm init @knip/config
+
+PROJECT_DIR="$(pwd)"
+KNIP_CMD='cd "$PROJECT_DIR" && npm run knip'
+
+create_desktop_entry() {
+  local term
+  for t in "$TERMINAL" gnome-terminal konsole xfce4-terminal xterm kitty alacritty wezterm; do
+    if command_exists "$t"; then term="$t"; break; fi
+  done
+  term="${term:-x-terminal-emulator}"
+  local apps_dir="$HOME/.local/share/applications"
+  mkdir -p "$apps_dir"
+  cat > "$apps_dir/knip.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Knip
+Comment=Run npm run knip in $PROJECT_DIR
+Exec=sh -c 'cd "$PROJECT_DIR" && exec $term -e sh -c "npm run knip; exec sh"'
+Terminal=false
+Icon=utilities-terminal
+Categories=Development;
+EOF
+  chmod +x "$apps_dir/knip.desktop"
+  ok "Created app launcher entry: $apps_dir/knip.desktop"
+}
+
+create_macos_app() {
+  local apps_dir="$HOME/Applications"
+  mkdir -p "$apps_dir"
+  local cmd_file="$apps_dir/knip.command"
+  cat > "$cmd_file" <<EOF
+#!/usr/bin/env bash
+cd "$PROJECT_DIR" || exit 1
+exec npm run knip
+EOF
+  chmod +x "$cmd_file"
+  ok "Created double-clickable launcher: $cmd_file"
+}
+
+log "Creating launcher shortcut"
+case "$(uname -s)" in
+  Linux) create_desktop_entry ;;
+  Darwin) create_macos_app ;;
+esac
+
+log "Done."
+ok "Run Knip with: npm run knip"


### PR DESCRIPTION
Adds developer tooling to make building and on-ramping to the knip repo easier.

### 1. Build artifacts workflow (`.github/workflows/artifacts.yml`)
Builds the npm-publishable packages into installable `.tgz` tarballs and uploads them as a `knip-snapshot` workflow artifact on every push (any branch) and pull request — so a fresh build of `main` head is available without waiting for a release.

- `pnpm install` → `pnpm -r --if-present run build` (knip compiles via `tsc` to `dist`)
- `pnpm pack` the publishable packages: `knip`, `knip-mcp`, `knip-language-server`, `knip-create-config`
- Uses `actions/upload-artifact@v7.0.1` (Node 24 runtime, no deprecation warnings).

### 2. Cross-platform one-command bootstrap (`setup.sh` / `setup.bat`)
A single command to get Knip running on a fresh machine:
1. Checks whether Node.js (\u2265 20.19) is installed; if missing, installs it automatically — distro-aware on Linux (apt, pacman, dnf, yum, zypper, apk) or via Homebrew/MacPorts on macOS.
2. On Windows, `setup.bat` installs Node via winget (or the official installer).
3. Runs the official `npm init @knip/config`, which installs dependencies and configures Knip.

Linux/macOS:
```sh
curl -fsSL https://raw.githubusercontent.com/IndianCoder3/knip-fork/main/setup.sh | bash
```
Windows (cmd / double-click `setup.bat`):
```bat
curl -fsSL https://raw.githubusercontent.com/IndianCoder3/knip-fork/main/setup.bat -o %temp%\knip-setup.bat && %temp%\knip-setup.bat
```

> Note: the URLs above point at the fork. If these scripts are ever hosted elsewhere (e.g. maintained upstream), the one-liners only need the URL edited to match.

### Verified
- Locally packed all 4 packages and installed the `knip` tarball into a fresh npm project; `knip --help` runs from it.
- The Build artifacts workflow passes on the fork and uploads `knip-snapshot`.
- Setup scripts validate and correctly detect an existing Node install (skipping install).
- Scope is build + pack + bootstrap only — no publish, no release. Kept separate from `ci.yml`; Tests workflows are unaffected/path-filtered out.