### PR TITLE
fix: don't flag a tag that suppresses member issues

### DIFF
--- a/packages/knip/fixtures/tags-hints/tag-suppresses-members/index.ts
+++ b/packages/knip/fixtures/tags-hints/tag-suppresses-members/index.ts
@@ -1,0 +1,5 @@
+import { isNormal, levels, timeout } from './utils.js';
+
+isNormal(1000);
+levels;
+timeout;

--- a/packages/knip/fixtures/tags-hints/tag-suppresses-members/knip.json
+++ b/packages/knip/fixtures/tags-hints/tag-suppresses-members/knip.json
@@ -1,0 +1,3 @@
+{
+  "tags": ["-knipignore"]
+}

--- a/packages/knip/fixtures/tags-hints/tag-suppresses-members/package.json
+++ b/packages/knip/fixtures/tags-hints/tag-suppresses-members/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/tag-suppresses-members"
+}

--- a/packages/knip/fixtures/tags-hints/tag-suppresses-members/status.ts
+++ b/packages/knip/fixtures/tags-hints/tag-suppresses-members/status.ts
@@ -1,0 +1,18 @@
+/** @knipignore */
+export enum StatusCode {
+  normal = 1000,
+  warning = 3000,
+  critical = 4000,
+}
+
+/** @knipignore */
+export enum Level {
+  low = 1,
+  high = 2,
+}
+
+/** @knipignore */
+export namespace Settings {
+  export const timeout = 1000;
+  export const retries = 3;
+}

--- a/packages/knip/fixtures/tags-hints/tag-suppresses-members/utils.ts
+++ b/packages/knip/fixtures/tags-hints/tag-suppresses-members/utils.ts
@@ -1,0 +1,7 @@
+import { Level, Settings, StatusCode } from './status.js';
+
+export const isNormal = (code: number) => code === StatusCode.normal;
+
+export const levels = [Level.low, Level.high];
+
+export const timeout = Settings.timeout;

--- a/packages/knip/src/graph/analyze.ts
+++ b/packages/knip/src/graph/analyze.ts
@@ -1,5 +1,5 @@
 import type { CatalogCounselor } from '../CatalogCounselor.ts';
-import type { ConfigurationChief } from '../ConfigurationChief.ts';
+import type { ConfigurationChief, Workspace } from '../ConfigurationChief.ts';
 import type { ConsoleStreamer } from '../ConsoleStreamer.ts';
 import type { DependencyDeputy } from '../DependencyDeputy.ts';
 import { createGraphExplorer } from '../graph-explorer/explorer.ts';
