### PR TITLE
fix: support object-form Rstest test environments

### DIFF
--- a/packages/knip/fixtures/plugins/rstest/rstest.config.ts
+++ b/packages/knip/fixtures/plugins/rstest/rstest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  testEnvironment: { name: 'happy-dom', prebundle: 'auto' },
 });

--- a/packages/knip/fixtures/plugins/rstest/rstest.config.ts
+++ b/packages/knip/fixtures/plugins/rstest/rstest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: { name: 'happy-dom', prebundle: 'auto' },
+  testEnvironment: 'happy-dom',
 });

--- a/packages/knip/fixtures/plugins/rstest2/package.json
+++ b/packages/knip/fixtures/plugins/rstest2/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@plugins/rstest2",
   "devDependencies": {
-    "@rstest/core": "*"
+    "@rstest/core": "*",
+    "happy-dom": "*"
   }
 }

--- a/packages/knip/fixtures/plugins/rstest2/rstest.config.ts
+++ b/packages/knip/fixtures/plugins/rstest2/rstest.config.ts
@@ -3,4 +3,5 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   include: ['./*.test.ts'],
   exclude: ['./excluded.test.ts'],
+  testEnvironment: { name: 'happy-dom', prebundle: 'auto' },
 });

--- a/packages/knip/src/plugins/rstest/index.ts
+++ b/packages/knip/src/plugins/rstest/index.ts
@@ -21,8 +21,10 @@ const mocks = ['**/__mocks__/**/*.?(c|m)[jt]s?(x)'];
 const entry = ['**/*.{test,spec}.?(c|m)[jt]s?(x)'];
 
 function testEnvironment(config: RstestConfig) {
-  if (!config.testEnvironment || config.testEnvironment === 'node') return [];
-  return [config.testEnvironment];
+  const environment =
+    typeof config.testEnvironment === 'string' ? config.testEnvironment : config.testEnvironment?.name;
+  if (!environment || environment === 'node') return [];
+  return [environment];
 }
 
 const resolveConfig: ResolveConfig<RstestConfig> = async config => {

--- a/packages/knip/src/plugins/rstest/types.ts
+++ b/packages/knip/src/plugins/rstest/types.ts
@@ -4,7 +4,7 @@ export type RstestConfig = {
   // https://rstest.rs/config/test/exclude#exclude
   exclude?: string[];
   // https://rstest.rs/config/test/testenvironment#testenvironment
-  testEnvironment?: 'node' | 'jsdom' | 'happy-dom';
+  testEnvironment?: 'node' | 'jsdom' | 'happy-dom' | { name: 'node' | 'jsdom' | 'happy-dom' };
   // https://rstest.rs/config/test/setupFiles#setupfiles
   setupFiles?: string[];
 };


### PR DESCRIPTION
Closes #2009

Prevent crashes and resolve the configured environment name correctly.
