### PR TITLE
Mark the Knip CLI as a production entry

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,7 @@
       "project": ["!templates"]
     },
     "packages/knip": {
-      "entry": ["test/**/*.ts"],
+      "entry": ["src/cli.ts!", "test/**/*.ts"],
       "project": ["src/**/*.ts!", "!src/util/empty.ts", "!**/_template"],
       "ignoreDependencies": ["prettier"]
     },

--- a/packages/knip/fixtures/tags-hints/configuration-hints-production-entry/knip.json
+++ b/packages/knip/fixtures/tags-hints/configuration-hints-production-entry/knip.json
@@ -1,0 +1,4 @@
+{
+  "entry": ["src/cli.js!"],
+  "project": ["src/**/*.js!"]
+}

--- a/packages/knip/fixtures/tags-hints/configuration-hints-production-entry/package.json
+++ b/packages/knip/fixtures/tags-hints/configuration-hints-production-entry/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/configuration-hints-production-entry",
+  "scripts": {
+    "check": "node src/cli.js"
+  }
+}

--- a/packages/knip/src/WorkspaceWorker.ts
+++ b/packages/knip/src/WorkspaceWorker.ts
@@ -602,7 +602,7 @@ export class WorkspaceWorker {
     }
 
     for (const pattern of patterns) {
-      if (pattern.startsWith('!')) continue;
+      if (pattern.startsWith('!') || pattern.endsWith('!')) continue;
       const filePathOrPattern = join(this.dir, pattern.replace(/!$/, ''));
       if (includedPaths.has(filePathOrPattern)) {
         hints.push({ type: `${type}-redundant`, identifier: pattern, workspaceName });

--- a/packages/knip/test/tags-hints/configuration-hints.test.ts
+++ b/packages/knip/test/tags-hints/configuration-hints.test.ts
@@ -63,6 +63,17 @@ test('No hints when user overrides plugin entry config', async () => {
   });
 });
 
+test('No redundant entry hint for production entries', async () => {
+  const cwd = resolve('fixtures/tags-hints/configuration-hints-production-entry');
+  const options = await createOptions({ cwd });
+  const { configurationHints } = await main(options);
+
+  assert.deepEqual(
+    configurationHints.filter(hint => hint.type === 'entry-redundant'),
+    []
+  );
+});
+
 test('Hint when project pattern excludes an extension registered as a compiler', async () => {
   const cwd = resolve('fixtures/tags-hints/configuration-hints-extension-excluded');
   const options = await createOptions({ cwd });


### PR DESCRIPTION
## Summary

- mark the Knip CLI as a production entry
- avoid redundant-entry hints for production-only patterns
- add regression coverage for production entries also referenced by package scripts

## Testing

- `node --test test/tags-hints/configuration-hints.test.ts`
- `pnpm build`
- `pnpm knip`
- `pnpm knip:production`
- `pnpm --dir ../.. run ci`