### PR TITLE
fix: track pnpm workspace override catalogs

### DIFF
--- a/packages/docs/src/content/docs/features/catalogs.md
+++ b/packages/docs/src/content/docs/features/catalogs.md
@@ -34,7 +34,8 @@ the `catalog:` protocol in its `package.json`:
 `catalog:` references the `default` catalog, while `catalog:validation`
 references the named `validation` catalog. References are resolved from
 `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`,
-`resolutions` and `pnpm.overrides`.
+`resolutions`, `package.json#pnpm.overrides` (pnpm 10 and older), and
+`pnpm-workspace.yaml#overrides`.
 
 Entries defined in a catalog but not referenced anywhere are reported as [unused
 catalog entries][2].
@@ -42,8 +43,9 @@ catalog entries][2].
 ## Unresolved catalog references
 
 A `catalog:` reference is reported when the selected catalog does not define
-that package. These issues point to the consuming `package.json`, where package
-managers would otherwise fail to resolve the version.
+that package. These issues point to the consuming `package.json` or
+`pnpm-workspace.yaml`, where package managers would otherwise fail to resolve
+the version.
 
 ## Filter and fix
 

--- a/packages/knip/fixtures/dependencies/catalog-named-package-json-root/package.json
+++ b/packages/knip/fixtures/dependencies/catalog-named-package-json-root/package.json
@@ -22,5 +22,10 @@
       "express": "^4.18.0",
       "fastify": "^4.0.0"
     }
+  },
+  "pnpm": {
+    "overrides": {
+      "@nu/xt@^3": "catalog:frontend"
+    }
   }
 }

--- a/packages/knip/fixtures/dependencies/catalog-named/pnpm-workspace.yaml
+++ b/packages/knip/fixtures/dependencies/catalog-named/pnpm-workspace.yaml
@@ -12,3 +12,6 @@ catalogs:
   backend:
     '@ex/press': ^4.18.0
     fastify: ^4.0.0
+
+overrides:
+  '@nu/xt@^3': 'catalog:frontend'

--- a/packages/knip/fixtures/dependencies/catalog-pnpm/pnpm-workspace.yaml
+++ b/packages/knip/fixtures/dependencies/catalog-pnpm/pnpm-workspace.yaml
@@ -5,3 +5,13 @@ catalog:
   react: ^18.0.0
   typescript: ^5.0.0
   lodash: ^4.17.21
+  left-pad: ^1.3.0
+  ms: ^2.1.3
+  bar: ^1.0.0
+  kleur: ^4.1.5
+
+overrides:
+  left-pad@^1: 'catalog:'
+  debug>ms: 'catalog:'
+  foo>bar@>=1: 'catalog:'
+  foo@3 || >=2>kleur: 'catalog:'

--- a/packages/knip/fixtures/dependencies/catalog-references/package.json
+++ b/packages/knip/fixtures/dependencies/catalog-references/package.json
@@ -3,5 +3,10 @@
   "private": true,
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "pnpm": {
+    "overrides": {
+      "missing-package-json@^1": "catalog:"
+    }
+  }
 }

--- a/packages/knip/fixtures/dependencies/catalog-references/packages/app/package.json
+++ b/packages/knip/fixtures/dependencies/catalog-references/packages/app/package.json
@@ -3,5 +3,10 @@
   "dependencies": {
     "lodash": "catalog:",
     "express": "catalog:backend"
+  },
+  "pnpm": {
+    "overrides": {
+      "debug>react": "catalog:"
+    }
   }
 }

--- a/packages/knip/fixtures/dependencies/catalog-references/pnpm-workspace.yaml
+++ b/packages/knip/fixtures/dependencies/catalog-references/pnpm-workspace.yaml
@@ -7,3 +7,6 @@ catalog:
 catalogs:
   frontend:
     vue: ^3.0.0
+
+overrides:
+  missing@^1: 'catalog:'

--- a/packages/knip/src/CatalogCounselor.ts
+++ b/packages/knip/src/CatalogCounselor.ts
@@ -5,23 +5,32 @@ import { PackagePeeker } from './PackagePeeker.ts';
 import type { Fixes } from './types/exports.ts';
 import type { Issue } from './types/issues.ts';
 import type { Catalog, Catalogs, WorkspacePackage } from './types/package-json.ts';
-import { type CatalogReference, extractCatalogReferences, parseCatalog } from './util/catalog.ts';
+import {
+  type CatalogReference,
+  extractCatalogReferences,
+  getOverrideCatalogReferences,
+  type OverrideCatalogReference,
+  parseCatalog,
+} from './util/catalog.ts';
 import type { MainOptions } from './util/create-options.ts';
 import { extname } from './util/path.ts';
 import { YamlCatalogPeeker } from './YamlCatalogPeeker.ts';
 
