### PR TITLE
fix: honor explicit entry export analysis

### DIFF
--- a/packages/docs/src/content/docs/reference/configuration.md
+++ b/packages/docs/src/content/docs/reference/configuration.md
@@ -453,7 +453,8 @@ entry files when reporting unused exports:
 
 If enabled, Knip will report unused exports in entry source files. But not in
 entry and configuration files as configured by plugins, such as `next.config.js`
-or `src/routes/+page.svelte`.
+or `src/routes/+page.svelte`. Entry files discovered only through `package.json`
+scripts are also excluded; add them to `entry` to include their exports.
 
 This will also enable reporting unused members of exported enums and namespaces.
 

--- a/packages/knip/fixtures/entry/include-entry-exports-scripts/package.json
+++ b/packages/knip/fixtures/entry/include-entry-exports-scripts/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "index": "tsx ./src/index.ts",
     "module1": "tsx ./src/script1.ts",
     "module2": "tsx ./src/script2.ts",
     "module3": "tsx ./src/script3.ts"

--- a/packages/knip/fixtures/entry/include-entry-exports-scripts/src/index.ts
+++ b/packages/knip/fixtures/entry/include-entry-exports-scripts/src/index.ts
@@ -1,0 +1,4 @@
+const plugin = {};
+
+export { plugin };
+export default plugin;

