### PR TITLE
Explain ambiguous star exports in traces

### DIFF
--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-barrel.ts
@@ -1,0 +1,2 @@
+export * from './alias-left';
+export * from './alias-right';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-left.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-left.ts
@@ -1,0 +1,3 @@
+export { leftShared as converged, apple as split } from './bindings';
+export { default as namedDefault } from './named-default';
+export { default as expressionDefault } from './expression-default';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-left.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-left.ts
@@ -1,3 +1,4 @@
 export { leftShared as converged, apple as split } from './bindings';
 export { default as namedDefault } from './named-default';
+export { default as declaredDefault } from './declared-default';
 export { default as expressionDefault } from './expression-default';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-right.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-right.ts
@@ -1,0 +1,3 @@
+export { rightShared as converged, pear as split } from './bindings';
+export { apple as namedDefault } from './named-default';
+export { apple as expressionDefault } from './expression-default';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-right.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/alias-right.ts
@@ -1,3 +1,4 @@
 export { rightShared as converged, pear as split } from './bindings';
 export { apple as namedDefault } from './named-default';
+export { apple as declaredDefault } from './declared-default';
 export { apple as expressionDefault } from './expression-default';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/barrel.ts
@@ -1,0 +1,2 @@
+export * from './fruits';
+export * from './vegetables';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/bindings.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/bindings.ts
@@ -1,0 +1,5 @@
+const shared = 'apple';
+const apple = 'apple';
+const pear = 'pear';
+
+export { shared as leftShared, shared as rightShared, apple, pear };

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-barrel.ts
@@ -1,0 +1,2 @@
+export * from './copy-left';
+export * from './copy-right';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-left.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-left.ts
@@ -1,3 +1,5 @@
 import { fruit } from './origin';
+import * as source from './origin';
 
 export const same = fruit;
+export const namespaceCopy = source;

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-left.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-left.ts
@@ -1,0 +1,3 @@
+import { fruit } from './origin';
+
+export const same = fruit;

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-right.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-right.ts
@@ -1,3 +1,5 @@
 import { fruit } from './origin';
+import * as source from './origin';
 
 export const same = fruit;
+export const namespaceCopy = source;

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-right.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/copy-right.ts
@@ -1,0 +1,3 @@
+import { fruit } from './origin';
+
+export const same = fruit;

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/cycle-a.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/cycle-a.ts
@@ -1,0 +1,2 @@
+export * from './cycle-b';
+export * from './cycle-left';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/cycle-b.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/cycle-b.ts
@@ -1,0 +1,2 @@
+export * from './cycle-a';
+export * from './cycle-right';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/cycle-left.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/cycle-left.ts
@@ -1,0 +1,1 @@
+export const cycleName = 'left';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/cycle-right.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/cycle-right.ts
@@ -1,0 +1,1 @@
+export const cycleName = 'right';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/declared-default.d.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/declared-default.d.ts
@@ -1,0 +1,3 @@
+export default function apple(): void;
+
+export { apple };

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/default-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/default-barrel.ts
@@ -1,0 +1,2 @@
+export * from './default-fruits';
+export * from './default-vegetables';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/default-fruits.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/default-fruits.ts
@@ -1,0 +1,1 @@
+export default 'apple';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/default-vegetables.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/default-vegetables.ts
@@ -1,0 +1,1 @@
+export default 'carrot';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/dynamic-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/dynamic-barrel.ts
@@ -1,0 +1,2 @@
+export * from './dynamic-left';
+export * from './dynamic-right';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/dynamic-left.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/dynamic-left.ts
@@ -1,0 +1,3 @@
+const source = await import('./origin');
+
+export { source as dynamicCopy };

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/dynamic-right.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/dynamic-right.ts
@@ -1,0 +1,3 @@
+const source = await import('./origin');
+
+export { source as dynamicCopy };

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/explicit-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/explicit-barrel.ts
@@ -1,0 +1,2 @@
+export { fruit } from './winner';
+export * from './shadowed';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/expression-default.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/expression-default.ts
@@ -1,0 +1,4 @@
+const apple = 'apple';
+
+export { apple };
+export default apple;

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/fruits.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/fruits.ts
@@ -1,0 +1,11 @@
+export const foo = () => 'apple';
+
+export class Entity {}
+
+export class TypeEntity {}
+
+export interface Model {
+  name: string;
+}
+
+export interface CrossNamespace {}

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/index.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/index.ts
@@ -1,0 +1,33 @@
+import { CrossNamespace, Entity, foo, type Model } from './barrel';
+import copied from './default-fruits';
+import copiedAgain from './default-vegetables';
+import './default-barrel';
+import { same } from './copy-barrel';
+import { converged, expressionDefault, namedDefault, split } from './alias-barrel';
+import { Produce } from './namespace-barrel';
+import { Produce as DistinctProduce } from './namespace-distinct-barrel';
+import { fruit as FruitNamespace } from './namespace-explicit-barrel';
+import { fruit as winner } from './explicit-barrel';
+import { cycleName } from './cycle-a';
+import type { TypeEntity } from './type-barrel';
+
+foo();
+const model: Model = { name: 'apple' };
+console.log(model);
+new Entity();
+console.log({} as TypeEntity);
+console.log(
+  CrossNamespace,
+  copied,
+  copiedAgain,
+  same,
+  converged,
+  split,
+  namedDefault,
+  expressionDefault,
+  Produce,
+  DistinctProduce.vegetable,
+  FruitNamespace,
+  winner,
+  cycleName
+);

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/index.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/index.ts
@@ -2,8 +2,8 @@ import { CrossNamespace, Entity, foo, type Model } from './barrel';
 import copied from './default-fruits';
 import copiedAgain from './default-vegetables';
 import './default-barrel';
-import { same } from './copy-barrel';
-import { converged, expressionDefault, namedDefault, split } from './alias-barrel';
+import { namespaceCopy, same } from './copy-barrel';
+import { converged, declaredDefault, expressionDefault, namedDefault, split } from './alias-barrel';
 import { Produce } from './namespace-barrel';
 import { Produce as DistinctProduce } from './namespace-distinct-barrel';
 import { fruit as FruitNamespace } from './namespace-explicit-barrel';
