### PR TITLE
fix: recover from corrupt cache file

### DIFF
--- a/packages/knip/src/util/file-entry-cache.ts
+++ b/packages/knip/src/util/file-entry-cache.ts
@@ -39,7 +39,7 @@ export class FileEntryCache<T> {
 
   constructor(cacheId: string, _path: string) {
     this.filePath = path.resolve(_path, cacheId);
-    if (isFile(this.filePath)) this.cache = create(this.filePath);
+    if (isFile(this.filePath)) this.cache = create(this.filePath) ?? this.cache;
   }
 
   getFileDescriptor(filePath: string): FileDescriptor<T> {

--- a/packages/knip/test/util/file-entry-cache.test.ts
+++ b/packages/knip/test/util/file-entry-cache.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { FileEntryCache } from '../../src/util/file-entry-cache.ts';
@@ -14,6 +14,31 @@ test('Persist file metadata in a new nested cache directory', () => {
     writeFileSync(filePath, 'apple\n');
     const cache = new FileEntryCache<string>('compiler', cacheLocation);
     const descriptor = cache.getFileDescriptor(filePath);
+    assert.ok(descriptor.meta);
+    descriptor.meta.data = 'compiled apple';
+    cache.reconcile();
+
+    const restored = new FileEntryCache<string>('compiler', cacheLocation).getFileDescriptor(filePath);
+    assert.equal(restored.changed, false);
+    assert.equal(restored.meta?.data, 'compiled apple');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('Recover from a truncated cache file', () => {
+  const cwd = toPosix(mkdtempSync(join(tmpdir(), 'knip-file-entry-cache-')));
+  const filePath = join(cwd, 'selection.foo');
+  const cacheLocation = join(cwd, 'node_modules/.cache/knip');
+
+  try {
+    writeFileSync(filePath, 'apple\n');
+    mkdirSync(cacheLocation, { recursive: true });
+    writeFileSync(join(cacheLocation, 'compiler'), Buffer.from([0xff]));
+
+    const cache = new FileEntryCache<string>('compiler', cacheLocation);
+    const descriptor = cache.getFileDescriptor(filePath);
+    assert.equal(descriptor.changed, true);
     assert.ok(descriptor.meta);
     descriptor.meta.data = 'compiled apple';
     cache.reconcile();


### PR DESCRIPTION
Closes #2031

A truncated or corrupt cache file (e.g. from an interrupted write) made createCache return undefined, overwriting the initial empty Map and crashing getFileDescriptor with a TypeError. Now falls back to the empty cache so analysis proceeds and the cache is rewritten on reconcile.