--- a/packages/knip/fixtures/workspaces/include-entry-exports/package.json
+++ b/packages/knip/fixtures/workspaces/include-entry-exports/package.json
@@ -1,12 +1,19 @@
 {
   "name": "@fixtures/workspaces-include-entry-exports",
+  "scripts": {
+    "lib": "node packages/lib/index.js"
+  },
   "workspaces": [
     "packages/*"
   ],
   "knip": {
     "workspaces": {
-      "packages/app": {},
+      "packages/app": {
+        "entry": ["index.js"],
+        "includeEntryExports": true
+      },
       "packages/lib": {
+        "entry": ["index.js"],
         "includeEntryExports": true
       }
     }

--- a/packages/knip/fixtures/workspaces/include-entry-exports/packages/lib/package.json
+++ b/packages/knip/fixtures/workspaces/include-entry-exports/packages/lib/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "@fixtures/workspaces-include-entry-exports__lib"
+  "name": "@fixtures/workspaces-include-entry-exports__lib",
+  "scripts": {
+    "app": "node ../app/index.js"
+  }
 }

--- a/packages/knip/src/ProjectPrincipal.ts
+++ b/packages/knip/src/ProjectPrincipal.ts
@@ -31,6 +31,7 @@ export class ProjectPrincipal {
   projectPaths = new Set<string>();
   programPaths = new Set<string>();
   skipExportsAnalysis = new Set<string>();
+  private includeExportsAnalysis = new Set<string>();
 
   pluginCtx: PluginVisitorContext = {
     filePath: '',
@@ -164,7 +165,14 @@ export class ProjectPrincipal {
     if (!isInNodeModules(filePath) && this.hasAcceptedExtension(filePath)) {
       this.entryPaths.add(filePath);
       this.projectPaths.add(filePath);
-      if (options?.skipExportsAnalysis) this.skipExportsAnalysis.add(filePath);
+      if (options) {
+        if (options.skipExportsAnalysis) {
+          if (!this.includeExportsAnalysis.has(filePath)) this.skipExportsAnalysis.add(filePath);
+        } else {
+          this.includeExportsAnalysis.add(filePath);
+          this.skipExportsAnalysis.delete(filePath);
+        }
+      }
       this.onPathAdded?.(filePath);
     }
   }
@@ -190,6 +198,8 @@ export class ProjectPrincipal {
   removeProjectPath(filePath: string) {
     this.entryPaths.delete(filePath);
     this.projectPaths.delete(filePath);
+    this.skipExportsAnalysis.delete(filePath);
+    this.includeExportsAnalysis.delete(filePath);
     this.invalidateFile(filePath);
     this.deletedFiles.add(filePath);
   }

--- a/packages/knip/src/ProjectPrincipal.ts
+++ b/packages/knip/src/ProjectPrincipal.ts
@@ -59,6 +59,7 @@ export class ProjectPrincipal {
   toSourceFilePath: ToSourceFilePath;
   private findWorkspacePackageTarget: WorkspacePackageTargetHandler | undefined;
   private findWorkspaceNameByFilePath: (filePath: string) => string | undefined;
+  private isReportExports: boolean;
 
   fileManager: SourceFileManager;
   private resolveModule: ResolveModule = () => undefined;
@@ -78,6 +79,7 @@ export class ProjectPrincipal {
     this.toSourceFilePath = toSourceFilePath;
     this.findWorkspacePackageTarget = findWorkspacePackageTarget;
     this.findWorkspaceNameByFilePath = findWorkspaceNameByFilePath;
+    this.isReportExports = options.isReportExports;
     this.tsConfigFile = options.tsConfigFile ? toAbsolute(options.tsConfigFile, options.cwd) : undefined;
     this.pluginVisitorObjects.push(createBunShellVisitor(this.pluginCtx));
     this.fileManager = new SourceFileManager({
@@ -226,7 +228,7 @@ export class ProjectPrincipal {
         const isProjectPath = this.projectPaths.has(filePath);
 
         // Cached project files: skip read+parse and pass the cached FileNode through.
-        const cachedFile = isProjectPath ? this.cache.getCachedFile(filePath) : undefined;
+        const cachedFile = isProjectPath ? this.getCachedFile(filePath) : undefined;
 
         if (cachedFile) {
           const internalPaths = analyzeFile(filePath, undefined, '', cachedFile);
@@ -295,6 +297,12 @@ export class ProjectPrincipal {
     return Array.from(this.projectPaths).filter(filePath => !this.resolvedFiles.has(filePath));
   }
 
+  private getCachedFile(filePath: string) {
+    const cachedFile = this.cache.getCachedFile(filePath);
+    const skipExports = this.skipExportsAnalysis.has(filePath) || !this.isReportExports;
+    return cachedFile?.skipExports === skipExports ? cachedFile : undefined;
+  }
+
   analyzeSourceFile(
     filePath: string,
     options: GetImportsAndExportsOptions,
@@ -305,7 +313,7 @@ export class ProjectPrincipal {
   ) {
     if (cachedFile) return cachedFile;
 
-    const cached = this.cache.getCachedFile(filePath);
+    const cached = this.getCachedFile(filePath);
     if (cached) return cached;
 
     sourceText ??= this.fileManager.readFile(filePath);

--- a/packages/knip/src/graph/build.ts
+++ b/packages/knip/src/graph/build.ts
@@ -1,7 +1,7 @@
 import { _getInputsFromScripts } from '../binaries/index.ts';
 import type { ScriptParserContext } from '../binaries/create-script-parser-context.ts';
 import type { CatalogCounselor } from '../CatalogCounselor.ts';
-import type { ConfigurationChief, Workspace } from '../ConfigurationChief.ts';
+import { isDefaultPattern, type ConfigurationChief, type Workspace } from '../ConfigurationChief.ts';
 import type { ConsoleStreamer } from '../ConsoleStreamer.ts';
 import { getCompilerExtensions, getIncludedCompilers, normalizeCompilerExtension } from '../compilers/index.ts';
 import { DEFAULT_EXTENSIONS, FOREIGN_FILE_EXTENSIONS, IS_DTS } from '../constants.ts';
@@ -353,11 +353,15 @@ export async function build({
     }
 
     if (!options.isProduction) {
-      const hints = worker.getConfigurationHints('entry', userEntryPatterns, userEntryPaths, principal.entryPaths);
+      const includedPaths = config.isIncludeEntryExports
+        ? new Set([...principal.entryPaths].filter(filePath => !principal.skipExportsAnalysis.has(filePath)))
+        : principal.entryPaths;
+      const hints = worker.getConfigurationHints('entry', userEntryPatterns, userEntryPaths, includedPaths);
       for (const hint of hints) collector.addConfigurationHint(hint);
     }
 
-    principal.addEntryPaths(userEntryPaths);
+    const hasExplicitEntries = config.entry.some(pattern => !isDefaultPattern('entry', pattern));
+    principal.addEntryPaths(userEntryPaths, hasExplicitEntries ? { skipExportsAnalysis: false } : undefined);
 
     if (options.isUseTscFiles && isFile) {
       const isIgnoredWorkspace = chief.createIgnoredWorkspaceMatcher(name, dir);

--- a/packages/knip/src/graph/build.ts
+++ b/packages/knip/src/graph/build.ts
@@ -545,6 +545,7 @@ export async function build({
 
       const node = graph.get(filePath);
       if (node) {
+        node.skipExports = file.skipExports;
         node.imports = file.imports;
         node.exports = file.exports;
         node.duplicates = file.duplicates;

--- a/packages/knip/src/types/module-graph.ts
+++ b/packages/knip/src/types/module-graph.ts
@@ -81,6 +81,7 @@ type ExportMap = Map<Identifier, Export>;
 export type Imports = Set<Import>;
 
 export type FileNode = {
+  skipExports: boolean;
   imports: {
     readonly internal: ImportMap;
     readonly external: Set<Import>;

--- a/packages/knip/src/typescript/get-imports-and-exports.ts
+++ b/packages/knip/src/typescript/get-imports-and-exports.ts
@@ -436,6 +436,7 @@ const getImportsAndExports = (
   }
 
   return {
+    skipExports,
     imports: { internal, external, externalRefs: new Set(), programFiles, entryFiles, imports, unresolved },
     exports,
     duplicates: [...aliasedExports.values()],

--- a/packages/knip/src/util/module-graph.ts
+++ b/packages/knip/src/util/module-graph.ts
@@ -36,6 +36,7 @@ export const updateImportMap = (file: FileNode, importMap: ImportMap, graph: Mod
 };
 
 export const createFileNode = (): FileNode => ({
+  skipExports: false,
   imports: {
     internal: new Map(),
     external: new Set(),

--- a/packages/knip/test/entry/include-entry-exports-scripts.test.ts
+++ b/packages/knip/test/entry/include-entry-exports-scripts.test.ts
@@ -13,8 +13,8 @@ test('Skip unused exports in entry source files and scripts', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 5,
-    total: 5,
+    processed: 6,
+    total: 6,
   });
 });
 
@@ -25,7 +25,7 @@ test('Report unused exports in source files (skip for scripts and plugin entry f
   assert.deepEqual(counters, {
     ...baseCounters,
     exports: 0, // skip for scripts and plugin entry files
-    processed: 5,
-    total: 5,
+    processed: 6,
+    total: 6,
   });
 });

--- a/packages/knip/test/infra/cache-entry-policy.test.ts
+++ b/packages/knip/test/infra/cache-entry-policy.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { main } from '../../src/index.ts';
@@ -7,7 +7,7 @@ import { join } from '../../src/util/path.ts';
 import { createOptions } from '../helpers/create-options.ts';
 
 test('Cached files respect entry export policy changes', async () => {
-  const cwd = mkdtempSync(join(tmpdir(), 'knip-entry-policy-'));
+  const cwd = realpathSync(mkdtempSync(join(tmpdir(), 'knip-entry-policy-')));
   const cacheLocation = mkdtempSync(join(tmpdir(), 'knip-cache-'));
   const run = async () => main(await createOptions({ cwd, args: { cache: true, 'cache-location': cacheLocation } }));
 

--- a/packages/knip/test/infra/cache-entry-policy.test.ts
+++ b/packages/knip/test/infra/cache-entry-policy.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import { join } from '../../src/util/path.ts';
+import { createOptions } from '../helpers/create-options.ts';
+
+test('Cached files respect entry export policy changes', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'knip-entry-policy-'));
+  const cacheLocation = mkdtempSync(join(tmpdir(), 'knip-cache-'));
+  const run = async () => main(await createOptions({ cwd, args: { cache: true, 'cache-location': cacheLocation } }));
+
+  mkdirSync(join(cwd, 'src'));
+  writeFileSync(join(cwd, 'package.json'), '{"scripts":{"custom":"node src/custom.js"}}');
+  writeFileSync(join(cwd, 'knip.json'), '{"includeEntryExports":true,"project":["src/**/*.js"]}');
+  writeFileSync(join(cwd, 'src/custom.js'), 'export const unused = true;\n', { flag: 'wx' });
+
+  try {
+    assert.equal((await run()).counters.exports, 0);
+
+    writeFileSync(
+      join(cwd, 'knip.json'),
+      '{"includeEntryExports":true,"entry":["src/custom.js"],"project":["src/**/*.js"]}'
+    );
+    assert.equal((await run()).counters.exports, 1);
+
+    writeFileSync(join(cwd, 'knip.json'), '{"includeEntryExports":true,"project":["src/**/*.js"]}');
+    assert.equal((await run()).counters.exports, 0);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(cacheLocation, { recursive: true, force: true });
+  }
+});

--- a/packages/knip/test/workspaces/include-entry-exports.test.ts
+++ b/packages/knip/test/workspaces/include-entry-exports.test.ts
@@ -9,13 +9,15 @@ const cwd = resolve('fixtures/workspaces/include-entry-exports');
 
 test('Respect includeEntryExports per workspace', async () => {
   const options = await createOptions({ cwd });
-  const { issues, counters } = await main(options);
+  const { issues, counters, configurationHints } = await main(options);
 
+  assert(issues.exports['packages/app/index.js']['unused']);
   assert(issues.exports['packages/lib/index.js']['unused']);
+  assert.deepEqual(configurationHints, []);
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    exports: 1,
+    exports: 2,
     processed: 2,
     total: 2,
   });


### PR DESCRIPTION
Closes #2011

Explicit workspace entries now override script-derived export exemptions and avoid incorrect redundancy hints.