@@ -12,7 +12,7 @@ import {
 import type { IssueCollector } from '../IssueCollector.ts';
 import traceReporter from '../reporters/trace.ts';
 import type { CyclesConfig, IgnoreExportsUsedInFile } from '../types/config.ts';
-import type { Export, ModuleGraph } from '../types/module-graph.ts';
+import type { Export, ExportMember, ImportMaps, ModuleGraph } from '../types/module-graph.ts';
 import { shouldCountRefs } from '../typescript/ast-nodes.ts';
 import type { MainOptions } from '../util/create-options.ts';
 import { getPackageNameFromModuleSpecifier } from '../util/modules.ts';
@@ -100,6 +100,49 @@ export const analyze = async ({
     return false;
   };
 
+  const getMemberIssues = (
+    exportedItem: Export,
+    filePath: string,
+    identifier: string,
+    workspace: Workspace,
+    importsForExport: ImportMaps
+  ) => {
+    const isEnumMembers = options.includedIssueTypes.enumMembers && exportedItem.type === 'enum';
+    const isNsMembers =
+      options.includedIssueTypes.namespaceMembers && exportedItem.members.length > 0 && exportedItem.type !== 'enum';
+
+    if (!isEnumMembers && !isNsMembers) return;
+    if (exportedItem.members.length === 0) return;
+    if (explorer.isEnumerated(filePath, identifier)) return;
+    if (!options.includedIssueTypes.nsTypes && importsForExport.refs.has(identifier)) return;
+    if (isEnumMembers && hasStrictlyEnumReferences(importsForExport, identifier)) return;
+
+    const issueType: 'enumMembers' | 'namespaceMembers' = isEnumMembers ? 'enumMembers' : 'namespaceMembers';
+    const unusedMembers: ExportMember[] = [];
+    const ignoredMemberIds: string[] = [];
+
+    for (const member of exportedItem.members) {
+      if (findMatch(workspace.ignoreMembers, member.identifier)) continue;
+      if (shouldIgnore(member.jsDocTags)) continue;
+      if (member.hasRefsInFile) continue;
+
+      const id = `${identifier}.${member.identifier}`;
+      const [isMemberReferenced] = explorer.isReferenced(filePath, id, {
+        traverseEntries: true,
+        treatStarAtEntryAsReferenced: true,
+      });
+      const isMemberIgnored = shouldIgnoreTags(member.jsDocTags);
+
+      if (!isMemberReferenced) {
+        if (!isMemberIgnored) unusedMembers.push(member);
+      } else if (isMemberIgnored) {
+        ignoredMemberIds.push(id);
+      }
+    }
+
+    return { issueType, unusedMembers, ignoredMemberIds };
+  };
+
   const analyzeGraph = async () => {
     if (options.isReportValues || options.isReportTypes) {
       streamer.cast('Connecting the dots');
@@ -135,19 +178,26 @@ export const analyze = async ({
                 traverseEntries: isIncludeEntryExports,
               });
 
-              if (
-                isIgnored &&
-                (isReferenced ||
-                  isReferencedInUsedExport(exportedItem, filePath, isIncludeEntryExports, ignoreExportsUsedInFile))
-              ) {
-                for (const tagName of exportedItem.jsDocTags) {
-                  if (options.tags[1].includes(tagName) || (isInternalProd && tagName === INTERNAL_TAG)) {
-                    collector.addTagHint({ type: 'tag', filePath, identifier, tagName });
+              if (isIgnored) {
+                if (
+                  isReferenced ||
+                  isReferencedInUsedExport(exportedItem, filePath, isIncludeEntryExports, ignoreExportsUsedInFile)
+                ) {
+                  const memberIssues = isReferenced
+                    ? getMemberIssues(exportedItem, filePath, identifier, workspace, importsForExport)
+                    : undefined;
+
+                  if (!memberIssues || memberIssues.unusedMembers.length === 0) {
+                    for (const tagName of exportedItem.jsDocTags) {
+                      if (options.tags[1].includes(tagName) || (isInternalProd && tagName === INTERNAL_TAG)) {
+                        collector.addTagHint({ type: 'tag', filePath, identifier, tagName });
+                      }
+                    }
                   }
                 }
-              }
 
-              if (isIgnored) continue;
+                continue;
+              }
 
               if (reExportingEntryFile) {
                 if (!isIncludeEntryExports) {
@@ -161,51 +211,27 @@ export const analyze = async ({
               }
 
               if (isReferenced) {
-                const isEnumMembers = options.includedIssueTypes.enumMembers && exportedItem.type === 'enum';
-                const isNsMembers =
-                  options.includedIssueTypes.namespaceMembers &&
-                  exportedItem.members.length > 0 &&
-                  exportedItem.type !== 'enum';
+                const memberIssues = getMemberIssues(exportedItem, filePath, identifier, workspace, importsForExport);
 
-                if ((isEnumMembers || isNsMembers) && exportedItem.members.length > 0) {
-                  if (explorer.isEnumerated(filePath, identifier)) continue;
-                  if (!options.includedIssueTypes.nsTypes && importsForExport.refs.has(identifier)) continue;
-                  if (isEnumMembers && hasStrictlyEnumReferences(importsForExport, identifier)) continue;
+                if (memberIssues) {
+                  for (const member of memberIssues.unusedMembers) {
+                    collector.addIssue({
+                      type: memberIssues.issueType,
+                      filePath,
+                      workspace: workspace.name,
+                      symbol: member.identifier,
+                      parentSymbol: identifier,
+                      pos: member.pos,
+                      line: member.line,
+                      col: member.col,
+                      fixes: member.fix ? [member.fix] : [],
+                    });
+                  }
 
-                  const issueType = isEnumMembers ? 'enumMembers' : 'namespaceMembers';
-
-                  for (const member of exportedItem.members) {
-                    if (findMatch(workspace.ignoreMembers, member.identifier)) continue;
-                    if (shouldIgnore(member.jsDocTags)) continue;
-
-                    if (!member.hasRefsInFile) {
-                      const id = `${identifier}.${member.identifier}`;
-                      const [isMemberReferenced] = explorer.isReferenced(filePath, id, {
-                        traverseEntries: true,
-                        treatStarAtEntryAsReferenced: true,
-                      });
-                      const isIgnored = shouldIgnoreTags(member.jsDocTags);
-
-                      if (!isMemberReferenced) {
-                        if (isIgnored) continue;
-
-                        collector.addIssue({
-                          type: issueType,
-                          filePath,
-                          workspace: workspace.name,
-                          symbol: member.identifier,
-                          parentSymbol: identifier,
-                          pos: member.pos,
-                          line: member.line,
-                          col: member.col,
-                          fixes: member.fix ? [member.fix] : [],
-                        });
-                      } else if (isIgnored) {
-                        for (const tagName of exportedItem.jsDocTags) {
-                          if (options.tags[1].includes(tagName)) {
-                            collector.addTagHint({ type: 'tag', filePath, identifier: id, tagName });
-                          }
-                        }
+                  for (const id of memberIssues.ignoredMemberIds) {
+                    for (const tagName of exportedItem.jsDocTags) {
+                      if (options.tags[1].includes(tagName)) {
+                        collector.addTagHint({ type: 'tag', filePath, identifier: id, tagName });
                       }
                     }
                   }

--- a/packages/knip/test/tags-hints/tag-suppresses-members.test.ts
+++ b/packages/knip/test/tags-hints/tag-suppresses-members.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import { join } from '../../src/util/path.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/tags-hints/tag-suppresses-members');
+
+test('Do not flag a tag that suppresses member issues', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, tagHints, counters } = await main(options);
+
+  assert.deepEqual(
+    tagHints,
+    new Set([{ type: 'tag', filePath: join(cwd, 'status.ts'), identifier: 'Level', tagName: '@knipignore' }])
+  );
+
+  assert.equal(Object.keys(issues.enumMembers).length, 0);
+  assert.equal(Object.keys(issues.namespaceMembers).length, 0);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 3,
+    total: 3,
+  });
+});
+
+test('Report the members a tag suppresses when the tag is not configured', async () => {
+  const options = await createOptions({ cwd, tags: ['-unrelated'] });
+  const { issues, tagHints, counters } = await main(options);
+
+  assert(issues.enumMembers['status.ts']['StatusCode.warning']);
+  assert(issues.enumMembers['status.ts']['StatusCode.critical']);
+  assert(issues.namespaceMembers['status.ts']['Settings.retries']);
+  assert.equal(tagHints.size, 0);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    enumMembers: 2,
+    namespaceMembers: 1,
+    processed: 3,
+    total: 3,
+  });
+});


### PR DESCRIPTION
fixes #1957

A `@knipignore` tag on an export gets an "Unused tag" hint whenever the export itself is referenced. The check stops there. The same tag also exempts that export's members, so a tag that suppresses enum member or namespace member issues is reported as unused.

`analyze.ts` emitted the hint at the top of the export branch, then ran `if (isIgnored) continue;` before the member scan. At that point the code cannot know whether the tag suppressed anything.

The member scan now lives in `getMemberIssues`, and the export-level hint fires only when that scan finds nothing to report. The scan itself is unchanged: same guards, same order, same per-member checks. It had one call site before and it has two now, so the ignored branch and the reported branch ask the same question.

Measured on the new fixture. It holds three exports, each tagged `@knipignore`, with `tags: ["-knipignore"]` in `knip.json`:

| export | members used | members the tag hides | hint on main | hint on this branch |
|---|---|---|---|---|
| `StatusCode` (enum) | `normal` | `warning`, `critical` | yes | no |
| `Level` (enum) | `low`, `high` | none | yes | yes |
| `Settings` (namespace) | `timeout` | `retries` | yes | no |

`Level` is the control. Its tag really does nothing, so the hint stays.

The second test drops the exemption with `tags: ['-unrelated']`. It then reports what the tag hides: `StatusCode.warning`, `StatusCode.critical` and `Settings.retries`.

One note on the reporter's own reproduction. On `main` today it prints the hint, and that is now correct. #1956 landed, so `StatusCode[Number.parseInt(code)]` counts every member as used. The tag there hides nothing. The fixture reaches the same defect through a case that survives that fix, where one member of the enum is used by name.

Verified:

```
node scripts/run-test.js --runtime node    1101 passed, 0 failed
pnpm build                                 exit 0
pnpm exec oxlint                           no findings
pnpm exec oxfmt --check                    all matched files use the correct format
pnpm knip && pnpm knip:production          no findings
```

With the `analyze.ts` change reverted, the first new test fails and the second still passes.
