### PR TITLE
fix: add a fallback to seach for lock file at `cwd` if its missing at the `root` level

### DIFF
--- a/packages/create-config/index.js
+++ b/packages/create-config/index.js
@@ -26,6 +26,18 @@ const readFirstBytes = (filePath, length = 128) => {
   return buffer.subarray(0, bytesRead).toString('utf-8');
 };
 
+const detectPackageManager = dir => {
+  if (fileExists(path.join(dir, 'bun.lock'))) return 'bun';
+  if (fileExists(path.join(dir, 'bun.lockb'))) return 'bun';
+  if (hasAccess(path.join(dir, 'yarn.lock'))) {
+    const yarnLock = readFirstBytes(path.join(dir, 'yarn.lock'), 128);
+    return yarnLock.includes('yarn lockfile v1') ? 'yarn' : 'yarn-berry';
+  }
+  if (fileExists(path.join(dir, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (fileExists(path.join(dir, 'package-lock.json'))) return 'npm';
+  if (fileExists(path.join(dir, 'npm-shrinkwrap.json'))) return 'npm';
+};
+
 const getPackageManager = () => {
   // get the root of the repository
   let repositoryRoot = '';
@@ -35,14 +47,14 @@ const getPackageManager = () => {
       .trim();
   } catch {}
 
-  if (fileExists(path.join(repositoryRoot, 'bun.lock'))) return 'bun';
-  if (fileExists(path.join(repositoryRoot, 'bun.lockb'))) return 'bun';
-  if (hasAccess(path.join(repositoryRoot, 'yarn.lock'))) {
-    const yarnLock = readFirstBytes(path.join(repositoryRoot, 'yarn.lock'), 128);
-    return yarnLock.includes('yarn lockfile v1') ? 'yarn' : 'yarn-berry';
+  const cwd = process.cwd();
+
+  if (repositoryRoot && path.resolve(repositoryRoot) !== cwd) {
+    const pm = detectPackageManager(repositoryRoot);
+    if (pm) return pm;
   }
-  if (fileExists(path.join(repositoryRoot, 'pnpm-lock.yaml'))) return 'pnpm';
-  return 'npm';
+
+  return detectPackageManager(cwd) ?? 'npm';
 };
 
 const getBinX = pm => {


### PR DESCRIPTION
Hey — small one. Ran into this setting knip up in a repo where the JS project isn't at the git root.

### Description

``npm create @knip/config`` picks the wrong package manager when the git root isn't the JS project root. In a `yarn` project it runs ``npm add -D knip ...``, which leaves a ``package-lock.json`` sitting next to the ``pnpm-lock.yaml``.
I was able to find it, because my package.json's setup has issues with `npm` `--legacy-peer-deps`. And it started to throw errors.

### Steps to reproduce

```sh
mkdir -p my-repo/frontend && cd my-repo && git init -q .   # git root, no lockfile
cd frontend && npm init -y && touch pnpm-lock.yaml
npm create @knip/config
```

Runs ``npm add -D knip typescript @types/node``. Should be ``pnpm add``.

### What's happening

https://github.com/webpro-nl/knip/blob/aaab35a948b458e3031989c13c13d099fdd6f229/packages/create-config/index.js#L29-L36

That's right for the common case, for monorepos — npm, pnpm, yarn and bun workspaces all keep a single lockfile at the workspace root, so a workspace package has none of its own. Looking in cwd would come up empty for every monorepo package.

The problem is it assumes ``git root == workspace root``. When that's not true nothing matches, we fall through to return 'npm', and then install in cwd — ``execSync(cmd, { stdio: 'inherit' })`` passes no cwd, so the child inherits ours. Detection reads one directory, the install happens in another.