### PR TITLE
Update raw transfer problems doc with low RAM machines

### DIFF
--- a/packages/docs/src/content/docs/reference/known-issues.md
+++ b/packages/docs/src/content/docs/reference/known-issues.md
@@ -83,9 +83,9 @@ The solution is to [disable the Nx Daemon][6]:
 NX_DAEMON=false knip
 ```
 
-## Windows raw transfer memory errors
+## Raw transfer memory errors
 
-On Windows with Node.js 22 or newer, oxc-parser raw transfer may fail under
+On machines with low RAM or Windows with Node.js >=22, oxc-parser raw transfer may fail under
 memory pressure:
 
 ```sh


### PR DESCRIPTION
In #1813, it was said that "... oxc-parser's raw-transfer path reserves a ~6 GiB ArrayBuffer per parse buffer. Windows has no overcommit, so that ~6 GiB is charged against the commit limit at allocation; under memory pressure the allocation throws."

Unfortunately, that doesn't seem to be the whole story, since I just got the same error on a 4GB RAM Raspberry Pi:
```
file:///home/andy/vigi-tools/node_modules/.pnpm/oxc-parser@0.147.0/node_modules/oxc-parser/src-js/raw-transfer/common.js:294
  const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
                      ^

RangeError: Array buffer allocation failed
    at new ArrayBuffer (<anonymous>)
    at createBuffer (file:///home/andy/vigi-tools/node_modules/.pnpm/oxc-parser@0.147.0/node_modules/oxc-parser/src-js/raw-transfer/common.js:294:23)
   ...
```

Without raw transfer, everything is fine.

Hence, I'm suggesting for the docs to include a mention of low RAM machines.