### PR TITLE
Fix eslintrc `parserOptions.parser` handling in ESLint plugin

### DIFF
--- a/packages/knip/fixtures/plugins/eslint6/.eslintrc.json
+++ b/packages/knip/fixtures/plugins/eslint6/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "root": true,
+  "extends": ["eslint:recommended"],
+  "parser": "vue-eslint-parser",
+  "parserOptions": {
+    "parser": "@babel/eslint-parser"
+  },
+  "overrides": [
+    {
+      "files": ["*.vue"],
+      "parserOptions": {
+        "parser": {
+          "js": "espree",
+          "ts": "@typescript-eslint/parser",
+          "<template>": "espree"
+        }
+      }
+    }
+  ]
+}

--- a/packages/knip/fixtures/plugins/eslint6/package.json
+++ b/packages/knip/fixtures/plugins/eslint6/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@plugins/eslint6",
+  "devDependencies": {
+    "eslint": "*",
+    "vue-eslint-parser": "*",
+    "@typescript-eslint/parser": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/eslint7/.eslintrc.cjs
+++ b/packages/knip/fixtures/plugins/eslint7/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  root: true,
+  extends: ['eslint:recommended'],
+  parser: 'espree',
+  overrides: [
+    {
+      files: ['*.vue'],
+      parser: 'vue-eslint-parser',
+      parserOptions: {
+        parser: require('@typescript-eslint/parser'),
+      },
+    },
+  ],
+};

--- a/packages/knip/fixtures/plugins/eslint7/node_modules/@typescript-eslint/parser/index.js
+++ b/packages/knip/fixtures/plugins/eslint7/node_modules/@typescript-eslint/parser/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  parse: () => {},
+  parseForESLint: () => {},
+  version: '8.70.0',
+  meta: { name: 'typescript-eslint/parser', version: '8.70.0' },
+};

--- a/packages/knip/fixtures/plugins/eslint7/node_modules/@typescript-eslint/parser/package.json
+++ b/packages/knip/fixtures/plugins/eslint7/node_modules/@typescript-eslint/parser/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@typescript-eslint/parser",
+  "version": "8.70.0"
+}

--- a/packages/knip/fixtures/plugins/eslint7/package.json
+++ b/packages/knip/fixtures/plugins/eslint7/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@plugins/eslint7",
+  "devDependencies": {
+    "@typescript-eslint/parser": "*",
+    "eslint": "*",
+    "espree": "*",
+    "vue-eslint-parser": "*"
+  }
+}

--- a/packages/knip/src/plugins/eslint/helpers.ts
+++ b/packages/knip/src/plugins/eslint/helpers.ts
@@ -49,20 +49,24 @@ const getInputsDeprecated = (
   // const rules = getDependenciesFromRules(config.rules); // TODO enable in next major? Unexpected/breaking in certain cases w/ eslint v8
   const rules = getDependenciesFromRules({});
   const overrides = config.overrides ? [config.overrides].flat().flatMap(d => getInputsDeprecated(d, options)) : [];
-  const deferred = compact([...extendsSpecifiers, ...plugins, ...parsers, ...settings, ...rules]).map(id =>
-    toDeferResolve(id)
-  );
-  return [...extendConfigs, ...deferred, ...babelDependencies, ...overrides];
+  const deferred = compact([...extendsSpecifiers, ...plugins, ...settings, ...rules]).map(id => toDeferResolve(id));
+  return [...extendConfigs, ...deferred, ...parsers, ...babelDependencies, ...overrides];
 };
 