-export type CatalogContainer = { filePath: string; catalog?: Catalog; catalogs?: Catalogs };
+export type CatalogContainer = { filePath: string; catalog?: Catalog; catalogs?: Catalogs; overrides?: Catalog };
 
 export class CatalogCounselor {
   private filePath: string;
   private entries = new Set<string>();
   private referencedEntries = new Set<string>();
   private referenceIssues: Issue[] = [];
+  private overrideReferences: OverrideCatalogReference[] = [];
   private fileContent?: string;
 
   constructor(options: MainOptions) {
     this.filePath = options.catalog.filePath;
     this.entries = parseCatalog(options.catalog);
+    this.overrideReferences = getOverrideCatalogReferences(options.catalog.overrides);
+    for (const reference of this.overrideReferences) this.addReference(reference);
   }
 
   private addReferencedCatalogEntry(entryName: string) {
@@ -39,14 +48,17 @@ export class CatalogCounselor {
     manifestStr,
   }: Pick<WorkspacePackage, 'name' | 'manifest' | 'manifestPath' | 'manifestStr'>) {
     const catalogReferences = extractCatalogReferences(manifest);
+    if (workspace === ROOT_WORKSPACE_NAME) {
+      for (const reference of getOverrideCatalogReferences(manifest.pnpm?.overrides)) catalogReferences.push(reference);
+    }
     if (catalogReferences.length === 0) return;
 
     const peeker = new PackagePeeker(manifestStr);
-    for (const { catalogName, packageName } of catalogReferences) {
+    for (const { catalogName, packageName, selector } of catalogReferences) {
       const catalogEntryName = `${catalogName}:${packageName}`;
       this.addReferencedCatalogEntry(catalogEntryName);
       if (!this.entries.has(catalogEntryName)) {
-        const pos = peeker.getCatalogReferenceLocation(packageName, catalogName);
+        const pos = peeker.getCatalogReferenceLocation(selector ?? packageName, catalogName);
         this.referenceIssues.push({
           type: 'catalogReferences',
           filePath,
@@ -64,12 +76,13 @@ export class CatalogCounselor {
     const filePath = this.filePath;
     const workspace = ROOT_WORKSPACE_NAME;
     const catalogIssues: Issue[] = [];
+    const overrideReferenceIssues: Issue[] = [];
 
-    if (this.entries.size > 0) {
+    if (this.entries.size > 0 || this.overrideReferences.length > 0) {
       this.fileContent = await readFile(filePath, 'utf-8');
       const isYaml = ['.yml', '.yaml'].includes(extname(filePath));
-      const Peeker = isYaml ? YamlCatalogPeeker : JsonCatalogPeeker;
-      const peeker = new Peeker(this.fileContent);
+      const yamlPeeker = isYaml ? new YamlCatalogPeeker(this.fileContent) : undefined;
+      const peeker = yamlPeeker ?? new JsonCatalogPeeker(this.fileContent);
 
       for (const entry of this.entries.keys()) {
         if (!this.referencedEntries.has(entry)) {
@@ -80,8 +93,22 @@ export class CatalogCounselor {
           catalogIssues.push({ type: 'catalog', filePath, workspace, symbol, parentSymbol, fixes, ...pos });
         }
       }
+
+      for (const { catalogName, packageName, selector } of this.overrideReferences) {
+        if (this.entries.has(`${catalogName}:${packageName}`)) continue;
+        const pos = yamlPeeker?.getOverrideCatalogReferenceLocation(selector);
+        overrideReferenceIssues.push({
+          type: 'catalogReferences',
+          filePath,
+          workspace,
+          symbol: packageName,
+          parentSymbol: catalogName,
+          fixes: [],
+          ...pos,
+        });
+      }
     }
 
-    return [...catalogIssues, ...this.referenceIssues];
+    return [...catalogIssues, ...this.referenceIssues, ...overrideReferenceIssues];
   }
 }

--- a/packages/knip/src/YamlCatalogPeeker.ts
+++ b/packages/knip/src/YamlCatalogPeeker.ts
@@ -26,6 +26,8 @@ export class YamlCatalogPeeker {
         this.sections.catalog = i;
       } else if (line.startsWith('catalogs:')) {
         this.sections.catalogs = i;
+      } else if (line.startsWith('overrides:')) {
+        this.sections.overrides = i;
       }
     }
     this.ready = true;
@@ -65,6 +67,19 @@ export class YamlCatalogPeeker {
           }
         }
       }
+    }
+  }
+
+  public getOverrideCatalogReferenceLocation(selector: string) {
+    if (!this.ready) this.init();
+
+    const startLine = this.sections.overrides;
+    if (typeof startLine === 'undefined') return;
+
+    for (let i = startLine + 1; i < this.lines.length; i++) {
+      const line = this.lines[i];
+      if (!line.startsWith('  ')) break;
+      if (matchesKey(line, '  ', selector)) return { line: i + 1, col: line.indexOf(selector) + 1 };
     }
   }
 }

--- a/packages/knip/src/util/catalog.ts
+++ b/packages/knip/src/util/catalog.ts
@@ -10,7 +10,10 @@ export const DEFAULT_CATALOG = 'default';
 export type CatalogReference = {
   catalogName: string;
   packageName: string;
+  selector?: string;
 };
+
+export type OverrideCatalogReference = CatalogReference & { selector: string };
 
 const CATALOG_PROTOCOL = '@catalog:';
 
@@ -50,7 +53,7 @@ export const getCatalogContainer = async (
     manifest.catalogs ??
     ((!Array.isArray(manifest.workspaces) && manifest.workspaces?.catalogs) || {});
 
-  return { filePath, catalog, catalogs };
+  return { filePath, catalog, catalogs, overrides: pnpmWorkspace?.overrides };
 };
 
 const extractEntries = (catalog: unknown): string[] => {
@@ -77,26 +80,48 @@ export const parseCatalog = (container: CatalogContainer) => {
   return entries;
 };
 
+const OVERRIDE_DELIMITER = /[^ |@]>/;
+
+const toCatalogReference = (packageName: string, version: unknown): CatalogReference | undefined => {
+  if (typeof version !== 'string' || !version.startsWith('catalog:')) return;
+  return { catalogName: version.slice('catalog:'.length) || DEFAULT_CATALOG, packageName };
+};
+
+const collectCatalogReferences = (
+  dependencies: Record<string, string> | undefined,
+  catalogReferences: CatalogReference[]
+) => {
+  if (!dependencies) return;
+
+  for (const [packageName, version] of Object.entries(dependencies)) {
+    const reference = toCatalogReference(packageName, version);
+    if (reference) catalogReferences.push(reference);
+  }
+};
+
+export const getOverrideCatalogReferences = (overrides: Record<string, string> | undefined) => {
+  const catalogReferences: OverrideCatalogReference[] = [];
+  if (!overrides) return catalogReferences;
+
+  for (const [selector, version] of Object.entries(overrides)) {
+    const delimiterIndex = selector.search(OVERRIDE_DELIMITER);
+    const target = delimiterIndex === -1 ? selector : selector.slice(delimiterIndex + 2);
+    const packageName = getPackageNameFromModuleSpecifier(target);
+    if (!packageName) continue;
+    const reference = toCatalogReference(packageName, version);
+    if (reference) catalogReferences.push({ ...reference, selector });
+  }
+  return catalogReferences;
+};
+
 export const extractCatalogReferences = (manifest: PackageJson): CatalogReference[] => {
   const catalogReferences: CatalogReference[] = [];
 
-  const checkDependencies = (dependencies: Record<string, string> | undefined) => {
-    if (!dependencies) return;
-
-    for (const [name, version] of Object.entries(dependencies)) {
-      if (typeof version === 'string' && version.startsWith('catalog:')) {
-        const catalogName = version.slice('catalog:'.length) || DEFAULT_CATALOG;
-        catalogReferences.push({ catalogName, packageName: name });
-      }
-    }
-  };
-
-  checkDependencies(manifest.dependencies);
-  checkDependencies(manifest.devDependencies);
-  checkDependencies(manifest.peerDependencies);
-  checkDependencies(manifest.optionalDependencies);
-  checkDependencies(manifest.resolutions);
-  checkDependencies(manifest.pnpm?.overrides);
+  collectCatalogReferences(manifest.dependencies, catalogReferences);
+  collectCatalogReferences(manifest.devDependencies, catalogReferences);
+  collectCatalogReferences(manifest.peerDependencies, catalogReferences);
+  collectCatalogReferences(manifest.optionalDependencies, catalogReferences);
+  collectCatalogReferences(manifest.resolutions, catalogReferences);
 
   return catalogReferences;
 };

--- a/packages/knip/test/dependencies/catalog.package-json.test.ts
+++ b/packages/knip/test/dependencies/catalog.package-json.test.ts
@@ -28,12 +28,12 @@ test('Should track referenced catalog entries (package.json root)', async () => 
   const { issues, counters } = await main(options);
 
   assert(issues.catalog['package.json']['default.lodash']);
-  assert(issues.catalog['package.json']['frontend.@nu/xt']);
+  assert(!issues.catalog['package.json']['frontend.@nu/xt']);
   assert(issues.catalog['package.json']['backend.fastify']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    catalog: 3,
+    catalog: 2,
     processed: 1,
     total: 1,
   });

--- a/packages/knip/test/dependencies/catalog.pnpm.test.ts
+++ b/packages/knip/test/dependencies/catalog.pnpm.test.ts
@@ -11,6 +11,10 @@ test('Should track referenced default catalog entries', async () => {
   const { issues, counters } = await main(options);
 
   assert(issues.catalog['pnpm-workspace.yaml']['default.lodash']);
+  assert(!issues.catalog['pnpm-workspace.yaml']['default.left-pad']);
+  assert(!issues.catalog['pnpm-workspace.yaml']['default.ms']);
+  assert(!issues.catalog['pnpm-workspace.yaml']['default.bar']);
+  assert(!issues.catalog['pnpm-workspace.yaml']['default.kleur']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
@@ -26,12 +30,12 @@ test('Should track referenced named catalog entries', async () => {
   const { issues, counters } = await main(options);
 
   assert(issues.catalog['pnpm-workspace.yaml']['default.lodash']);
-  assert(issues.catalog['pnpm-workspace.yaml']['frontend.@nu/xt']);
+  assert(!issues.catalog['pnpm-workspace.yaml']['frontend.@nu/xt']);
   assert(issues.catalog['pnpm-workspace.yaml']['backend.fastify']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    catalog: 3,
+    catalog: 2,
     processed: 1,
     total: 1,
   });
@@ -46,13 +50,17 @@ test('Should report unused entries and unresolved references independently', asy
   assert(issues.catalog['pnpm-workspace.yaml']['frontend.vue']);
   const defaultReference = issues.catalogReferences['packages/app/package.json']['default.lodash'];
   const namedReference = issues.catalogReferences['packages/app/package.json']['backend.express'];
+  const packageOverrideReference = issues.catalogReferences['package.json']['default.missing-package-json'];
+  const overrideReference = issues.catalogReferences['pnpm-workspace.yaml']['default.missing'];
   assert.deepEqual({ line: defaultReference.line, col: defaultReference.col }, { line: 4, col: 6 });
   assert.deepEqual({ line: namedReference.line, col: namedReference.col }, { line: 5, col: 6 });
+  assert.deepEqual({ line: packageOverrideReference.line, col: packageOverrideReference.col }, { line: 9, col: 8 });
+  assert.deepEqual({ line: overrideReference.line, col: overrideReference.col }, { line: 12, col: 3 });
 
   assert.deepEqual(counters, {
     ...baseCounters,
     catalog: 2,
-    catalogReferences: 2,
+    catalogReferences: 4,
     processed: 1,
     total: 1,
   });

--- a/packages/knip/test/fix/fix-catalog-json-root.test.ts
+++ b/packages/knip/test/fix/fix-catalog-json-root.test.ts
@@ -12,7 +12,7 @@ test('Fix catalog entries', async () => {
   const { issues } = await main(options);
 
   assert(issues.catalog['package.json']['default.lodash']);
-  assert(issues.catalog['package.json']['frontend.@nu/xt']);
+  assert(!issues.catalog['package.json']['frontend.@nu/xt']);
   assert(issues.catalog['package.json']['backend.fastify']);
 
   assert.equal(
@@ -33,10 +33,16 @@ test('Fix catalog entries', async () => {
   },
   "catalogs": {
     "frontend": {
-      "vue": "^3.0.0"
+      "vue": "^3.0.0",
+      "@nu/xt": "^3.0.0"
     },
     "backend": {
       "express": "^4.18.0"
+    }
+  },
+  "pnpm": {
+    "overrides": {
+      "@nu/xt@^3": "catalog:frontend"
     }
   }
 }

--- a/packages/knip/test/fix/fix-catalog-yaml.test.ts
+++ b/packages/knip/test/fix/fix-catalog-yaml.test.ts
@@ -12,7 +12,7 @@ test('Fix catalog entries (pnpm-workspace.yaml)', async () => {
   const { issues } = await main(options);
 
   assert(issues.catalog['pnpm-workspace.yaml']['default.lodash']);
-  assert(issues.catalog['pnpm-workspace.yaml']['frontend.@nu/xt']);
+  assert(!issues.catalog['pnpm-workspace.yaml']['frontend.@nu/xt']);
   assert(issues.catalog['pnpm-workspace.yaml']['backend.fastify']);
 
   assert.equal(
@@ -26,8 +26,12 @@ catalog:
 catalogs:
   frontend:
     vue: ^3.0.0
+    "@nu/xt": ^3.0.0
   backend:
     '@ex/press': ^4.18.0
+
+overrides:
+  '@nu/xt@^3': 'catalog:frontend'
 `
   );
 });


### PR DESCRIPTION
Closes #1998

Recognize catalog references in pnpm-workspace.yaml overrides, preventing used entries from being reported as unused.

### Before

Catalog entries used by workspace overrides were reported unused.

###  After

Override references are recognized correctly.