### PR TITLE
fix: throw when a sync compiler returns a promise

### DIFF
--- a/packages/docs/src/content/docs/features/compilers.md
+++ b/packages/docs/src/content/docs/features/compilers.md
@@ -80,7 +80,9 @@ The compiler function interface is straightforward. Text in, text out:
 (source: string, filename: string) => string;
 ```
 
-This may also be an `async` function.
+This may also be an `async` function. Knip uses the `async` keyword to tell sync
+and async compilers apart, so a regular function that returns a promise throws
+an error.
 
 ### Examples
 

--- a/packages/knip/fixtures/compilers/promise-sync/index.ts
+++ b/packages/knip/fixtures/compilers/promise-sync/index.ts
@@ -1,0 +1,1 @@
+import './styles.foo';

--- a/packages/knip/fixtures/compilers/promise-sync/knip.ts
+++ b/packages/knip/fixtures/compilers/promise-sync/knip.ts
@@ -1,0 +1,5 @@
+export default {
+  compilers: {
+    foo: (text: string) => Promise.resolve(text),
+  },
+};

--- a/packages/knip/fixtures/compilers/promise-sync/package.json
+++ b/packages/knip/fixtures/compilers/promise-sync/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/compilers-promise-sync",
+  "dependencies": {
+    "dep": "*"
+  }
+}

--- a/packages/knip/fixtures/compilers/promise-sync/styles.foo
+++ b/packages/knip/fixtures/compilers/promise-sync/styles.foo
@@ -1,0 +1,1 @@
+import 'dep';

--- a/packages/knip/src/typescript/SourceFileManager.ts
+++ b/packages/knip/src/typescript/SourceFileManager.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import type { AsyncCompilers, SyncCompilers } from '../compilers/types.ts';
 import { FOREIGN_FILE_EXTENSIONS } from '../constants.ts';
 import { debugLog } from '../util/debug.ts';
+import { ConfigurationError } from '../util/errors.ts';
 import { extname, isInternal } from '../util/path.ts';
 
 interface SourceFileManagerOptions {
@@ -34,7 +35,13 @@ export class SourceFileManager {
       return '';
     }
     const compiled = compiler ? compiler(contents, filePath) : contents;
-    if (compiler) debugLog('*', `Compiled ${filePath}`);
+    if (compiler) {
+      if (typeof compiled !== 'string')
+        throw new ConfigurationError(
+          `Compiler for ${ext} did not return a string (${filePath}), a compiler returning a promise must use the \`async\` keyword or be set in \`asyncCompilers\``
+        );
+      debugLog('*', `Compiled ${filePath}`);
+    }
     this.sourceTextCache.set(filePath, compiled);
     return compiled;
   }

--- a/packages/knip/test/compilers/promise-sync.test.ts
+++ b/packages/knip/test/compilers/promise-sync.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import { ConfigurationError } from '../../src/util/errors.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/compilers/promise-sync');
+
+test('Throw when a sync compiler returns a promise', async () => {
+  await assert.rejects(
+    async () => {
+      const options = await createOptions({ cwd });
+      await main(options);
+    },
+    error =>
+      error instanceof ConfigurationError &&
+      error.message.includes('Compiler for .foo did not return a string') &&
+      error.message.includes('asyncCompilers')
+  );
+});


### PR DESCRIPTION
Closes #1906, option 2 from the issue.

A compiler that returns a promise without the `async` keyword is classified as sync, because `isAsyncCompiler` in `src/compilers/index.ts` only checks `fn.constructor.name === 'AsyncFunction'`. `SourceFileManager.readFile` then puts the returned Promise object into `sourceTextCache` as the file's source text, so TypeScript sees no imports in that file and everything it referenced is reported unused. Nothing is logged, and `CompilerAsync` accepts both shapes, so a delegating compiler like `text => transpiler.transform(text)` lands on the broken side while looking correctly typed.

`readFile` now throws a `ConfigurationError` when a sync compiler returns a non-string:

```
ERROR: Compiler for .foo did not return a string (…/styles.foo), a compiler returning a promise must use the `async` keyword or be set in `asyncCompilers`
```

The check is inside the branch that already runs only when the extension has a compiler, so files without one are untouched.

`fixtures/compilers/promise-sync` is the reproduction from the issue: a `.foo` compiler written as `(text: string) => Promise.resolve(text)`, and a `.foo` file importing `dep`. On main, `knip` in that fixture exits 0 and reports `dep` as an unused dependency; with the change it reports the error above. Making the compiler `async` keeps the fixture clean either way, which is the whole trap.

Also added a line to the compilers page saying the `async` keyword is what Knip goes by.

Verification: `node --test test/compilers/promise-sync.test.ts` fails on main with "Missing expected rejection" and passes with the fix; `node --test 'test/compilers/*.test.ts'` 19/19; `pnpm run --dir packages/knip test` 1100/1100; `pnpm run ci`, `pnpm build`, `node ./src/cli.ts --directory ../..` and the same with `--production --strict` all clean on Node 22.
