### PR TITLE
fix(nuxt): resolve components imported from '#components'

### DIFF
--- a/packages/knip/fixtures/plugins/nuxt-auto-import/.nuxt/components.d.ts
+++ b/packages/knip/fixtures/plugins/nuxt-auto-import/.nuxt/components.d.ts
@@ -4,5 +4,6 @@ type LazyComponent<T> = T;
 
 export const AppHeader: typeof import('../components/AppHeader.vue').default;
 export const StatusBadge: typeof import('../components/StatusBadge.vue').default;
+export const VirtualOnly: typeof import('../components/VirtualOnly.vue').default;
 export const LazyAppHeader: LazyComponent<typeof import('../components/AppHeader.vue').default>;
 export const LazyStatusBadge: LazyComponent<typeof import('../components/StatusBadge.vue').default>;

--- a/packages/knip/fixtures/plugins/nuxt-auto-import/app.vue
+++ b/packages/knip/fixtures/plugins/nuxt-auto-import/app.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
+import type { VirtualOnly } from '#components';
+
 const { count } = useCounter();
 const date = ref(formatDate(new Date()));
 const theme = { default: 'system' };
+const badge = ref<InstanceType<typeof VirtualOnly>>();
 </script>
 
 <template>

--- a/packages/knip/fixtures/plugins/nuxt-auto-import/components/VirtualOnly.vue
+++ b/packages/knip/fixtures/plugins/nuxt-auto-import/components/VirtualOnly.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ label: string }>();
+</script>
+
+<template>
+  <span>{{ label }}</span>
+</template>

--- a/packages/knip/src/plugins/_vue/auto-import.ts
+++ b/packages/knip/src/plugins/_vue/auto-import.ts
@@ -227,6 +227,31 @@ const getSyntheticImports = (maps: AutoImportMaps, identifiers: Set<string>, tem
   return syntheticImports;
 };
 
+
+const virtualComponentsMatcher = /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"]#components['"]/g;
+
+/**
+ * Nuxt exposes auto-imported components through the `#components` virtual module.
+ * That specifier resolves to nothing on disk, so imports from it are ignored and
+ * the component files look unused. Map the named imports back to their files.
+ */
+const getVirtualComponentImports = (source: string, componentMap: Map<string, string[]>) => {
+  if (componentMap.size === 0 || !source.includes('#components')) return [];
+  const imports: string[] = [];
+  for (const [, names] of source.matchAll(virtualComponentsMatcher)) {
+    for (const binding of names.split(',')) {
+      const name = binding.replace(/^\s*type\s+/, '').trim().split(/\s+as\s+/)[0]?.trim();
+      if (!name) continue;
+      const specifiers = componentMap.get(name);
+      if (!specifiers) continue;
+      // aliased: the original binding is still in scope in the compiled output
+      imports.push(`import { default as ${name}$knip } from '${specifiers[0]}';`);
+      for (let i = 1; i < specifiers.length; i++) imports.push(`import '${specifiers[i]}';`);
+    }
+  }
+  return imports;
+};
+
 const compileVueSfc = (source: string, path: string, maps: AutoImportMaps, root: string) => {
   if (maps.importMap.size === 0 && maps.componentMap.size === 0) {
     return [scriptBodies(source, path), stylePreprocessorImports(source, path)].filter(Boolean).join(';\n');
@@ -263,6 +288,7 @@ const compileVueSfc = (source: string, path: string, maps: AutoImportMaps, root:
     for (const id of collectVue2TemplateIdentifiers(compiled.code)) identifiers.add(id);
   }
   scripts.push(...getSyntheticImports(maps, identifiers, templateTags));
+  scripts.push(...getVirtualComponentImports(source, maps.componentMap));
 
   const styles = stylePreprocessorImports(source, path);
   if (styles) scripts.push(styles);
@@ -271,8 +297,12 @@ const compileVueSfc = (source: string, path: string, maps: AutoImportMaps, root:
 };
 
 const compileTs = (source: string, path: string, maps: AutoImportMaps) => {
-  if (maps.importMap.size === 0 || path.endsWith('.d.ts') || path.endsWith('.config.ts')) return source;
-  const syntheticImports = getSyntheticImports(maps, collectIdentifiers(source, path));
+  if (path.endsWith('.d.ts') || path.endsWith('.config.ts')) return source;
+  if (maps.importMap.size === 0 && maps.componentMap.size === 0) return source;
+  const syntheticImports = [
+    ...(maps.importMap.size === 0 ? [] : getSyntheticImports(maps, collectIdentifiers(source, path))),
+    ...getVirtualComponentImports(source, maps.componentMap),
+  ];
   return syntheticImports.length === 0 ? source : `${source}\n${syntheticImports.join('\n')}`;
 };
 

--- a/packages/knip/test/plugins/nuxt-auto-import.test.ts
+++ b/packages/knip/test/plugins/nuxt-auto-import.test.ts
@@ -13,6 +13,8 @@ test('Find dependencies and entries through generated definitions in .nuxt dir',
 
   assert('composables/useTheme.ts' in issues.files);
   assert('components/StatusBadge.vue' in issues.files);
+  // only referenced through `import { VirtualOnly } from '#components'`
+  assert(!('components/VirtualOnly.vue' in issues.files));
 
   assert(issues.dependencies['package.json']['vue']);
   assert(issues.dependencies['package.json']['@vueuse/nuxt']);
@@ -24,7 +26,7 @@ test('Find dependencies and entries through generated definitions in .nuxt dir',
     files: 2,
     dependencies: 2,
     exports: 1,
-    processed: 7,
-    total: 7,
+    processed: 8,
+    total: 8,
   });
 });


### PR DESCRIPTION
Closes #2005.

### Problem

`#components` resolves to nothing on disk, so it is ignored as unresolved:

```ts
toIgnore('#components', 'unresolved'),
```

That suppresses the warning, but it also means a named import from it creates no reference — so a component used only this way is reported as an unused file:

```ts
import { LanguageSelect } from '#components'
```

Deleting such a file on that advice breaks the build:

```
[unimport] failed to find "LanguageSelect" imported from "#components"
```

In the repo where this surfaced, 12 of 105 reported unused files were live components imported this way.

### Fix

Map named imports from `#components` back to their files using the component map the plugin already builds from `.nuxt/components.d.ts` — the same source template-tag resolution uses. Bindings are aliased (`Foo$knip`) so the original import remains valid in the compiled output.

The `.ts` compiler path bailed out when the import map was empty, so it now also runs when only the component map is populated — `.ts` files importing from `#components` (typing a template ref, for instance) are covered too.

### Test

`nuxt-auto-import` gains `components/VirtualOnly.vue`, referenced **only** through `import type { VirtualOnly } from '#components'` in `app.vue` and never used as a tag, so it isolates this path.

- without the fix: `files: 3` — `VirtualOnly.vue` reported unused
- with the fix: `files: 2` — correctly resolved

Full suite on this machine: **992 pass / 107 fail**, against a baseline of **991 / 108** on the same checkout — one test fixed, nothing else changed. The 107 appear to be pre-existing environment failures here rather than anything related to this change.

### Note

`#imports` is likely affected the same way for auto-imported composables, but I have not touched it — happy to follow up if you would like it in the same shape.
