### PR TITLE
fix: fix trailing comma on dependency removal

### DIFF
--- a/packages/language-server/src/code-actions.js
+++ b/packages/language-server/src/code-actions.js
@@ -40,6 +40,15 @@ export const createRemoveDependencyEdit = (document, uri, issue) => {
     const range = { start: { line: lineIndex, character: 0 }, end: { line: lineIndex + 1, character: 0 } };
     const edits = [TextEdit.del(range)];
 
+    if (lineIndex > 0 && !document.getText(range).trimEnd().endsWith(',')) {
+      const prevRange = { start: { line: lineIndex - 1, character: 0 }, end: { line: lineIndex, character: 0 } };
+      const prevLine = document.getText(prevRange).trimEnd();
+      if (prevLine.endsWith(',')) {
+        const start = { line: lineIndex - 1, character: prevLine.length - 1 };
+        edits.push(TextEdit.del({ start, end: { line: lineIndex - 1, character: prevLine.length } }));
+      }
+    }
+
     return { changes: { [uri]: edits } };
   } catch (_error) {
     return null;

--- a/packages/language-server/test/code-actions.test.js
+++ b/packages/language-server/test/code-actions.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { createRemoveDependencyEdit } from '../src/code-actions.js';
+
+const uri = 'file:///project/package.json';
+
+const manifest = (eol = '\n') =>
+  [
+    '{',
+    '  "name": "project",',
+    '  "dependencies": {',
+    '    "react": "^19.0.0",',
+    '    "lodash": "^4.17.21",',
+    '    "chalk": "^5.0.0"',
+    '  },',
+    '  "devDependencies": {',
+    '    "typescript": "^5.0.0"',
+    '  }',
+    '}',
+    '',
+  ].join(eol);
+
+const remove = (text, symbol) => {
+  const document = TextDocument.create(uri, 'json', 1, text);
+  const line = text.split(/\r?\n/).findIndex(l => l.includes(`"${symbol}"`)) + 1;
+  const edit = createRemoveDependencyEdit(document, uri, { type: 'dependencies', symbol, line });
+  return TextDocument.applyEdits(document, edit.changes[uri]);
+};
+
+for (const [label, eol] of [
+  ['LF', '\n'],
+  ['CRLF', '\r\n'],
+]) {
+  test(`removes first dependency (${label})`, () => {
+    const result = remove(manifest(eol), 'react');
+    assert.deepEqual(JSON.parse(result).dependencies, { lodash: '^4.17.21', chalk: '^5.0.0' });
+  });
+
+  test(`removes middle dependency (${label})`, () => {
+    const result = remove(manifest(eol), 'lodash');
+    assert.deepEqual(JSON.parse(result).dependencies, { react: '^19.0.0', chalk: '^5.0.0' });
+  });
+
+  test(`removes last dependency (${label})`, () => {
+    const result = remove(manifest(eol), 'chalk');
+    assert.deepEqual(JSON.parse(result).dependencies, { react: '^19.0.0', lodash: '^4.17.21' });
+    assert.ok(result.includes(`"lodash": "^4.17.21"${eol}  }`));
+  });
+
+  test(`removes sole dependency (${label})`, () => {
+    const result = remove(manifest(eol), 'typescript');
+    assert.deepEqual(JSON.parse(result).devDependencies, {});
+  });
+}


### PR DESCRIPTION
Closes #2030

Removing the last entry in dependencies/devDependencies via the editor quick fix left the previous line's trailing comma, producing invalid JSON. The edit now also strips that comma when the removed line has none. Adds tests for first/middle/last/sole removal with LF and CRLF.