+const isParserObject = (value: Record<string, unknown>) =>
+  typeof value.parseForESLint === 'function' || typeof value.parse === 'function';
+
+const toParser = (name: string) => toDeferResolve(name, name === 'espree' ? { optional: true } : {});
+
 const getParsers = ({ parser, parserOptions }: BaseConfig) => {
-  const parsers: string[] = [];
+  const inputs: Input[] = [];
   for (const value of [parser, parserOptions?.parser]) {
-    for (const name of value && typeof value === 'object' ? Object.values(value) : [value]) {
-      if (typeof name === 'string' && name !== 'espree') parsers.push(name);
+    if (typeof value === 'string') inputs.push(toParser(value));
+    else if (value && typeof value === 'object' && !isParserObject(value)) {
+      for (const name of Object.values(value)) if (typeof name === 'string') inputs.push(toParser(name));
     }
   }
-  return parsers;
+  return inputs;
 };
 
 const isQualifiedSpecifier = (specifier: string) =>

--- a/packages/knip/src/plugins/eslint/helpers.ts
+++ b/packages/knip/src/plugins/eslint/helpers.ts
@@ -5,7 +5,7 @@ import { getPackageNameFromFilePath, getPackageNameFromModuleSpecifier } from '.
 import { extname, isAbsolute, isInternal } from '../../util/path.ts';
 import { substringBefore } from '../../util/string.ts';
 import { getDependenciesFromConfig } from '../babel/index.ts';
-import type { ESLintConfig, ESLintConfigDeprecated, OverrideConfigDeprecated, Settings } from './types.ts';
+import type { BaseConfig, ESLintConfig, ESLintConfigDeprecated, OverrideConfigDeprecated, Settings } from './types.ts';
 
 export const isFlatConfig = (fileName: string) => /eslint\.config/.test(fileName);
 
@@ -41,7 +41,7 @@ const getInputsDeprecated = (
     toConfig('eslint', specifier, { containingFilePath: options.configFilePath })
   );
   const plugins = config.plugins ? config.plugins.map(resolvePluginSpecifier) : [];
-  const parser = config.parser ?? config.parserOptions?.parser;
+  const parsers = getParsers(config);
   const babelDependencies = config.parserOptions?.babelOptions
     ? getDependenciesFromConfig(config.parserOptions.babelOptions)
     : [];
@@ -49,10 +49,20 @@ const getInputsDeprecated = (
   // const rules = getDependenciesFromRules(config.rules); // TODO enable in next major? Unexpected/breaking in certain cases w/ eslint v8
   const rules = getDependenciesFromRules({});
   const overrides = config.overrides ? [config.overrides].flat().flatMap(d => getInputsDeprecated(d, options)) : [];
-  const deferred = compact([...extendsSpecifiers, ...plugins, parser, ...settings, ...rules]).map(id =>
+  const deferred = compact([...extendsSpecifiers, ...plugins, ...parsers, ...settings, ...rules]).map(id =>
     toDeferResolve(id)
   );
   return [...extendConfigs, ...deferred, ...babelDependencies, ...overrides];
+};
+
+const getParsers = ({ parser, parserOptions }: BaseConfig) => {
+  const parsers: string[] = [];
+  for (const value of [parser, parserOptions?.parser]) {
+    for (const name of value && typeof value === 'object' ? Object.values(value) : [value]) {
+      if (typeof name === 'string' && name !== 'espree') parsers.push(name);
+    }
+  }
+  return parsers;
 };
 
 const isQualifiedSpecifier = (specifier: string) =>

--- a/packages/knip/src/plugins/eslint/types.ts
+++ b/packages/knip/src/plugins/eslint/types.ts
@@ -1,6 +1,6 @@
 type ParserOptions = {
   project?: string;
-  parser?: string;
+  parser?: string | Record<string, unknown>;
   babelOptions?: {
     plugins: string[];
     presets: string[];
@@ -11,7 +11,7 @@ export type Settings = Record<string, Record<string, unknown> | string>;
 
 type Rules = Record<string, string | number>;
 
-type BaseConfig = {
+export type BaseConfig = {
   extends?: string | string[];
   parser?: string;
   parserOptions?: ParserOptions;

--- a/packages/knip/test/plugins/eslint6.test.ts
+++ b/packages/knip/test/plugins/eslint6.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/eslint6');
+
+test('Find dependencies with the ESLint plugin (deprecated/6)', async () => {
+  const options = await createOptions({ cwd });
+  const { issues, counters } = await main(options);
+
+  assert(issues.unlisted['.eslintrc.json']['@babel/eslint-parser']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    unlisted: 1,
+    processed: 0,
+    total: 0,
+  });
+});

--- a/packages/knip/test/plugins/eslint7.test.ts
+++ b/packages/knip/test/plugins/eslint7.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.ts';
+import baseCounters from '../helpers/baseCounters.ts';
+import { createOptions } from '../helpers/create-options.ts';
+import { resolve } from '../helpers/resolve.ts';
+
+const cwd = resolve('fixtures/plugins/eslint7');
+
+test('Find dependencies with the ESLint plugin (deprecated/7)', async () => {
+  const options = await createOptions({ cwd });
+  const { counters } = await main(options);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
The ESLint plugin resolved the parser of an eslintrc config with `config.parser ?? config.parserOptions?.parser`. Since `parserOptions.parser` only exists for wrapper parsers (vue/svelte/astro-eslint-parser), which always set `parser` as well, the fallback never fired and e.g. `@typescript-eslint/parser` was reported as unused.

vue-eslint-parser also documents an object form, `parserOptions: { parser: { js: 'espree', ts: '@typescript-eslint/parser' } }`. In an `overrides` entry (where `parser` is not set) that object was passed to `toDeferResolve` as-is and crashed Knip:

    TypeError: input.specifier.startsWith is not a function