### PR TITLE
fix: recognize pnpm stage as built-in

### DIFF
--- a/packages/knip/src/binaries/resolvers/pnpm.ts
+++ b/packages/knip/src/binaries/resolvers/pnpm.ts
@@ -74,6 +74,7 @@ const commands = [
   'self-update',
   'server',
   'setup',
+  'stage',
   'start',
   'store',
   't',

--- a/packages/knip/test/util/get-inputs-from-scripts.test.ts
+++ b/packages/knip/test/util/get-inputs-from-scripts.test.ts
@@ -279,6 +279,7 @@ test('getInputsFromScripts (pnpm)', () => {
   t('pnpm runtime set node 22 -g', []);
   t('pnpm rt set node lts -g', []);
   t('pnpm sbom --sbom-format cyclonedx', []);
+  t('pnpm stage publish', []);
   t('pnpm pack-app --entry dist/index.cjs --target linux-x64', []);
   t('pnpm peers check', []);
   t('pnpm ping --registry https://registry.npmjs.org', []);


### PR DESCRIPTION
Closes #2013 

Prevents pnpm stage from being reported as an unlisted binary.