### PR TITLE
Add @tailwindcss/webpack as Tailwind plugin enabler

### DIFF
--- a/packages/knip/fixtures/plugins/tailwind5/main.js
+++ b/packages/knip/fixtures/plugins/tailwind5/main.js
@@ -1,0 +1,2 @@
+import '@tailwindcss/webpack';
+import './styles.css';

--- a/packages/knip/fixtures/plugins/tailwind5/package.json
+++ b/packages/knip/fixtures/plugins/tailwind5/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@plugins/tailwind5",
+  "type": "module",
+  "dependencies": {
+    "tw-animate-css": "*"
+  },
+  "devDependencies": {
+    "@tailwindcss/webpack": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/tailwind5/styles.css
+++ b/packages/knip/fixtures/plugins/tailwind5/styles.css
@@ -1,0 +1,1 @@
+@import 'tw-animate-css';

--- a/packages/knip/src/plugins/tailwind/index.ts
+++ b/packages/knip/src/plugins/tailwind/index.ts
@@ -9,7 +9,13 @@ import compiler from './compiler.ts';
 
 const title = 'Tailwind';
 
-const enablers = ['tailwindcss', '@tailwindcss/vite', '@tailwindcss/postcss', '@tailwindcss/cli'];
+const enablers = [
+  'tailwindcss',
+  '@tailwindcss/vite',
+  '@tailwindcss/webpack',
+  '@tailwindcss/postcss',
+  '@tailwindcss/cli',
+];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 

--- a/packages/knip/test/plugins/tailwind5.test.ts
+++ b/packages/knip/test/plugins/tailwind5.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/tailwind5');
+
+test('Find dependencies with the Tailwind plugin (5)', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 2,
+    total: 2,
+  });
+});


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- See [DEVELOPMENT.md][1] for development and QA guidelines

Through [the CI workflow][2] the changes will be tested in Ubuntu, macOS and Windows.
The changes will also be [tested against a number of external projects][3].

[1]: https://github.com/webpro-nl/knip/blob/main/.github/DEVELOPMENT.md
[2]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/ci.yml
[3]: https://github.com/webpro-nl/knip/blob/main/.github/workflows/integration.yml

-->
tailwind plugin misses webpack version that we have switched to recently with our nextjs app (turbopack compatible).