### PR TITLE
feat: expose identifier in SARIF logicalLocations (resolve #1936)

### DIFF
--- a/packages/knip/src/reporters/sarif.ts
+++ b/packages/knip/src/reporters/sarif.ts
@@ -24,20 +24,28 @@ const getUri = (filePath: string, cwd: string) =>
     .map(segment => encodeURIComponent(segment))
     .join('/');
 
-const getLocation = ({ filePath, line, col, symbol }: Issue, cwd: string) => ({
-  physicalLocation: {
-    artifactLocation: { uri: getUri(filePath, cwd) },
-    ...(line !== undefined && {
-      region: {
-        startLine: Math.max(line, 1),
-        ...(col !== undefined && {
-          startColumn: Math.max(col, 1),
-          endColumn: Math.max(col, 1) + Math.max(symbol.length, 1),
-        }),
-      },
-    }),
-  },
-});
+const getLogicalLocation = ({ type, symbol }: Issue) =>
+  type === 'files' ? [] : [{ name: symbol, fullyQualifiedName: symbol }];
+
+const getLocation = (issue: Issue, cwd: string) => {
+  const { filePath, line, col, symbol } = issue;
+  const logicalLocations = getLogicalLocation(issue);
+  return {
+    physicalLocation: {
+      artifactLocation: { uri: getUri(filePath, cwd) },
+      ...(line !== undefined && {
+        region: {
+          startLine: Math.max(line, 1),
+          ...(col !== undefined && {
+            startColumn: Math.max(col, 1),
+            endColumn: Math.max(col, 1) + Math.max(symbol.length, 1),
+          }),
+        },
+      }),
+    },
+    ...(logicalLocations.length > 0 && { logicalLocations }),
+  };
+};
 
 const sortByLocation = (a: Issue, b: Issue) =>
   a.filePath.localeCompare(b.filePath) ||

--- a/packages/knip/test/cli/cli-reporter-sarif.test.ts
+++ b/packages/knip/test/cli/cli-reporter-sarif.test.ts
@@ -107,6 +107,7 @@ test('knip --reporter sarif', () => {
             artifactLocation: { uri: 'src/index.ts' },
             region: { startLine: 9, startColumn: 27, endColumn: 37 },
           },
+          logicalLocations: [{ name: 'unresolved', fullyQualifiedName: 'unresolved' }],
         },
       },
       {
@@ -119,6 +120,7 @@ test('knip --reporter sarif', () => {
             artifactLocation: { uri: 'src/index.ts' },
             region: { startLine: 10, startColumn: 27, endColumn: 42 },
           },
+          logicalLocations: [{ name: '@org/unresolved', fullyQualifiedName: '@org/unresolved' }],
         },
       },
       {
@@ -131,6 +133,7 @@ test('knip --reporter sarif', () => {
             artifactLocation: { uri: 'src/index.ts' },
             region: { startLine: 8, startColumn: 24, endColumn: 36 },
           },
+          logicalLocations: [{ name: './unresolved', fullyQualifiedName: './unresolved' }],
         },
       },
     ]


### PR DESCRIPTION
Adds `logicalLocations` to each SARIF `result` location, carrying the identifier (`name` + `fullyQualifiedName`) for non-`files` issue types. This lets SARIF consumers read the identifier directly instead of re-parsing `message.text` (#1936).

Additive reporter change only; SARIF tests updated and passing after `pnpm build`.

Hi @webpro, one heads-up — happy to adjust the SARIF fields if you'd prefer different ones. No rush.
