### PR TITLE
docs: add unused dependencies/exports pages to sidebar

### DIFF
--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -86,7 +86,10 @@ export default defineConfig({
             'guides/handling-issues',
             'reference/known-issues',
             'features/auto-fix',
-            'reference/faq',
+            {
+              label: 'FAQ',
+              items: ['reference/faq', 'typescript/unused-dependencies', 'typescript/unused-exports'],
+            },
             'reference/related-tooling',
           ],
         },

--- a/packages/docs/src/content/docs/typescript/unused-dependencies.md
+++ b/packages/docs/src/content/docs/typescript/unused-dependencies.md
@@ -1,8 +1,6 @@
 ---
 title: Unused dependencies
 description: Find and remove unused dependencies with Knip
-prev: false
-next: false
 ---
 
 One of Knip's core features is finding unused dependencies in your JavaScript

--- a/packages/docs/src/content/docs/typescript/unused-exports.md
+++ b/packages/docs/src/content/docs/typescript/unused-exports.md
@@ -1,8 +1,6 @@
 ---
 title: Unused exports
 description: Find and remove unused exports with Knip
-prev: false
-next: false
 ---
 
 Finding unused exports in your JavaScript and TypeScript projects is one of


### PR DESCRIPTION
`typescript/unused-dependencies` and `typescript/unused-exports` were not in the left navigation. They were only reachable through inline links in prose (homepage list, `why-use-knip`), so readers who orient by the sidebar never found them.

- Nest both under `FAQ` in the Troubleshooting group (same pattern as `Writing A Plugin`)
- Drop `prev: false` / `next: false` from their frontmatter so prev/next chains within the group

`pnpm astro build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)