@@ -21,9 +21,11 @@ console.log(
   copied,
   copiedAgain,
   same,
+  namespaceCopy,
   converged,
   split,
   namedDefault,
+  declaredDefault,
   expressionDefault,
   Produce,
   DistinctProduce.vegetable,

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/index.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/index.ts
@@ -3,12 +3,14 @@ import copied from './default-fruits';
 import copiedAgain from './default-vegetables';
 import './default-barrel';
 import { namespaceCopy, same } from './copy-barrel';
+import { dynamicCopy } from './dynamic-barrel';
 import { converged, declaredDefault, expressionDefault, namedDefault, split } from './alias-barrel';
 import { Produce } from './namespace-barrel';
 import { Produce as DistinctProduce } from './namespace-distinct-barrel';
 import { fruit as FruitNamespace } from './namespace-explicit-barrel';
 import { fruit as winner } from './explicit-barrel';
 import { cycleName } from './cycle-a';
+import { Basket } from './member-barrel';
 import type { TypeEntity } from './type-barrel';
 
 foo();
@@ -22,6 +24,7 @@ console.log(
   copiedAgain,
   same,
   namespaceCopy,
+  dynamicCopy,
   converged,
   split,
   namedDefault,
@@ -31,5 +34,6 @@ console.log(
   DistinctProduce.vegetable,
   FruitNamespace,
   winner,
-  cycleName
+  cycleName,
+  Basket.fruit
 );

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/member-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/member-barrel.ts
@@ -1,0 +1,6 @@
+export * from './winner';
+export * from './shadowed';
+
+export enum Basket {
+  fruit = 1,
+}

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/named-default.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/named-default.ts
@@ -1,0 +1,3 @@
+export default function apple() {}
+
+export { apple };

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-barrel.ts
@@ -1,0 +1,2 @@
+export * from './namespace-left';
+export * from './namespace-right';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-distinct-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-distinct-barrel.ts
@@ -1,0 +1,2 @@
+export * from './namespace-left';
+export * from './namespace-distinct';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-distinct.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-distinct.ts
@@ -1,0 +1,1 @@
+export * as Produce from './namespace-origin-two';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-explicit-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-explicit-barrel.ts
@@ -1,0 +1,3 @@
+export * as fruit from './origin';
+export * from './winner';
+export * from './shadowed';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-left.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-left.ts
@@ -1,0 +1,1 @@
+export * as Produce from './origin';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-origin-two.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-origin-two.ts
@@ -1,0 +1,1 @@
+export const vegetable = 'carrot';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-right.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/namespace-right.ts
@@ -1,0 +1,1 @@
+export * as Produce from './origin';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/origin.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/origin.ts
@@ -1,0 +1,1 @@
+export const fruit = 'apple';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/package.json
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/re-exports-ambiguous-barrel"
+}

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/shadowed.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/shadowed.ts
@@ -1,0 +1,1 @@
+export const fruit = 'pear';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/type-barrel.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/type-barrel.ts
@@ -1,0 +1,2 @@
+export type * from './fruits';
+export type * from './vegetables';

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/vegetables.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/vegetables.ts
@@ -1,0 +1,11 @@
+export const foo = () => 'carrot';
+
+export class Entity {}
+
+export class TypeEntity {}
+
+export interface Model {
+  name: string;
+}
+
+export const CrossNamespace = 1;

--- a/packages/knip/fixtures/re-exports/ambiguous-barrel/winner.ts
+++ b/packages/knip/fixtures/re-exports/ambiguous-barrel/winner.ts
@@ -1,0 +1,1 @@
+export const fruit = 'apple';

--- a/packages/knip/src/graph-explorer/explorer.ts
+++ b/packages/knip/src/graph-explorer/explorer.ts
@@ -3,6 +3,7 @@ import { invalidateCache as invalidateCacheInternal } from './cache.ts';
 import { buildExportsTree } from './operations/build-exports-tree.ts';
 import { findAllCycles } from './operations/find-all-cycles.ts';
 import { findCycles } from './operations/find-cycles.ts';
+import { getAmbiguousStarExport } from './operations/get-ambiguous-star-export.ts';
 import { getContention } from './operations/get-contention.ts';
 import { getDependencyUsage } from './operations/get-dependency-usage.ts';
 import { getUsage } from './operations/get-usage.ts';
@@ -28,6 +29,8 @@ export const createGraphExplorer = (graph: ModuleGraph, entryPaths: Set<string>)
       isEnumerated(graph, filePath, graph.get(filePath)?.importedBy, identifier),
     buildExportsTree: (options: { filePath?: string; identifier?: string }) =>
       buildExportsTree(graph, entryPaths, options),
+    getAmbiguousStarExport: (filePath: string, identifier: string) =>
+      getAmbiguousStarExport(graph, filePath, identifier),
     getDependencyUsage: (pattern?: string | RegExp) => getDependencyUsage(graph, pattern),
     resolveDefinition: (filePath: string, identifier: string) => resolveDefinition(graph, filePath, identifier),
     getUsage: (filePath: string, identifier: string) => getUsage(graph, entryPaths, filePath, identifier),

--- a/packages/knip/src/graph-explorer/operations/get-ambiguous-star-export.ts
+++ b/packages/knip/src/graph-explorer/operations/get-ambiguous-star-export.ts
@@ -1,0 +1,25 @@
+import type { ModuleGraph } from '../../types/module-graph.ts';
+import { createExportOriginResolver, type ExportNamespace } from './resolve-export-origins.ts';
+
+export interface AmbiguousStarExport {
+  namespaces: ExportNamespace[];
+  origins: { filePath: string; identifier: string }[];
+}
+
+export const getAmbiguousStarExport = (
+  graph: ModuleGraph,
+  filePath: string,
+  identifier: string
+): AmbiguousStarExport | undefined => {
+  if (identifier === 'default') return;
+  const resolution = createExportOriginResolver(graph)(filePath, identifier);
+  if (resolution.hasExplicitExport || resolution.origins.length < 2) return;
+
+  const namespaces = new Set<ExportNamespace>();
+  const origins = [];
+  for (const origin of resolution.origins) {
+    for (const namespace of origin.namespaces) namespaces.add(namespace);
+    origins.push({ filePath: origin.filePath, identifier: origin.identifier });
+  }
+  return { namespaces: [...namespaces], origins };
+};

--- a/packages/knip/src/graph-explorer/operations/get-ambiguous-star-export.ts
+++ b/packages/knip/src/graph-explorer/operations/get-ambiguous-star-export.ts
@@ -1,8 +1,7 @@
 import type { ModuleGraph } from '../../types/module-graph.ts';
-import { createExportOriginResolver, type ExportNamespace } from './resolve-export-origins.ts';
+import { createExportOriginResolver } from './resolve-export-origins.ts';
 
 export interface AmbiguousStarExport {
-  namespaces: ExportNamespace[];
   origins: { filePath: string; identifier: string }[];
 }
 
@@ -15,11 +14,9 @@ export const getAmbiguousStarExport = (
   const resolution = createExportOriginResolver(graph)(filePath, identifier);
   if (resolution.hasExplicitExport || resolution.origins.length < 2) return;
 
-  const namespaces = new Set<ExportNamespace>();
   const origins = [];
   for (const origin of resolution.origins) {
-    for (const namespace of origin.namespaces) namespaces.add(namespace);
     origins.push({ filePath: origin.filePath, identifier: origin.identifier });
   }
-  return { namespaces: [...namespaces], origins };
+  return { origins };
 };

--- a/packages/knip/src/graph-explorer/operations/resolve-export-origins.ts
+++ b/packages/knip/src/graph-explorer/operations/resolve-export-origins.ts
@@ -90,23 +90,13 @@ export const createExportOriginResolver = (graph: ModuleGraph) => {
         for (const [sourcePath, imports] of node.imports.internal) {
           if (getPassThroughReExportSources(imports, identifier)) {
             addResolution(
-              resolve(
-                sourcePath,
-                identifier,
-                isTypeOnly || isTypeOnlyEdge(node, sourcePath, identifier),
-                seen
-              )
+              resolve(sourcePath, identifier, isTypeOnly || isTypeOnlyEdge(node, sourcePath, identifier), seen)
             );
           }
           forEachAliasReExport(imports, (sourceId, alias) => {
             if (alias !== identifier) return;
             addResolution(
-              resolve(
-                sourcePath,
-                sourceId,
-                isTypeOnly || isTypeOnlyEdge(node, sourcePath, sourceId),
-                seen
-              )
+              resolve(sourcePath, sourceId, isTypeOnly || isTypeOnlyEdge(node, sourcePath, sourceId), seen)
             );
           });
         }
@@ -126,12 +116,7 @@ export const createExportOriginResolver = (graph: ModuleGraph) => {
       for (const [sourcePath, imports] of node.imports.internal) {
         if (!getStarReExportSources(imports)) continue;
         addResolution(
-          resolve(
-            sourcePath,
-            identifier,
-            isTypeOnly || isTypeOnlyEdge(node, sourcePath, IMPORT_STAR),
-            seen
-          )
+          resolve(sourcePath, identifier, isTypeOnly || isTypeOnlyEdge(node, sourcePath, IMPORT_STAR), seen)
         );
       }
     }

--- a/packages/knip/src/graph-explorer/operations/resolve-export-origins.ts
+++ b/packages/knip/src/graph-explorer/operations/resolve-export-origins.ts
@@ -1,0 +1,145 @@
+import { IMPORT_STAR, SYMBOL_TYPE } from '../../constants.ts';
+import type { FileNode, ModuleGraph } from '../../types/module-graph.ts';
+import {
+  forEachAliasReExport,
+  getNamespaceReExportSources,
+  getPassThroughReExportSources,
+  getStarReExportSources,
+} from '../visitors.ts';
+
+export type ExportNamespace = 'type' | 'value';
+
+export interface ExportOrigin {
+  filePath: string;
+  identifier: string;
+  namespaces: ExportNamespace[];
+}
+
+export interface ExportOriginResolution {
+  origins: ExportOrigin[];
+  hasExplicitExport: boolean;
+}
+
+const getNamespaces = (type: string, isTypeOnly: boolean): ExportNamespace[] => {
+  if (isTypeOnly || type === SYMBOL_TYPE.TYPE || type === SYMBOL_TYPE.INTERFACE) return ['type'];
+  if (type === SYMBOL_TYPE.CLASS || type === SYMBOL_TYPE.ENUM || type === SYMBOL_TYPE.NAMESPACE)
+    return ['type', 'value'];
+  return ['value'];
+};
+
+const isTypeOnlyEdge = (node: FileNode, sourcePath: string, identifier: string) => {
+  let isMatch = false;
+  let isTypeOnly = true;
+  for (const item of node.imports.imports) {
+    if (item.filePath !== sourcePath || item.identifier !== identifier) continue;
+    isMatch = true;
+    isTypeOnly &&= item.isTypeOnly;
+  }
+  return isMatch && isTypeOnly;
+};
+
+export const createExportOriginResolver = (graph: ModuleGraph) => {
+  const cache = new Map<string, ExportOriginResolution>();
+
+  const resolve = (
+    filePath: string,
+    identifier: string,
+    isTypeOnly = false,
+    seen = new Set<string>()
+  ): ExportOriginResolution => {
+    const key = `${filePath}:${identifier}:${isTypeOnly}`;
+    const isRoot = seen.size === 0;
+    const cached = isRoot ? cache.get(key) : undefined;
+    if (cached) return cached;
+    if (seen.has(key)) return { origins: [], hasExplicitExport: false };
+    seen.add(key);
+
+    const node = graph.get(filePath);
+    if (!node) return { origins: [], hasExplicitExport: false };
+
+    const origins = new Map<string, ExportOrigin>();
+    const addOrigin = (origin: ExportOrigin, typeOnly = isTypeOnly) => {
+      const namespaces: ExportNamespace[] = typeOnly ? ['type'] : origin.namespaces;
+      const originKey = `${origin.filePath}:${origin.identifier}`;
+      const existing = origins.get(originKey);
+      if (!existing) {
+        origins.set(originKey, { ...origin, namespaces: [...namespaces] });
+        return;
+      }
+      for (const namespace of namespaces)
+        if (!existing.namespaces.includes(namespace)) existing.namespaces.push(namespace);
+    };
+    const addResolution = (resolution: ExportOriginResolution, typeOnly = isTypeOnly) => {
+      for (const origin of resolution.origins) addOrigin(origin, typeOnly);
+    };
+    const exp = node.exports.get(identifier);
+    let hasExplicitExport = !!exp;
+
+    for (const [sourcePath, imports] of node.imports.internal) {
+      if (!getNamespaceReExportSources(imports, identifier)) continue;
+      hasExplicitExport = true;
+      addOrigin({
+        filePath: sourcePath,
+        identifier: IMPORT_STAR,
+        namespaces: isTypeOnlyEdge(node, sourcePath, identifier) ? ['type'] : ['type', 'value'],
+      });
+    }
+
+    if (exp) {
+      if (exp.isBindingReExport) {
+        for (const [sourcePath, imports] of node.imports.internal) {
+          if (getPassThroughReExportSources(imports, identifier)) {
+            addResolution(
+              resolve(
+                sourcePath,
+                identifier,
+                isTypeOnly || isTypeOnlyEdge(node, sourcePath, identifier),
+                seen
+              )
+            );
+          }
+          forEachAliasReExport(imports, (sourceId, alias) => {
+            if (alias !== identifier) return;
+            addResolution(
+              resolve(
+                sourcePath,
+                sourceId,
+                isTypeOnly || isTypeOnlyEdge(node, sourcePath, sourceId),
+                seen
+              )
+            );
+          });
+        }
+      }
+      if (origins.size === 0 && !exp.isBindingReExport) {
+        addOrigin({ filePath, identifier: exp.binding, namespaces: getNamespaces(exp.type, isTypeOnly) });
+      }
+    }
+
+    if (hasExplicitExport) {
+      const resolution = { origins: [...origins.values()], hasExplicitExport };
+      if (isRoot) cache.set(key, resolution);
+      return resolution;
+    }
+
+    if (identifier !== 'default') {
+      for (const [sourcePath, imports] of node.imports.internal) {
+        if (!getStarReExportSources(imports)) continue;
+        addResolution(
+          resolve(
+            sourcePath,
+            identifier,
+            isTypeOnly || isTypeOnlyEdge(node, sourcePath, IMPORT_STAR),
+            seen
+          )
+        );
+      }
+    }
+
+    const resolution = { origins: [...origins.values()], hasExplicitExport };
+    if (isRoot) cache.set(key, resolution);
+    return resolution;
+  };
+
+  return (filePath: string, identifier: string) => resolve(filePath, identifier);
+};

--- a/packages/knip/src/graph-explorer/operations/resolve-export-origins.ts
+++ b/packages/knip/src/graph-explorer/operations/resolve-export-origins.ts
@@ -1,5 +1,5 @@
-import { IMPORT_STAR, SYMBOL_TYPE } from '../../constants.ts';
-import type { FileNode, ModuleGraph } from '../../types/module-graph.ts';
+import { IMPORT_STAR } from '../../constants.ts';
+import type { ModuleGraph } from '../../types/module-graph.ts';
 import {
   forEachAliasReExport,
   getNamespaceReExportSources,
@@ -7,12 +7,9 @@ import {
   getStarReExportSources,
 } from '../visitors.ts';
 
-export type ExportNamespace = 'type' | 'value';
-
 export interface ExportOrigin {
   filePath: string;
   identifier: string;
-  namespaces: ExportNamespace[];
 }
 
 export interface ExportOriginResolution {
@@ -20,34 +17,11 @@ export interface ExportOriginResolution {
   hasExplicitExport: boolean;
 }
 
-const getNamespaces = (type: string, isTypeOnly: boolean): ExportNamespace[] => {
-  if (isTypeOnly || type === SYMBOL_TYPE.TYPE || type === SYMBOL_TYPE.INTERFACE) return ['type'];
-  if (type === SYMBOL_TYPE.CLASS || type === SYMBOL_TYPE.ENUM || type === SYMBOL_TYPE.NAMESPACE)
-    return ['type', 'value'];
-  return ['value'];
-};
-
-const isTypeOnlyEdge = (node: FileNode, sourcePath: string, identifier: string) => {
-  let isMatch = false;
-  let isTypeOnly = true;
-  for (const item of node.imports.imports) {
-    if (item.filePath !== sourcePath || item.identifier !== identifier) continue;
-    isMatch = true;
-    isTypeOnly &&= item.isTypeOnly;
-  }
-  return isMatch && isTypeOnly;
-};
-
 export const createExportOriginResolver = (graph: ModuleGraph) => {
   const cache = new Map<string, ExportOriginResolution>();
 
-  const resolve = (
-    filePath: string,
-    identifier: string,
-    isTypeOnly = false,
-    seen = new Set<string>()
-  ): ExportOriginResolution => {
-    const key = `${filePath}:${identifier}:${isTypeOnly}`;
+  const resolve = (filePath: string, identifier: string, seen = new Set<string>()): ExportOriginResolution => {
+    const key = `${filePath}:${identifier}`;
     const isRoot = seen.size === 0;
     const cached = isRoot ? cache.get(key) : undefined;
     if (cached) return cached;
@@ -58,51 +32,37 @@ export const createExportOriginResolver = (graph: ModuleGraph) => {
     if (!node) return { origins: [], hasExplicitExport: false };
 
     const origins = new Map<string, ExportOrigin>();
-    const addOrigin = (origin: ExportOrigin, typeOnly = isTypeOnly) => {
-      const namespaces: ExportNamespace[] = typeOnly ? ['type'] : origin.namespaces;
+    const addOrigin = (origin: ExportOrigin) => {
       const originKey = `${origin.filePath}:${origin.identifier}`;
-      const existing = origins.get(originKey);
-      if (!existing) {
-        origins.set(originKey, { ...origin, namespaces: [...namespaces] });
-        return;
-      }
-      for (const namespace of namespaces)
-        if (!existing.namespaces.includes(namespace)) existing.namespaces.push(namespace);
+      if (!origins.has(originKey)) origins.set(originKey, origin);
     };
-    const addResolution = (resolution: ExportOriginResolution, typeOnly = isTypeOnly) => {
-      for (const origin of resolution.origins) addOrigin(origin, typeOnly);
+    const addResolution = (resolution: ExportOriginResolution) => {
+      for (const origin of resolution.origins) addOrigin(origin);
     };
     const exp = node.exports.get(identifier);
     let hasExplicitExport = !!exp;
 
     for (const [sourcePath, imports] of node.imports.internal) {
+      if (exp && !exp.isBindingReExport) continue;
       if (!getNamespaceReExportSources(imports, identifier)) continue;
       hasExplicitExport = true;
-      addOrigin({
-        filePath: sourcePath,
-        identifier: IMPORT_STAR,
-        namespaces: isTypeOnlyEdge(node, sourcePath, identifier) ? ['type'] : ['type', 'value'],
-      });
+      addOrigin({ filePath: sourcePath, identifier: IMPORT_STAR });
     }
 
     if (exp) {
       if (exp.isBindingReExport) {
         for (const [sourcePath, imports] of node.imports.internal) {
           if (getPassThroughReExportSources(imports, identifier)) {
-            addResolution(
-              resolve(sourcePath, identifier, isTypeOnly || isTypeOnlyEdge(node, sourcePath, identifier), seen)
-            );
+            addResolution(resolve(sourcePath, identifier, seen));
           }
           forEachAliasReExport(imports, (sourceId, alias) => {
             if (alias !== identifier) return;
-            addResolution(
-              resolve(sourcePath, sourceId, isTypeOnly || isTypeOnlyEdge(node, sourcePath, sourceId), seen)
-            );
+            addResolution(resolve(sourcePath, sourceId, seen));
           });
         }
       }
       if (origins.size === 0 && !exp.isBindingReExport) {
-        addOrigin({ filePath, identifier: exp.binding, namespaces: getNamespaces(exp.type, isTypeOnly) });
+        addOrigin({ filePath, identifier: exp.binding });
       }
     }
 
@@ -115,9 +75,7 @@ export const createExportOriginResolver = (graph: ModuleGraph) => {
     if (identifier !== 'default') {
       for (const [sourcePath, imports] of node.imports.internal) {
         if (!getStarReExportSources(imports)) continue;
-        addResolution(
-          resolve(sourcePath, identifier, isTypeOnly || isTypeOnlyEdge(node, sourcePath, IMPORT_STAR), seen)
-        );
+        addResolution(resolve(sourcePath, identifier, seen));
       }
     }
 

--- a/packages/knip/src/reporters/trace.ts
+++ b/packages/knip/src/reporters/trace.ts
@@ -80,12 +80,7 @@ export default ({ graph, explorer, options, workspaceFilePathFilter, issues }: T
       const collision = traceFile && traceExport ? explorer.getAmbiguousStarExport(traceFile, traceExport) : undefined;
       if (collision) {
         collision.origins.sort((a, b) => compareStrings(a.filePath, b.filePath));
-        const namespaces = collision.namespaces.join(' and ');
-        const namespaceLabel =
-          collision.namespaces.length === 1 ? `${namespaces} namespace` : `${namespaces} namespaces`;
-        console.log(
-          `Ambiguous export ${st.cyanBright(traceExport ?? '')} in ${toRel(traceFile ?? '')}: competing export * origins in the ${namespaceLabel}`
-        );
+        console.log(`${toRel(traceFile ?? '')}:${st.cyanBright(traceExport ?? '')} [ambiguous]`);
         for (let i = 0; i < collision.origins.length; i++) {
           const origin = collision.origins[i];
           const connector = i === collision.origins.length - 1 ? '└──' : '├──';

--- a/packages/knip/src/reporters/trace.ts
+++ b/packages/knip/src/reporters/trace.ts
@@ -43,6 +43,24 @@ export default ({ graph, explorer, options, workspaceFilePathFilter, issues }: T
     else for (const line of rows) console.log(line);
   } else {
     let nodes = explorer.buildExportsTree({ filePath: options.traceFile, identifier: options.traceExport });
+    const traceFile = options.traceFile;
+    const traceExport = options.traceExport;
+    const dotIndex = traceExport?.indexOf('.') ?? -1;
+    const resolvedTraceExport = dotIndex === -1 ? traceExport : traceExport?.slice(0, dotIndex);
+    const collision =
+      traceFile && resolvedTraceExport ? explorer.getAmbiguousStarExport(traceFile, resolvedTraceExport) : undefined;
+    const toRel = (path: string) => toRelative(path, options.cwd);
+
+    if (collision) {
+      collision.origins.sort((a, b) => compareStrings(a.filePath, b.filePath));
+      console.log(`${toRel(traceFile ?? '')}:${st.cyanBright(resolvedTraceExport ?? '')} [ambiguous]`);
+      for (let i = 0; i < collision.origins.length; i++) {
+        const origin = collision.origins[i];
+        const connector = i === collision.origins.length - 1 ? '└──' : '├──';
+        console.log(`${st.dim(connector)} ${toRel(origin.filePath)}:${st.cyanBright(origin.identifier)}`);
+      }
+      return;
+    }
 
     // Fallback: resolve dotted name as namespace member (e.g. Fruits.apple → Fruits)
     if (nodes.length === 0 && options.traceExport?.includes('.')) {
@@ -72,22 +90,8 @@ export default ({ graph, explorer, options, workspaceFilePathFilter, issues }: T
     }
 
     nodes.sort((a, b) => compareStrings(a.filePath, b.filePath) || compareStrings(a.identifier, b.identifier));
-    const toRel = (path: string) => toRelative(path, options.cwd);
 
     if (nodes.length === 0) {
-      const traceFile = options.traceFile;
-      const traceExport = options.traceExport;
-      const collision = traceFile && traceExport ? explorer.getAmbiguousStarExport(traceFile, traceExport) : undefined;
-      if (collision) {
-        collision.origins.sort((a, b) => compareStrings(a.filePath, b.filePath));
-        console.log(`${toRel(traceFile ?? '')}:${st.cyanBright(traceExport ?? '')} [ambiguous]`);
-        for (let i = 0; i < collision.origins.length; i++) {
-          const origin = collision.origins[i];
-          const connector = i === collision.origins.length - 1 ? '└──' : '├──';
-          console.log(`${st.dim(connector)} ${toRel(origin.filePath)}:${st.cyanBright(origin.identifier)}`);
-        }
-        return;
-      }
       if (options.traceFile && !graph.has(options.traceFile)) {
         console.log(`File not found in module graph: ${toRel(options.traceFile)}`);
       } else {

--- a/packages/knip/src/reporters/trace.ts
+++ b/packages/knip/src/reporters/trace.ts
@@ -75,6 +75,24 @@ export default ({ graph, explorer, options, workspaceFilePathFilter, issues }: T
     const toRel = (path: string) => toRelative(path, options.cwd);
 
     if (nodes.length === 0) {
+      const traceFile = options.traceFile;
+      const traceExport = options.traceExport;
+      const collision = traceFile && traceExport ? explorer.getAmbiguousStarExport(traceFile, traceExport) : undefined;
+      if (collision) {
+        collision.origins.sort((a, b) => compareStrings(a.filePath, b.filePath));
+        const namespaces = collision.namespaces.join(' and ');
+        const namespaceLabel =
+          collision.namespaces.length === 1 ? `${namespaces} namespace` : `${namespaces} namespaces`;
+        console.log(
+          `Ambiguous export ${st.cyanBright(traceExport ?? '')} in ${toRel(traceFile ?? '')}: competing export * origins in the ${namespaceLabel}`
+        );
+        for (let i = 0; i < collision.origins.length; i++) {
+          const origin = collision.origins[i];
+          const connector = i === collision.origins.length - 1 ? '└──' : '├──';
+          console.log(`${st.dim(connector)} ${toRel(origin.filePath)}:${st.cyanBright(origin.identifier)}`);
+        }
+        return;
+      }
       if (options.traceFile && !graph.has(options.traceFile)) {
         console.log(`File not found in module graph: ${toRel(options.traceFile)}`);
       } else {

--- a/packages/knip/src/types/module-graph.ts
+++ b/packages/knip/src/types/module-graph.ts
@@ -56,6 +56,7 @@ export interface ExternalRef {
 
 export interface Export extends Position {
   readonly identifier: Identifier;
+  readonly binding: Identifier;
   readonly type: SymbolType;
   readonly members: ExportMember[];
   jsDocTags: Tags;
@@ -65,6 +66,7 @@ export interface Export extends Position {
   referencedIn: Set<string> | undefined;
   readonly fixes: Fixes;
   isReExport: boolean;
+  isBindingReExport: boolean;
 }
 
 export interface ExportMember extends Position {

--- a/packages/knip/src/typescript/visitors/exports.ts
+++ b/packages/knip/src/typescript/visitors/exports.ts
@@ -54,7 +54,17 @@ export function handleExportNamed(node: ExportNamedDeclaration, s: WalkState) {
             : undefined;
         const specTags = s.getJSDocTags(spec.start);
         const tags = specTags.size ? new Set([...declTags, ...specTags]) : declTags;
-        s.addExport(exportedName, type, spec.exported?.start ?? spec.start, [], fix as Fix, true, tags);
+        s.addExport(
+          exportedName,
+          type,
+          spec.exported?.start ?? spec.start,
+          [],
+          fix as Fix,
+          true,
+          tags,
+          exportedName,
+          true
+        );
       }
     }
     return;
@@ -250,7 +260,9 @@ export function handleExportNamed(node: ExportNamedDeclaration, s: WalkState) {
         [],
         fix as Fix,
         isReExport,
-        s.getJSDocTags(node.start)
+        s.getJSDocTags(node.start),
+        localName,
+        isReExport
       );
       if (exportedName) s.specifierExportNames.add(exportedName);
       if (localName && exportedName) addLocalToExport(s, localName, exportedName);
@@ -272,20 +284,24 @@ export function handleExportDefault(node: ExportDefaultDeclaration, s: WalkState
   let type: SymbolType = SYMBOL_TYPE.UNKNOWN;
   let pos = decl.start;
   let members: ExportMember[] = [];
+  let binding = 'default';
 
   if (decl.type === 'FunctionDeclaration') {
     type = SYMBOL_TYPE.FUNCTION;
     pos = decl.id?.start ?? decl.start;
+    binding = decl.id?.name ?? binding;
     s.collectRefsInType(decl, 'default', hasExplicitFunctionReturnType(decl));
   } else if (decl.type === 'ClassDeclaration') {
     type = SYMBOL_TYPE.CLASS;
     pos = decl.id?.start ?? decl.start;
+    binding = decl.id?.name ?? binding;
     members = [];
     s.collectRefsInType(decl, 'default', true);
     if (decl.id) addLocalToExport(s, decl.id.name, 'default');
   } else if (decl.type === 'TSInterfaceDeclaration') {
     type = SYMBOL_TYPE.INTERFACE;
     pos = decl.id.start;
+    binding = decl.id.name;
     s.collectRefsInType(decl.body, 'default', false);
   } else if (decl.type === 'Identifier') {
     type = s.localDeclarationTypes.get(decl.name) ?? SYMBOL_TYPE.UNKNOWN;
@@ -321,7 +337,7 @@ export function handleExportDefault(node: ExportDefaultDeclaration, s: WalkState
     }
   }
 
-  s.addExport('default', type, pos, members, fix, false, s.getJSDocTags(node.start));
+  s.addExport('default', type, pos, members, fix, false, s.getJSDocTags(node.start), binding);
 }
 
 export function handleExportAssignment(node: TSExportAssignment, s: WalkState) {

--- a/packages/knip/src/typescript/visitors/exports.ts
+++ b/packages/knip/src/typescript/visitors/exports.ts
@@ -286,7 +286,7 @@ export function handleExportDefault(node: ExportDefaultDeclaration, s: WalkState
   let members: ExportMember[] = [];
   let binding = 'default';
 
-  if (decl.type === 'FunctionDeclaration') {
+  if (decl.type === 'FunctionDeclaration' || decl.type === 'TSDeclareFunction') {
     type = SYMBOL_TYPE.FUNCTION;
     pos = decl.id?.start ?? decl.start;
     binding = decl.id?.name ?? binding;

--- a/packages/knip/src/typescript/visitors/exports.ts
+++ b/packages/knip/src/typescript/visitors/exports.ts
@@ -239,6 +239,7 @@ export function handleExportNamed(node: ExportNamedDeclaration, s: WalkState) {
 
       const _import = localName ? s.localImportMap.get(localName) : undefined;
       const isReExport = !!_import;
+      const isBindingReExport = !!_import && !_import.isDynamicImport;
 
       if (_import) {
         const internalImport = s.internal.get(_import.filePath);
@@ -262,7 +263,7 @@ export function handleExportNamed(node: ExportNamedDeclaration, s: WalkState) {
         isReExport,
         s.getJSDocTags(node.start),
         localName,
-        isReExport
+        isBindingReExport
       );
       if (exportedName) s.specifierExportNames.add(exportedName);
       if (localName && exportedName) addLocalToExport(s, localName, exportedName);

--- a/packages/knip/src/typescript/visitors/walk.ts
+++ b/packages/knip/src/typescript/visitors/walk.ts
@@ -131,7 +131,9 @@ export interface WalkState extends WalkContext {
     members: ExportMember[],
     fix: Fix,
     isReExport: boolean,
-    jsDocTags: Set<string>
+    jsDocTags: Set<string>,
+    binding?: string,
+    isBindingReExport?: boolean
   ) => void;
   getFix: (start: number, end: number, flags?: number) => Fix;
   getTypeFix: (start: number, end: number) => Fix;
@@ -155,7 +157,9 @@ const _addExport = (
   members: ExportMember[],
   fix: Fix,
   isReExport: boolean,
-  jsDocTags: Set<string>
+  jsDocTags: Set<string>,
+  binding = identifier,
+  isBindingReExport = false
 ) => {
   const item = state.exports.get(identifier);
   if (item) {
@@ -169,10 +173,12 @@ const _addExport = (
       }
     }
     item.isReExport = isReExport;
+    item.isBindingReExport = isBindingReExport;
   } else {
     const { line, col } = getLineAndCol(state.lineStarts, pos);
     state.exports.set(identifier, {
       identifier,
+      binding,
       type,
       members,
       jsDocTags,
@@ -184,6 +190,7 @@ const _addExport = (
       referencedIn: undefined,
       fixes: fix ? [fix] : [],
       isReExport,
+      isBindingReExport,
     });
   }
 };

--- a/packages/knip/test/cli/cli-trace-ambiguous.test.ts
+++ b/packages/knip/test/cli/cli-trace-ambiguous.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { showDiff } from '../helpers/diff.ts';
+import { exec } from '../helpers/exec.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/re-exports/ambiguous-barrel');
+
+test('knip --trace-export explains ambiguous barrel value exports', () => {
+  const actual = exec('knip --trace-export foo --trace-file barrel.ts', { cwd }).stdout;
+  const expected = `Ambiguous export foo in barrel.ts: competing export * origins in the value namespace
+├── fruits.ts:foo
+└── vegetables.ts:foo`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export explains ambiguous barrel type exports', () => {
+  const actual = exec('knip --trace-export Model --trace-file barrel.ts', { cwd }).stdout;
+  const expected = `Ambiguous export Model in barrel.ts: competing export * origins in the type namespace
+├── fruits.ts:Model
+└── vegetables.ts:Model`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export reports collisions in both namespaces', () => {
+  const actual = exec('knip --trace-export Entity --trace-file barrel.ts', { cwd }).stdout;
+  const expected = `Ambiguous export Entity in barrel.ts: competing export * origins in the type and value namespaces
+├── fruits.ts:Entity
+└── vegetables.ts:Entity`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export limits export type star collisions to the type namespace', () => {
+  const actual = exec('knip --trace-export TypeEntity --trace-file type-barrel.ts', { cwd }).stdout;
+  const expected = `Ambiguous export TypeEntity in type-barrel.ts: competing export * origins in the type namespace
+├── fruits.ts:TypeEntity
+└── vegetables.ts:TypeEntity`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export still traces a collision origin', () => {
+  const actual = exec('knip --trace-export foo --trace-file fruits.ts', { cwd }).stdout;
+  const expected = `fruits.ts:foo
+└── barrel.ts:reExportStar[foo]
+    └── index.ts:import[foo] ⎆ ✓`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export does not forward default through export star', () => {
+  assert.equal(
+    exec('knip --trace-export default --trace-file default-barrel.ts', { cwd }).stdout,
+    'No export default found in default-barrel.ts'
+  );
+});
+
+test('knip --trace-export reports cross-namespace competitors', () => {
+  const actual = exec('knip --trace-export CrossNamespace --trace-file barrel.ts', { cwd }).stdout;
+  const expected = `Ambiguous export CrossNamespace in barrel.ts: competing export * origins in the type and value namespaces
+├── fruits.ts:CrossNamespace
+└── vegetables.ts:CrossNamespace`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export keeps copied imports as distinct local bindings', () => {
+  const actual = exec('knip --trace-export same --trace-file copy-barrel.ts', { cwd }).stdout;
+  const expected = `Ambiguous export same in copy-barrel.ts: competing export * origins in the value namespace
+├── copy-left.ts:same
+└── copy-right.ts:same`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export converges aliases of one local binding through a diamond', () => {
+  assert.equal(
+    exec('knip --trace-export converged --trace-file alias-barrel.ts', { cwd }).stdout,
+    'No export converged found in alias-barrel.ts'
+  );
+});
+
+test('knip --trace-export converges named default declarations with their local binding', () => {
+  assert.equal(
+    exec('knip --trace-export namedDefault --trace-file alias-barrel.ts', { cwd }).stdout,
+    'No export namedDefault found in alias-barrel.ts'
+  );
+});
+
+test('knip --trace-export keeps expression defaults distinct from their referenced binding', () => {
+  const actual = exec('knip --trace-export expressionDefault --trace-file alias-barrel.ts', { cwd }).stdout;
+  const expected = `Ambiguous export expressionDefault in alias-barrel.ts: competing export * origins in the value namespace
+├── expression-default.ts:default
+└── expression-default.ts:apple`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export distinguishes bindings from the same defining module', () => {
+  const actual = exec('knip --trace-export split --trace-file alias-barrel.ts', { cwd }).stdout;
+  const expected = `Ambiguous export split in alias-barrel.ts: competing export * origins in the value namespace
+├── bindings.ts:apple
+└── bindings.ts:pear`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export converges namespace exports of one module', () => {
+  assert.equal(
+    exec('knip --trace-export Produce --trace-file namespace-barrel.ts', { cwd }).stdout,
+    'No export Produce found in namespace-barrel.ts'
+  );
+});
+
+test('knip --trace-export gives explicit namespace exports precedence over export star', () => {
+  assert.doesNotMatch(
+    exec('knip --trace-export fruit --trace-file namespace-explicit-barrel.ts', { cwd }).stdout,
+    /^Ambiguous export/
+  );
+});
+
+test('knip --trace-export distinguishes namespace exports of different modules', () => {
+  const actual = exec('knip --trace-export Produce --trace-file namespace-distinct-barrel.ts', { cwd }).stdout;
+  const expected = `Ambiguous export Produce in namespace-distinct-barrel.ts: competing export * origins in the type and value namespaces
+├── namespace-origin-two.ts:*
+└── origin.ts:*`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export gives explicit exports precedence over export star', () => {
+  const actual = exec('knip --trace-export fruit --trace-file explicit-barrel.ts', { cwd }).stdout;
+  const expected = `explicit-barrel.ts:fruit
+└── index.ts:importAs[fruit → winner] ⎆ ✓`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export terminates on ambiguous re-export cycles', () => {
+  const actual = exec('knip --trace-export cycleName --trace-file cycle-a.ts', { cwd }).stdout;
+  const expected = `Ambiguous export cycleName in cycle-a.ts: competing export * origins in the value namespace
+├── cycle-left.ts:cycleName
+└── cycle-right.ts:cycleName`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});

--- a/packages/knip/test/cli/cli-trace-ambiguous.test.ts
+++ b/packages/knip/test/cli/cli-trace-ambiguous.test.ts
@@ -109,6 +109,18 @@ test('knip --trace-export keeps copied namespace imports as distinct local bindi
   }
 });
 
+test('knip --trace-export keeps dynamic import results as distinct local bindings', () => {
+  const actual = exec('knip --trace-export dynamicCopy --trace-file dynamic-barrel.ts', { cwd }).stdout;
+  const expected = `dynamic-barrel.ts:dynamicCopy [ambiguous]
+├── dynamic-left.ts:source
+└── dynamic-right.ts:source`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
 test('knip --trace-export converges aliases of one local binding through a diamond', () => {
   assert.equal(
     exec('knip --trace-export converged --trace-file alias-barrel.ts', { cwd }).stdout,
@@ -170,6 +182,32 @@ test('knip --trace-export gives explicit namespace exports precedence over expor
 
 test('knip --trace-export distinguishes namespace exports of different modules', () => {
   const actual = exec('knip --trace-export Produce --trace-file namespace-distinct-barrel.ts', { cwd }).stdout;
+  const expected = `namespace-distinct-barrel.ts:Produce [ambiguous]
+├── namespace-origin-two.ts:*
+└── origin.ts:*`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export prioritizes exact ambiguous exports over matching enum members', () => {
+  const actual = exec('knip --trace-export fruit --trace-file member-barrel.ts', { cwd }).stdout;
+  const expected = `member-barrel.ts:fruit [ambiguous]
+├── shadowed.ts:fruit
+└── winner.ts:fruit`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export resolves dotted namespace traces through the namespace root', () => {
+  const actual = exec('knip --trace-export Produce.vegetable --trace-file namespace-distinct-barrel.ts', {
+    cwd,
+  }).stdout;
   const expected = `namespace-distinct-barrel.ts:Produce [ambiguous]
 ├── namespace-origin-two.ts:*
 └── origin.ts:*`;

--- a/packages/knip/test/cli/cli-trace-ambiguous.test.ts
+++ b/packages/knip/test/cli/cli-trace-ambiguous.test.ts
@@ -8,7 +8,7 @@ const cwd = resolve('fixtures/re-exports/ambiguous-barrel');
 
 test('knip --trace-export explains ambiguous barrel value exports', () => {
   const actual = exec('knip --trace-export foo --trace-file barrel.ts', { cwd }).stdout;
-  const expected = `Ambiguous export foo in barrel.ts: competing export * origins in the value namespace
+  const expected = `barrel.ts:foo [ambiguous]
 ├── fruits.ts:foo
 └── vegetables.ts:foo`;
 
@@ -20,7 +20,7 @@ test('knip --trace-export explains ambiguous barrel value exports', () => {
 
 test('knip --trace-export explains ambiguous barrel type exports', () => {
   const actual = exec('knip --trace-export Model --trace-file barrel.ts', { cwd }).stdout;
-  const expected = `Ambiguous export Model in barrel.ts: competing export * origins in the type namespace
+  const expected = `barrel.ts:Model [ambiguous]
 ├── fruits.ts:Model
 └── vegetables.ts:Model`;
 
@@ -32,7 +32,7 @@ test('knip --trace-export explains ambiguous barrel type exports', () => {
 
 test('knip --trace-export reports collisions in both namespaces', () => {
   const actual = exec('knip --trace-export Entity --trace-file barrel.ts', { cwd }).stdout;
-  const expected = `Ambiguous export Entity in barrel.ts: competing export * origins in the type and value namespaces
+  const expected = `barrel.ts:Entity [ambiguous]
 ├── fruits.ts:Entity
 └── vegetables.ts:Entity`;
 
@@ -44,7 +44,7 @@ test('knip --trace-export reports collisions in both namespaces', () => {
 
 test('knip --trace-export limits export type star collisions to the type namespace', () => {
   const actual = exec('knip --trace-export TypeEntity --trace-file type-barrel.ts', { cwd }).stdout;
-  const expected = `Ambiguous export TypeEntity in type-barrel.ts: competing export * origins in the type namespace
+  const expected = `type-barrel.ts:TypeEntity [ambiguous]
 ├── fruits.ts:TypeEntity
 └── vegetables.ts:TypeEntity`;
 
@@ -75,7 +75,7 @@ test('knip --trace-export does not forward default through export star', () => {
 
 test('knip --trace-export reports cross-namespace competitors', () => {
   const actual = exec('knip --trace-export CrossNamespace --trace-file barrel.ts', { cwd }).stdout;
-  const expected = `Ambiguous export CrossNamespace in barrel.ts: competing export * origins in the type and value namespaces
+  const expected = `barrel.ts:CrossNamespace [ambiguous]
 ├── fruits.ts:CrossNamespace
 └── vegetables.ts:CrossNamespace`;
 
@@ -87,9 +87,21 @@ test('knip --trace-export reports cross-namespace competitors', () => {
 
 test('knip --trace-export keeps copied imports as distinct local bindings', () => {
   const actual = exec('knip --trace-export same --trace-file copy-barrel.ts', { cwd }).stdout;
-  const expected = `Ambiguous export same in copy-barrel.ts: competing export * origins in the value namespace
+  const expected = `copy-barrel.ts:same [ambiguous]
 ├── copy-left.ts:same
 └── copy-right.ts:same`;
+
+  if (actual !== expected) {
+    showDiff(actual, expected);
+    assert.fail('Output mismatch (see diff above)');
+  }
+});
+
+test('knip --trace-export keeps copied namespace imports as distinct local bindings', () => {
+  const actual = exec('knip --trace-export namespaceCopy --trace-file copy-barrel.ts', { cwd }).stdout;
+  const expected = `copy-barrel.ts:namespaceCopy [ambiguous]
+├── copy-left.ts:namespaceCopy
+└── copy-right.ts:namespaceCopy`;
 
   if (actual !== expected) {
     showDiff(actual, expected);
@@ -111,9 +123,16 @@ test('knip --trace-export converges named default declarations with their local 
   );
 });
 
+test('knip --trace-export converges declared default functions with their local binding', () => {
+  assert.equal(
+    exec('knip --trace-export declaredDefault --trace-file alias-barrel.ts', { cwd }).stdout,
+    'No export declaredDefault found in alias-barrel.ts'
+  );
+});
+
 test('knip --trace-export keeps expression defaults distinct from their referenced binding', () => {
   const actual = exec('knip --trace-export expressionDefault --trace-file alias-barrel.ts', { cwd }).stdout;
-  const expected = `Ambiguous export expressionDefault in alias-barrel.ts: competing export * origins in the value namespace
+  const expected = `alias-barrel.ts:expressionDefault [ambiguous]
 ├── expression-default.ts:default
 └── expression-default.ts:apple`;
 
@@ -125,7 +144,7 @@ test('knip --trace-export keeps expression defaults distinct from their referenc
 
 test('knip --trace-export distinguishes bindings from the same defining module', () => {
   const actual = exec('knip --trace-export split --trace-file alias-barrel.ts', { cwd }).stdout;
-  const expected = `Ambiguous export split in alias-barrel.ts: competing export * origins in the value namespace
+  const expected = `alias-barrel.ts:split [ambiguous]
 ├── bindings.ts:apple
 └── bindings.ts:pear`;
 
@@ -145,13 +164,13 @@ test('knip --trace-export converges namespace exports of one module', () => {
 test('knip --trace-export gives explicit namespace exports precedence over export star', () => {
   assert.doesNotMatch(
     exec('knip --trace-export fruit --trace-file namespace-explicit-barrel.ts', { cwd }).stdout,
-    /^Ambiguous export/
+    /\[ambiguous\]$/m
   );
 });
 
 test('knip --trace-export distinguishes namespace exports of different modules', () => {
   const actual = exec('knip --trace-export Produce --trace-file namespace-distinct-barrel.ts', { cwd }).stdout;
-  const expected = `Ambiguous export Produce in namespace-distinct-barrel.ts: competing export * origins in the type and value namespaces
+  const expected = `namespace-distinct-barrel.ts:Produce [ambiguous]
 ├── namespace-origin-two.ts:*
 └── origin.ts:*`;
 
@@ -174,7 +193,7 @@ test('knip --trace-export gives explicit exports precedence over export star', (
 
 test('knip --trace-export terminates on ambiguous re-export cycles', () => {
   const actual = exec('knip --trace-export cycleName --trace-file cycle-a.ts', { cwd }).stdout;
-  const expected = `Ambiguous export cycleName in cycle-a.ts: competing export * origins in the value namespace
+  const expected = `cycle-a.ts:cycleName [ambiguous]
 ├── cycle-left.ts:cycleName
 └── cycle-right.ts:cycleName`;
 

--- a/packages/knip/test/graph-explorer/ambiguous-star-export.test.ts
+++ b/packages/knip/test/graph-explorer/ambiguous-star-export.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createGraphExplorer } from '../../src/graph-explorer/explorer.ts';
+import type { ModuleGraph } from '../../src/types/module-graph.ts';
+import { baseExport, baseFileNode, baseImportMaps } from '../helpers/baseNodeObjects.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+test('Explicit export wins over a shadowed star export', () => {
+  const winner = resolve('winner.ts');
+  const shadowed = resolve('shadowed.ts');
+  const barrel = resolve('barrel.ts');
+  const fruitExport = { ...baseExport, identifier: 'fruit', binding: 'fruit' };
+  const graph: ModuleGraph = new Map([
+    [winner, { ...baseFileNode, exports: new Map([['fruit', fruitExport]]) }],
+    [shadowed, { ...baseFileNode, exports: new Map([['fruit', fruitExport]]) }],
+    [
+      barrel,
+      {
+        ...baseFileNode,
+        exports: new Map([['fruit', { ...fruitExport, isReExport: true, isBindingReExport: true }]]),
+        imports: {
+          ...baseFileNode.imports,
+          internal: new Map([
+            [winner, { ...baseImportMaps, reExport: new Map([['fruit', new Set([barrel])]]) }],
+            [shadowed, { ...baseImportMaps, reExport: new Map([['*', new Set([barrel])]]) }],
+          ]),
+        },
+      },
+    ],
+  ]);
+  const explorer = createGraphExplorer(graph, new Set());
+
+  assert.equal(explorer.getAmbiguousStarExport(barrel, 'fruit'), undefined);
+});

--- a/packages/knip/test/graph-explorer/contention.test.ts
+++ b/packages/knip/test/graph-explorer/contention.test.ts
@@ -110,7 +110,7 @@ test('should return empty map when no contention exists', () => {
 
   graph.set(filePath2, {
     ...baseFileNode,
-    exports: new Map([['identifier', { ...baseExport, isReExport: true }]]),
+    exports: new Map([['identifier', { ...baseExport, isReExport: true, isBindingReExport: true }]]),
     imports: {
       ...baseFileNode.imports,
       internal: new Map([
@@ -253,7 +253,7 @@ test('should detect conflict from source file aggregated by consumer', () => {
 
   graph.set(indexFile, {
     ...baseFileNode,
-    exports: new Map([['identifier', { ...baseExport, isReExport: true }]]),
+    exports: new Map(),
     imports: {
       ...baseFileNode.imports,
       internal: new Map([

--- a/packages/knip/test/helpers/baseNodeObjects.ts
+++ b/packages/knip/test/helpers/baseNodeObjects.ts
@@ -29,6 +29,7 @@ export const baseFileNode: FileNode = {
 
 export const baseExport: Export = {
   identifier: 'identifier',
+  binding: 'identifier',
   pos: 0,
   line: 1,
   col: 0,
@@ -38,6 +39,7 @@ export const baseExport: Export = {
   hasRefsInFile: false,
   referencedIn: new Set(),
   isReExport: false,
+  isBindingReExport: false,
   fixes: [],
 };
 

--- a/packages/knip/test/re-exports/ambiguous-barrel.test.ts
+++ b/packages/knip/test/re-exports/ambiguous-barrel.test.ts
@@ -13,7 +13,7 @@ test('Keep exports behind ambiguous barrels alive', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 32,
-    total: 32,
+    processed: 33,
+    total: 33,
   });
 });

--- a/packages/knip/test/re-exports/ambiguous-barrel.test.ts
+++ b/packages/knip/test/re-exports/ambiguous-barrel.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/re-exports/ambiguous-barrel');
+
+test('Keep exports behind ambiguous barrels alive', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+      processed: 32,
+      total: 32,
+  });
+});

--- a/packages/knip/test/re-exports/ambiguous-barrel.test.ts
+++ b/packages/knip/test/re-exports/ambiguous-barrel.test.ts
@@ -13,7 +13,7 @@ test('Keep exports behind ambiguous barrels alive', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-      processed: 32,
-      total: 32,
+    processed: 32,
+    total: 32,
   });
 });

--- a/packages/knip/test/re-exports/ambiguous-barrel.test.ts
+++ b/packages/knip/test/re-exports/ambiguous-barrel.test.ts
@@ -13,7 +13,7 @@ test('Keep exports behind ambiguous barrels alive', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 33,
-    total: 33,
+    processed: 37,
+    total: 37,
   });
 });


### PR DESCRIPTION
Tracing an ambiguous star export now lists its competing definitions instead of reporting that no export was found. Resolution follows binding identity through aliases, nested re-exports, namespace re-exports, and cycles, while explicit exports take precedence and stars exclude default exports.

The graph retains local binding names so declarations that copy imported values remain distinct from binding-forwarding re-exports. Origin discovery runs only when tracing requests it; ordinary unused-export analysis remains conservative.

Verified with package QA (1,166 passing tests, 7 skipped), repository checks, 15 focused Node tests, and a graph test that bounds traversal through repeated diamonds.
