### PR TITLE
fix: track spreads under string-literal keys

### DIFF
--- a/packages/knip/fixtures/namespaces/ns-spread-reexport/index.ts
+++ b/packages/knip/fixtures/namespaces/ns-spread-reexport/index.ts
@@ -4,7 +4,10 @@ import { useUtils } from './consumer.js';
 import { useFruit } from './member-access.js';
 import { useAnimal } from './destructured.js';
 import { allColors, justRed } from './mixed-usage.js';
+import * as Queues from './queues.js';
 
 export function useResolvers() {
   return [resolvers, useAliasedResolvers, useUtils, useFruit, useAnimal, allColors, justRed];
 }
+
+export const registry = { 'my-queue': { handlers: { ...Queues } } };

--- a/packages/knip/fixtures/namespaces/ns-spread-reexport/queues.ts
+++ b/packages/knip/fixtures/namespaces/ns-spread-reexport/queues.ts
@@ -1,0 +1,1 @@
+export const send = 'send';

--- a/packages/knip/src/typescript/visitors/exports.ts
+++ b/packages/knip/src/typescript/visitors/exports.ts
@@ -146,12 +146,14 @@ export function handleExportNamed(node: ExportNamedDeclaration, s: WalkState) {
                     }
                     s.accessedAliases.add(name);
                   }
-                } else if (
-                  prop.type === 'Property' &&
-                  prop.value?.type === 'ObjectExpression' &&
-                  prop.key?.type === 'Identifier'
-                ) {
-                  findSpreads(prop.value, [...path, prop.key.name]);
+                } else if (prop.type === 'Property' && prop.value?.type === 'ObjectExpression') {
+                  const key =
+                    prop.key?.type === 'Identifier'
+                      ? prop.key.name
+                      : prop.key?.type === 'Literal' && typeof prop.key.value === 'string'
+                        ? prop.key.value
+                        : undefined;
+                  if (key) findSpreads(prop.value, [...path, key]);
                 }
               }
             };

--- a/packages/knip/test/namespaces/ns-spread-reexport.test.ts
+++ b/packages/knip/test/namespaces/ns-spread-reexport.test.ts
@@ -17,12 +17,13 @@ test('Should report members of re-exported spread namespace', async () => {
 
   assert(!issues.exports['hello.resolver.ts']);
   assert(!issues.exports['utils.ts']);
+  assert(!issues.exports['queues.ts']);
 
   assert.deepStrictEqual(counters, {
     ...baseCounters,
     exports: 3,
-    processed: 14,
-    total: 14,
+    processed: 15,
+    total: 15,
   });
 });
 
@@ -36,12 +37,13 @@ test('Should report members of re-exported spread namespace (with nsExports)', a
 
   assert(issues.nsExports['hello.resolver.ts']['resolverBarrel.Hello']);
   assert(issues.nsExports['utils.ts']['Utils.helper']);
+  assert(!issues.nsExports['queues.ts']);
 
   assert.deepStrictEqual(counters, {
     ...baseCounters,
     exports: 3,
     nsExports: 2,
-    processed: 14,
-    total: 14,
+    processed: 15,
+    total: 15,
   });
 });


### PR DESCRIPTION
Closes #2002

Nested namespace spreads under quoted object keys (e.g. 'my-queue') were skipped, so their exports were reported unused. findSpreads now recurses into string-literal keys too.